### PR TITLE
[WIP] Add local subxt-client implementation

### DIFF
--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -15,6 +15,7 @@ testing-utils = [
   "tempdir",
   "rand",
   "testchain",
+  "subxt-client"
 ]
 
 [dependencies]
@@ -41,10 +42,10 @@ sp-version = {git = "https://github.com/paritytech/substrate", branch = "polkado
 
 # Subxt dependencies
 # https://github.com/interlay/subxt/tree/polkadot-v0.9.18
-subxt = {package = "subxt", git = "https://github.com/interlay/subxt", rev = "1193d94206a669c59cc5dd89486fecfa82ca584a"}
-subxt-client = {package = "subxt-client", git = "https://github.com/interlay/subxt", rev = "1193d94206a669c59cc5dd89486fecfa82ca584a"}
+subxt = {package = "subxt", git = "https://github.com/interlay/subxt", rev = "344e44c3729adcb945b937d6703212e7ae41da50"}
+subxt-client = {package = "subxt-client", path = "./client", optional = true}
 
-jsonrpsee = {version = "0.8.0", features = ["macros", "jsonrpsee-types", "client", "jsonrpsee-ws-client", "jsonrpsee-client-transport"]}
+jsonrpsee = {version = "0.10.1", features = ["macros", "jsonrpsee-types", "client", "jsonrpsee-ws-client", "jsonrpsee-client-transport"]}
 
 # Runtime primitives
 spacewalk-runtime = {package = "spacewalk-runtime-standalone", path = "../../testchain/runtime"}

--- a/clients/runtime/client/Cargo.toml
+++ b/clients/runtime/client/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "subxt-client"
+version = "0.1.0"
+authors = []
+edition = "2018"
+
+license = "GPL-3.0"
+repository = "https://github.com/paritytech/substrate-subxt"
+documentation = "https://docs.rs/substrate-subxt-client"
+homepage = "https://www.parity.io/"
+description = "Embed a substrate node into your subxt application."
+keywords = ["parity", "substrate", "blockchain"]
+
+[dependencies]
+tokio = { version = "1.10", features = ["time", "rt-multi-thread"] }
+futures = { version = "0.3.9", features = ["compat"], package = "futures" }
+futures01 = { package = "futures", version = "0.1.29" }
+jsonrpsee = "0.10.1"
+jsonrpsee-types = "0.10.1"
+jsonrpsee-core = { version = "0.10.1", features = ["async-client"] }
+
+log = "0.4.13"
+serde_json = "1.0.61"
+thiserror = "1.0.23"
+
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
+
+[target.'cfg(target_arch="x86_64")'.dependencies]
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false, features = [
+    "wasmtime",
+] }

--- a/clients/runtime/client/src/lib.rs
+++ b/clients/runtime/client/src/lib.rs
@@ -1,0 +1,275 @@
+use futures::{
+    channel::mpsc,
+    future::{select, FutureExt},
+    sink::SinkExt,
+    stream::StreamExt,
+};
+use jsonrpsee_core::{
+    async_trait,
+    client::{Client as JsonRpcClient, TransportReceiverT, TransportSenderT},
+};
+use sc_network::config::TransportConfig;
+pub use sc_service::{
+    config::{DatabaseSource, KeystoreConfig, WasmExecutionMethod},
+    Error as ServiceError,
+};
+use sc_service::{
+    config::{NetworkConfiguration, TelemetryEndpoints},
+    ChainSpec, Configuration, KeepBlocks, RpcHandlers, RpcSession, TaskManager,
+};
+pub use sp_keyring::AccountKeyring;
+use thiserror::Error;
+use tokio::task;
+
+/// Error thrown by the client.
+#[derive(Debug, Error)]
+pub enum SubxtClientError {
+    /// Failed to parse json rpc message.
+    #[error("{0}")]
+    Json(#[from] serde_json::Error),
+    /// Channel closed.
+    #[error("{0}")]
+    Mpsc(#[from] mpsc::SendError),
+}
+
+/// Sending end.
+pub struct Sender(mpsc::UnboundedSender<String>);
+
+/// Receiving end
+pub struct Receiver(mpsc::UnboundedReceiver<String>);
+
+#[async_trait]
+impl TransportSenderT for Sender {
+    type Error = SubxtClientError;
+
+    async fn send(&mut self, msg: String) -> Result<(), Self::Error> {
+        self.0.send(msg).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TransportReceiverT for Receiver {
+    type Error = SubxtClientError;
+
+    async fn receive(&mut self) -> Result<String, Self::Error> {
+        let msg = self.0.next().await.expect("channel should be open");
+        Ok(msg)
+    }
+}
+
+/// Client for an embedded substrate node.
+pub struct SubxtClient {
+    rpc: RpcHandlers,
+    sender: Sender,
+    receiver: Receiver,
+}
+
+impl SubxtClient {
+    /// Create a new client.
+    pub fn new(mut task_manager: TaskManager, rpc: RpcHandlers) -> Self {
+        let (to_back, from_front) = mpsc::unbounded();
+        let (to_front, from_back) = mpsc::unbounded();
+
+        let rpc_copy = rpc.clone();
+        let session = RpcSession::new(to_front.clone());
+        task::spawn(
+            select(
+                Box::pin(from_front.for_each(move |message: String| {
+                    let rpc = rpc.clone();
+                    let session = session.clone();
+                    let mut to_front = to_front.clone();
+                    async move {
+                        let response = rpc.rpc_query(&session, &message).await;
+                        if let Some(response) = response {
+                            to_front.send(response).await.ok();
+                        }
+                    }
+                })),
+                Box::pin(async move {
+                    task_manager.future().await.ok();
+                }),
+            )
+            .map(drop),
+        );
+
+        Self {
+            rpc: rpc_copy,
+            sender: Sender(to_back),
+            receiver: Receiver(from_back),
+        }
+    }
+
+    /// Creates a new client from a config.
+    pub fn from_config<C: ChainSpec + 'static>(
+        config: SubxtClientConfig<C>,
+        builder: impl Fn(Configuration) -> Result<(TaskManager, RpcHandlers), ServiceError>,
+    ) -> Result<Self, ServiceError> {
+        let config = config.into_service_config();
+        let (task_manager, rpc_handlers) = (builder)(config)?;
+        Ok(Self::new(task_manager, rpc_handlers))
+    }
+}
+
+impl Clone for SubxtClient {
+    fn clone(&self) -> Self {
+        let (to_back, from_front) = mpsc::unbounded();
+        let (to_front, from_back) = mpsc::unbounded();
+
+        let rpc = self.rpc.clone();
+        let session = RpcSession::new(to_front.clone());
+        task::spawn(Box::pin(from_front.for_each(move |message: String| {
+            let rpc = rpc.clone();
+            let session = session.clone();
+            let mut to_front = to_front.clone();
+            async move {
+                let response = rpc.rpc_query(&session, &message).await;
+                if let Some(response) = response {
+                    to_front.send(response).await.ok();
+                }
+            }
+        })));
+
+        Self {
+            rpc: self.rpc.clone(),
+            sender: Sender(to_back),
+            receiver: Receiver(from_back),
+        }
+    }
+}
+
+impl From<SubxtClient> for JsonRpcClient {
+    fn from(client: SubxtClient) -> Self {
+        (client.sender, client.receiver).into()
+    }
+}
+
+/// Role of the node.
+#[derive(Clone, Copy, Debug)]
+pub enum Role {
+    /// Light client.
+    Light,
+    /// A full node (mainly used for testing purposes).
+    Authority(AccountKeyring),
+}
+
+impl From<Role> for sc_service::Role {
+    fn from(role: Role) -> Self {
+        match role {
+            Role::Light => Self::Light,
+            Role::Authority(_) => Self::Authority,
+        }
+    }
+}
+
+impl From<Role> for Option<String> {
+    fn from(role: Role) -> Self {
+        match role {
+            Role::Light => None,
+            Role::Authority(key) => Some(key.to_seed()),
+        }
+    }
+}
+
+/// Client configuration.
+#[derive(Clone)]
+pub struct SubxtClientConfig<C: ChainSpec + 'static> {
+    /// Name of the implementation.
+    pub impl_name: &'static str,
+    /// Version of the implementation.
+    pub impl_version: &'static str,
+    /// Author of the implementation.
+    pub author: &'static str,
+    /// Copyright start year.
+    pub copyright_start_year: i32,
+    /// Database configuration.
+    pub db: DatabaseSource,
+    /// Keystore configuration.
+    pub keystore: KeystoreConfig,
+    /// Chain specification.
+    pub chain_spec: C,
+    /// Role of the node.
+    pub role: Role,
+    /// Enable telemetry on the given port.
+    pub telemetry: Option<u16>,
+    /// Wasm execution method
+    pub wasm_method: WasmExecutionMethod,
+    /// Handle to the tokio runtime. Will be used to spawn futures by the task manager.
+    pub tokio_handle: tokio::runtime::Handle,
+}
+
+impl<C: ChainSpec + 'static> SubxtClientConfig<C> {
+    /// Creates a service configuration.
+    pub fn into_service_config(self) -> Configuration {
+        let mut network = NetworkConfiguration::new(
+            format!("{} (subxt client)", self.chain_spec.name()),
+            "unknown",
+            Default::default(),
+            None,
+        );
+        network.boot_nodes = self.chain_spec.boot_nodes().to_vec();
+        network.transport = TransportConfig::Normal {
+            enable_mdns: true,
+            allow_private_ipv4: true,
+            // wasm_external_transport: None,
+        };
+        let telemetry_endpoints = if let Some(port) = self.telemetry {
+            let endpoints = TelemetryEndpoints::new(vec![(format!("/ip4/127.0.0.1/tcp/{}/ws", port), 0)])
+                .expect("valid config; qed");
+            Some(endpoints)
+        } else {
+            None
+        };
+        let service_config = Configuration {
+            network,
+            impl_name: self.impl_name.to_string(),
+            impl_version: self.impl_version.to_string(),
+            chain_spec: Box::new(self.chain_spec),
+            role: self.role.into(),
+            database: self.db,
+            keystore: self.keystore,
+            max_runtime_instances: 8,
+            announce_block: true,
+            dev_key_seed: self.role.into(),
+            telemetry_endpoints,
+            tokio_handle: self.tokio_handle,
+            default_heap_pages: Default::default(),
+            disable_grandpa: Default::default(),
+            execution_strategies: Default::default(),
+            force_authoring: Default::default(),
+            keep_blocks: KeepBlocks::All,
+            keystore_remote: Default::default(),
+            offchain_worker: Default::default(),
+            prometheus_config: Default::default(),
+            rpc_cors: Default::default(),
+            rpc_http: Default::default(),
+            rpc_ipc: Default::default(),
+            rpc_ws: Default::default(),
+            rpc_ws_max_connections: Default::default(),
+            rpc_methods: Default::default(),
+            state_cache_child_ratio: Default::default(),
+            state_cache_size: Default::default(),
+            tracing_receiver: Default::default(),
+            tracing_targets: Default::default(),
+            transaction_pool: Default::default(),
+            wasm_method: self.wasm_method,
+            base_path: Default::default(),
+            informant_output_format: Default::default(),
+            state_pruning: Default::default(),
+            // transaction_storage: sc_client_db::TransactionStorageMode::BlockBody,
+            wasm_runtime_overrides: Default::default(),
+            rpc_max_payload: Default::default(),
+            ws_max_out_buffer_capacity: Default::default(),
+            runtime_cache_size: 2,
+        };
+
+        log::info!("{}", service_config.impl_name);
+        log::info!("✌️  version {}", service_config.impl_version);
+        log::info!("❤️  by {}, {}", self.author, self.copyright_start_year);
+        log::info!("📋 Chain specification: {}", service_config.chain_spec.name());
+        log::info!("🏷  Node name: {}", service_config.network.node_name);
+        log::info!("👤 Role: {:?}", self.role);
+
+        service_config
+    }
+}


### PR DESCRIPTION
The [polkadot-v0.9.18 version of interlays subxt fork ](https://github.com/interlay/subxt/tree/polkadot-v0.9.18) does not have a subxt-client implementation anymore. I noticed that in the latest interbtc-clients implementation they use a local implementation for that so I copied that to our clients as well.

Closes #69. 