### PR TITLE
Make clients independent of test chain

### DIFF
--- a/clients/Cargo.lock
+++ b/clients/Cargo.lock
@@ -5406,7 +5406,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version",
- "spacewalk-runtime-standalone",
  "spacewalk-standalone",
  "substrate-stellar-sdk",
  "subxt",

--- a/clients/README.md
+++ b/clients/README.md
@@ -24,6 +24,14 @@ To run the vault with a parachain (e.g. Pendulum) you need to specify the URL, s
 cargo run --bin vault --features parachain-metadata -- --keyring alice --spacewalk-parachain-url ws://localhost:8844 --stellar-vault-secret-key SB6WHKIU2HGVBRNKNOEOQUY4GFC4ZLG5XPGWLEAHTIZXBXXYACC76VSQ
 ```
 
+If you encounter subxt errors when doing RPC api calls, you can change the address types used when compiling the client by passing the `multi-address` feature:
+
+```
+cargo run --bin vault --features "parachain-metadata multi-address" -- --keyring alice --spacewalk-parachain-url ws://localhost:8844 --stellar-vault-secret-key SB6WHKIU2HGVBRNKNOEOQUY4GFC4ZLG5XPGWLEAHTIZXBXXYACC76VSQ
+```
+
+If this still does not fix your issue, try changing the types in `runtime/src/types.rs` manually.
+
 ## Tests
 
 To run the tests (unit and integration tests) for the spacewalk vault client run

--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -47,9 +47,6 @@ subxt-client = {package = "subxt-client", path = "./client", optional = true}
 
 jsonrpsee = {version = "0.10.1", features = ["macros", "jsonrpsee-types", "client", "jsonrpsee-ws-client", "jsonrpsee-client-transport"]}
 
-# Runtime primitives
-spacewalk-runtime = {package = "spacewalk-runtime-standalone", path = "../../testchain/runtime"}
-
 # Dependencies for the testing utils for integration tests
 rand = {version = "0.7", optional = true}
 tempdir = {version = "0.3.7", optional = true}

--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -8,6 +8,7 @@ version = "1.1.0"
 default = []
 parachain-metadata = []
 standalone-metadata = []
+multi-address = []
 testing-utils = [
   # "substrate-subxt/client",
   # "substrate-subxt-client",

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -21,9 +21,10 @@ pub use error::{Error, SubxtError};
 pub use retry::{notify_retry, RetryPolicy};
 pub use rpc::{SpacewalkPallet, SpacewalkParachain, UtilFuncs};
 pub use sp_arithmetic::{traits as FixedPointTraits, FixedI128, FixedPointNumber, FixedU128};
-use spacewalk_runtime::{AccountId, Address};
 pub use subxt::sp_core::{crypto::Ss58Codec, sr25519::Pair};
 pub use types::*;
+// explicitly import some types for making it clearer which ones we use in the runtime
+use types::{AccountId, Address, BlockNumber, Index, H256};
 
 pub const TX_FEES: u128 = 2000000000;
 pub const MILLISECS_PER_BLOCK: u64 = 6000;

--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -2,15 +2,25 @@ use crate::{metadata, Config, SpacewalkRuntime};
 pub use metadata_aliases::*;
 use subxt::sp_core::ed25519::Pair as KeyPair;
 
-pub type AccountId = spacewalk_runtime::AccountId;
-pub type Balance = spacewalk_runtime::Balance;
-pub type Index = u32;
+pub type Balance = u128;
 pub type BlockNumber = u32;
+pub type Index = u32;
 pub type H256 = subxt::sp_core::H256;
-
 pub type SpacewalkSigner = subxt::PairSigner<SpacewalkRuntime, KeyPair>;
-
 pub type FixedU128 = sp_arithmetic::FixedU128;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "multi-address")] {
+        use sp_runtime::{traits::{IdentifyAccount, Verify}, MultiAddress, MultiSignature};
+
+        type Signature = MultiSignature;
+        pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+        pub type Address = MultiAddress<AccountId, ()>;
+    } else {
+        pub type AccountId = subxt::sp_runtime::AccountId32;
+        pub type Address = AccountId;
+    }
+}
 
 mod metadata_aliases {
     use super::*;

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.0.1"
 integration = []
 parachain-metadata= ["runtime/parachain-metadata"]
 standalone-metadata = ["runtime/standalone-metadata"]
+multi-address = ["runtime/multi-address"]
 
 [dependencies]
 async-trait = "0.1.40"


### PR DESCRIPTION
Removes the usages of `spacewalk-runtime` in the vault client and adds a new `multi-address` cargo feature which can be supplied (and should be used when compiling spacewalk for pendulum). 

Although this might still not cover all possible type configurations (since there are only two options for now), I would opt for keeping it simple for now and extending it only once we need to. The different types for account Id and address are based on what interbtc has configured for their chain, and what we need for pendulum.

Closes #71. 