### PR TITLE
Use cache in github ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Clippy
-        run: |
-          rustup component add clippy 
-          cargo clippy --all -- -W warnings -W clippy::unwrap_used -W clippy::needless_collect 
-
       - name: Print sccache stats
         run: sccache --show-stats
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         # Call `rustup show` as a hack so that the toolchain defined in rust-toolchain.toml is installed
         run: rustup show
 
+      - name: Use Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: "${{ matrix.platform }}-cargo-${{ hashFiles('**/Cargo.lock') }}"
+          shared-key: "shared"
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           shared-key: "shared"
 
       - name: Save sccache
-        uses: actions/cache@v3
+        uses: pat-s/always-upload-cache@v3
         continue-on-error: true
         with:
           path: "${{ matrix.sccache-path }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [ pull_request ]
 
 name: continuous-integration
 
@@ -6,12 +6,40 @@ jobs:
   ci:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        os: [ ubuntu-latest, macos-latest ]
+        include:
+          - os: ubuntu-latest
+            sccache-path: /home/runner/.cache/sccache
+          - os: macos-latest
+            sccache-path: /Users/runner/Library/Caches/Mozilla.sccache
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      RUST_BACKTRACE: full
+      RUSTC_WRAPPER: sccache
+      SCCACHE_CACHE_SIZE: 2G
+      SCCACHE_DIR: ${{ matrix.sccache-path }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install sccache (ubuntu-latest)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          LINK: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: 0.2.13
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install sccache (macos-latest)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          brew install sccache             
 
       - name: Setup Rust toolchain
         # Call `rustup show` as a hack so that the toolchain defined in rust-toolchain.toml is installed
@@ -21,8 +49,19 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: "${{ matrix.platform }}-cargo-${{ hashFiles('**/Cargo.lock') }}"
+          key: "${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}"
           shared-key: "shared"
+
+      - name: Save sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: "${{ matrix.sccache-path }}"
+          key: "${{ matrix.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}"
+          restore-keys: "${{ matrix.os }}-sccache-"
+
+      - name: Start sccache server
+        run: sccache --start-server
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -34,15 +73,22 @@ jobs:
         with:
           command: test
           args: --all
-      
+
       - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      
+
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all -- -W warnings -W clippy::unwrap_used -W clippy::needless_collect
+
+      - name: Print sccache stats
+        run: sccache --show-stats
+
+      - name: Stop sccache server
+        run: sccache --stop-server || true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all --all-features
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
           shared-key: "shared"
 
       - name: Save sccache
-        uses: actions/cache@v2
-        continue-on-error: false
+        uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: "${{ matrix.sccache-path }}"
           key: "${{ matrix.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}"
@@ -81,10 +81,9 @@ jobs:
           args: --all -- --check
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -W warnings -W clippy::unwrap_used -W clippy::needless_collect
+        run: |
+          rustup component add clippy 
+          cargo clippy --all -- -W warnings -W clippy::unwrap_used -W clippy::needless_collect 
 
       - name: Print sccache stats
         run: sccache --show-stats


### PR DESCRIPTION
Adds caches for the CI jobs. The `rust-cache` action caches the dependencies, speeding up their download time if the Cargo.lock file did not change. 'sccache' is used to save the compiled artifacts and thus speed up compilation times. 
Clippy [does not work with sccache](https://github.com/rust-lang/rust-clippy/issues/3840) however, so I had to remove it. IMO it should be fine to remove it because it just spits out some warnings, that we probably ignore most of the time anyway.

These changes can cut down the duration of CI runs from ~30 minutes to ~12 minutes. At least for subsequent runs, where the dependencies did not change but just the code.

It also adds the `--all-features` flag to cargo test, because it is needed for the vault tests (as we have to specify either parachain-metadata, or standalone-metadata, and optionally the multi-address feature).

Closes #93. 