### PR TITLE
Remove asset from request extrinsics

### DIFF
--- a/pallets/currency/src/mock.rs
+++ b/pallets/currency/src/mock.rs
@@ -50,7 +50,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -59,7 +59,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -96,12 +96,16 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	// we don't use named reserves
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 pub struct CurrencyConvert;
@@ -131,7 +135,7 @@ parameter_types! {
 	pub const MinimumPeriod: Moment = 5;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 
 pub struct ExtBuilder;
 

--- a/pallets/fee/src/mock.rs
+++ b/pallets/fee/src/mock.rs
@@ -65,7 +65,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -74,7 +74,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -108,16 +108,19 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 impl reward::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = VaultId<AccountId, CurrencyId>;
 	type CurrencyId = CurrencyId;
@@ -126,7 +129,7 @@ impl reward::Config for Test {
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
@@ -145,7 +148,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 pub struct CurrencyConvert;
@@ -189,7 +192,7 @@ impl Config for Test {
 	type MaxExpectedValue = MaxExpectedValue;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 
 #[allow(dead_code)]
 pub type TestError = Error<Test>;

--- a/pallets/fee/src/tests.rs
+++ b/pallets/fee/src/tests.rs
@@ -7,18 +7,18 @@ use crate::{mock::*, IssueFee};
 
 fn test_setter<F1, F2>(f: F1, get_storage_value: F2)
 where
-	F1: Fn(Origin, UnsignedFixedPoint) -> DispatchResultWithPostInfo,
+	F1: Fn(RuntimeOrigin, UnsignedFixedPoint) -> DispatchResultWithPostInfo,
 	F2: Fn() -> UnsignedFixedPoint,
 {
 	run_test(|| {
 		let large_value =
 			UnsignedFixedPoint::checked_from_rational::<u128, u128>(101, 100).unwrap(); // 101%
-		assert_noop!(f(Origin::root(), large_value), TestError::AboveMaxExpectedValue);
+		assert_noop!(f(RuntimeOrigin::root(), large_value), TestError::AboveMaxExpectedValue);
 
 		let valid_value =
 			UnsignedFixedPoint::checked_from_rational::<u128, u128>(100, 100).unwrap(); // 100%
-		assert_noop!(f(Origin::signed(6), valid_value), DispatchError::BadOrigin);
-		assert_ok!(f(Origin::root(), valid_value));
+		assert_noop!(f(RuntimeOrigin::signed(6), valid_value), DispatchError::BadOrigin);
+		assert_ok!(f(RuntimeOrigin::root(), valid_value));
 		assert_eq!(get_storage_value(), valid_value);
 	})
 }

--- a/pallets/issue/src/benchmarking.rs
+++ b/pallets/issue/src/benchmarking.rs
@@ -77,7 +77,7 @@ benchmarks! {
 		register_vault::<T>(vault_id.clone());
 
 		Security::<T>::set_active_block_number(1u32.into());
-	}: _(RawOrigin::Signed(origin), amount, asset, vault_id)
+	}: _(RawOrigin::Signed(origin), amount, vault_id)
 
 	execute_issue {
 		let origin: T::AccountId = account("Origin", 0, 0);

--- a/pallets/issue/src/lib.rs
+++ b/pallets/issue/src/lib.rs
@@ -193,11 +193,10 @@ pub mod pallet {
 		pub fn request_issue(
 			origin: OriginFor<T>,
 			#[pallet::compact] amount: BalanceOf<T>,
-			asset: CurrencyId<T>,
 			vault_id: DefaultVaultId<T>,
 		) -> DispatchResultWithPostInfo {
 			let requester = ensure_signed(origin)?;
-			Self::_request_issue(requester, amount, asset, vault_id)?;
+			Self::_request_issue(requester, amount, vault_id)?;
 			Ok(().into())
 		}
 
@@ -273,11 +272,8 @@ impl<T: Config> Pallet<T> {
 	fn _request_issue(
 		requester: T::AccountId,
 		amount_requested: BalanceOf<T>,
-		_asset: CurrencyId<T>,
 		vault_id: DefaultVaultId<T>,
 	) -> Result<H256, DispatchError> {
-		// TODO change this to use the provided asset once multi-collateral is implemented
-		// let amount_requested = Amount::new(amount_requested, asset);
 		let amount_requested = Amount::new(amount_requested, vault_id.wrapped_currency());
 
 		let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;

--- a/pallets/issue/src/mock.rs
+++ b/pallets/issue/src/mock.rs
@@ -19,7 +19,7 @@ use primitives::{VaultCurrencyPair, VaultId};
 use crate as issue;
 use crate::{Config, Error};
 
-type TestExtrinsic = TestXt<Call, ()>;
+type TestExtrinsic = TestXt<RuntimeCall, ()>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -70,7 +70,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -79,7 +79,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -118,12 +118,15 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 parameter_types! {
@@ -132,15 +135,15 @@ parameter_types! {
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
-	Call: From<C>,
+	RuntimeCall: From<C>,
 {
-	type OverarchingCall = Call;
+	type OverarchingCall = RuntimeCall;
 	type Extrinsic = TestExtrinsic;
 }
 
 impl vault_registry::Config for Test {
 	type PalletId = VaultPalletId;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type Balance = Balance;
 	type WeightInfo = ();
 	type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
@@ -195,11 +198,11 @@ impl stellar_relay::Config for Test {
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 impl reward::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = VaultId<AccountId, CurrencyId>;
 	type CurrencyId = CurrencyId;
@@ -208,7 +211,7 @@ impl reward::Config for Test {
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
@@ -216,7 +219,7 @@ impl staking::Config for Test {
 }
 
 impl oracle::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
@@ -258,12 +261,12 @@ impl Convert<BlockNumber, Balance> for BlockNumberToBalance {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockNumberToBalance = BlockNumberToBalance;
 	type WeightInfo = ();
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 pub type VaultRegistryError = vault_registry::Error<Test>;
 

--- a/pallets/issue/src/tests.rs
+++ b/pallets/issue/src/tests.rs
@@ -476,7 +476,10 @@ fn test_cancel_issue_expired_succeeds() {
 #[test]
 fn test_set_issue_period_only_root() {
 	run_test(|| {
-		assert_noop!(Issue::set_issue_period(Origin::signed(USER), 1), DispatchError::BadOrigin);
-		assert_ok!(Issue::set_issue_period(Origin::root(), 1));
+		assert_noop!(
+			Issue::set_issue_period(RuntimeOrigin::signed(USER), 1),
+			DispatchError::BadOrigin
+		);
+		assert_ok!(Issue::set_issue_period(RuntimeOrigin::root(), 1));
 	})
 }

--- a/pallets/nomination/src/mock.rs
+++ b/pallets/nomination/src/mock.rs
@@ -18,7 +18,7 @@ use sp_runtime::{
 	FixedPointNumber,
 };
 
-type TestExtrinsic = TestXt<Call, ()>;
+type TestExtrinsic = TestXt<RuntimeCall, ()>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -68,8 +68,7 @@ impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
-	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -78,8 +77,9 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
+	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
 	type AccountData = ();
@@ -121,16 +121,19 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 impl reward::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = VaultId<AccountId, CurrencyId>;
 	type CurrencyId = CurrencyId;
@@ -144,15 +147,15 @@ parameter_types! {
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
-	Call: From<C>,
+	RuntimeCall: From<C>,
 {
-	type OverarchingCall = Call;
+	type OverarchingCall = RuntimeCall;
 	type Extrinsic = TestExtrinsic;
 }
 
 impl vault_registry::Config for Test {
 	type PalletId = VaultPalletId;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type Balance = Balance;
 	type WeightInfo = ();
 	type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
@@ -188,7 +191,7 @@ impl currency::Config for Test {
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
@@ -196,7 +199,7 @@ impl staking::Config for Test {
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 parameter_types! {
@@ -229,16 +232,16 @@ impl fee::Config for Test {
 }
 
 impl oracle::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 
 pub const ALICE: VaultId<AccountId, CurrencyId> = VaultId {

--- a/pallets/oracle/src/mock.rs
+++ b/pallets/oracle/src/mock.rs
@@ -57,7 +57,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -66,7 +66,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -104,12 +104,15 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 pub struct CurrencyConvert;
@@ -136,7 +139,7 @@ impl currency::Config for Test {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
@@ -152,18 +155,18 @@ impl pallet_timestamp::Config for Test {
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 
 pub struct ExtBuilder;

--- a/pallets/oracle/src/tests.rs
+++ b/pallets/oracle/src/tests.rs
@@ -32,7 +32,7 @@ fn feed_values_succeeds() {
 		let rate = FixedU128::checked_from_rational(100, 1).unwrap();
 
 		Oracle::is_authorized.mock_safe(|_| MockResult::Return(true));
-		let result = Oracle::feed_values(Origin::signed(3), vec![(key.clone(), rate)]);
+		let result = Oracle::feed_values(RuntimeOrigin::signed(3), vec![(key.clone(), rate)]);
 		assert_ok!(result);
 
 		mine_block();
@@ -63,7 +63,7 @@ mod oracle_offline_detection {
 
 	fn feed_value(currency_id: CurrencyId, oracle: SubmittingOracle) {
 		assert_ok!(Oracle::feed_values(
-			Origin::signed(match oracle {
+			RuntimeOrigin::signed(match oracle {
 				OracleA => 1,
 				OracleB => 2,
 			}),
@@ -163,13 +163,16 @@ fn feed_values_fails_with_invalid_oracle_source() {
 		let failed_rate = FixedU128::checked_from_rational(100, 1).unwrap();
 
 		Oracle::is_authorized.mock_safe(|_| MockResult::Return(true));
-		assert_ok!(Oracle::feed_values(Origin::signed(4), vec![(key.clone(), successful_rate)]));
+		assert_ok!(Oracle::feed_values(
+			RuntimeOrigin::signed(4),
+			vec![(key.clone(), successful_rate)]
+		));
 
 		mine_block();
 
 		Oracle::is_authorized.mock_safe(|_| MockResult::Return(false));
 		assert_err!(
-			Oracle::feed_values(Origin::signed(3), vec![(key.clone(), failed_rate)]),
+			Oracle::feed_values(RuntimeOrigin::signed(3), vec![(key.clone(), failed_rate)]),
 			TestError::InvalidOracleSource
 		);
 
@@ -237,7 +240,7 @@ fn test_is_invalidated() {
 		let rate = FixedU128::checked_from_rational(100, 1).unwrap();
 
 		Oracle::is_authorized.mock_safe(|_| MockResult::Return(true));
-		assert_ok!(Oracle::feed_values(Origin::signed(3), vec![(key.clone(), rate)]));
+		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(3), vec![(key.clone(), rate)]));
 		mine_block();
 
 		// max delay is 60 minutes, 60+ passed
@@ -266,16 +269,16 @@ fn insert_authorized_oracle_succeeds() {
 		let rate = FixedU128::checked_from_rational(1, 1).unwrap();
 		let name = Vec::<u8>::new();
 		assert_err!(
-			Oracle::feed_values(Origin::signed(oracle), vec![]),
+			Oracle::feed_values(RuntimeOrigin::signed(oracle), vec![]),
 			TestError::InvalidOracleSource
 		);
 		assert_err!(
-			Oracle::insert_authorized_oracle(Origin::signed(oracle), oracle, name.clone()),
+			Oracle::insert_authorized_oracle(RuntimeOrigin::signed(oracle), oracle, name.clone()),
 			DispatchError::BadOrigin
 		);
-		assert_ok!(Oracle::insert_authorized_oracle(Origin::root(), oracle, name.clone()));
+		assert_ok!(Oracle::insert_authorized_oracle(RuntimeOrigin::root(), oracle, name.clone()));
 		assert_emitted!(Event::OracleAdded { oracle_id: 1, name });
-		assert_ok!(Oracle::feed_values(Origin::signed(oracle), vec![(key, rate)]));
+		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(oracle), vec![(key, rate)]));
 	});
 }
 
@@ -285,10 +288,10 @@ fn remove_authorized_oracle_succeeds() {
 		let oracle = 1;
 		Oracle::insert_oracle(oracle, Vec::<u8>::new());
 		assert_err!(
-			Oracle::remove_authorized_oracle(Origin::signed(oracle), oracle),
+			Oracle::remove_authorized_oracle(RuntimeOrigin::signed(oracle), oracle),
 			DispatchError::BadOrigin
 		);
-		assert_ok!(Oracle::remove_authorized_oracle(Origin::root(), oracle,));
+		assert_ok!(Oracle::remove_authorized_oracle(RuntimeOrigin::root(), oracle,));
 		assert_emitted!(Event::OracleRemoved { oracle_id: 1 });
 	});
 }
@@ -308,7 +311,7 @@ fn set_btc_tx_fees_per_byte_succeeds() {
 			})
 			.collect();
 
-		assert_ok!(Oracle::feed_values(Origin::signed(3), values.clone()));
+		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(3), values.clone()));
 		mine_block();
 
 		for (key, value) in values {

--- a/pallets/redeem/src/benchmarking.rs
+++ b/pallets/redeem/src/benchmarking.rs
@@ -127,7 +127,7 @@ benchmarks! {
 		assert_ok!(Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(),
 			UnsignedFixedPoint::<T>::one()
 		));
-	}: _(RawOrigin::Signed(origin), amount, asset, stellar_address, vault_id.clone())
+	}: _(RawOrigin::Signed(origin), amount, stellar_address, vault_id.clone())
 
 	liquidation_redeem {
 		assert_ok!(Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(),

--- a/pallets/redeem/src/lib.rs
+++ b/pallets/redeem/src/lib.rs
@@ -217,12 +217,11 @@ pub mod pallet {
 		pub fn request_redeem(
 			origin: OriginFor<T>,
 			#[pallet::compact] amount_wrapped: BalanceOf<T>,
-			asset: CurrencyId<T>,
 			stellar_address: StellarPublicKeyRaw,
 			vault_id: DefaultVaultId<T>,
 		) -> DispatchResultWithPostInfo {
 			let redeemer = ensure_signed(origin)?;
-			Self::_request_redeem(redeemer, amount_wrapped, asset, stellar_address, vault_id)?;
+			Self::_request_redeem(redeemer, amount_wrapped, stellar_address, vault_id)?;
 			Ok(().into())
 		}
 
@@ -461,13 +460,10 @@ impl<T: Config> Pallet<T> {
 	fn _request_redeem(
 		redeemer: T::AccountId,
 		amount_wrapped: BalanceOf<T>,
-		_asset: CurrencyId<T>,
 		stellar_address: StellarPublicKeyRaw,
 		vault_id: DefaultVaultId<T>,
 	) -> Result<H256, DispatchError> {
-		// TODO change this to use the provided asset once multi-collateral is implemented
-		let asset = vault_id.wrapped_currency();
-		let amount_wrapped = Amount::new(amount_wrapped, asset);
+		let amount_wrapped = Amount::new(amount_wrapped, vault_id.wrapped_currency());
 
 		ext::security::ensure_parachain_status_running::<T>()?;
 

--- a/pallets/redeem/src/mock.rs
+++ b/pallets/redeem/src/mock.rs
@@ -18,7 +18,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup, Zero},
 };
 
-type TestExtrinsic = TestXt<Call, ()>;
+type TestExtrinsic = TestXt<RuntimeCall, ()>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -70,7 +70,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -79,7 +79,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -122,12 +122,15 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 parameter_types! {
@@ -136,15 +139,15 @@ parameter_types! {
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
-	Call: From<C>,
+	RuntimeCall: From<C>,
 {
-	type OverarchingCall = Call;
+	type OverarchingCall = RuntimeCall;
 	type Extrinsic = TestExtrinsic;
 }
 
 impl vault_registry::Config for Test {
 	type PalletId = VaultPalletId;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type Balance = Balance;
 	type WeightInfo = ();
 	type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
@@ -180,7 +183,7 @@ impl currency::Config for Test {
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
@@ -188,7 +191,7 @@ impl staking::Config for Test {
 }
 
 impl reward::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = VaultId<AccountId, CurrencyId>;
 	type CurrencyId = CurrencyId;
@@ -204,7 +207,7 @@ parameter_types! {
 pub type OrganizationId = u128;
 
 impl stellar_relay::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type OrganizationId = OrganizationId;
 	type OrganizationLimit = OrganizationLimit;
 	type ValidatorLimit = ValidatorLimit;
@@ -212,7 +215,7 @@ impl stellar_relay::Config for Test {
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 parameter_types! {
@@ -227,7 +230,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 impl oracle::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
@@ -250,11 +253,11 @@ impl fee::Config for Test {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 pub type VaultRegistryError = vault_registry::Error<Test>;
 
@@ -347,7 +350,7 @@ where
 	clear_mocks();
 	ExtBuilder::build().execute_with(|| {
 		assert_ok!(<oracle::Pallet<Test>>::feed_values(
-			Origin::signed(USER),
+			RuntimeOrigin::signed(USER),
 			vec![
 				(OracleKey::ExchangeRate(Token(DOT)), FixedU128::from(1)),
 				(OracleKey::FeeEstimation, FixedU128::from(3)),

--- a/pallets/redeem/src/tests.rs
+++ b/pallets/redeem/src/tests.rs
@@ -66,12 +66,10 @@ fn test_request_redeem_fails_with_amount_exceeds_user_balance() {
 			Amount::<Test>::new(2, <Test as currency::Config>::GetWrappedCurrencyId::get());
 		amount.mint_to(&USER).unwrap();
 		let amount = 10_000_000;
-		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
 				RuntimeOrigin::signed(USER),
 				amount,
-				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
 				VAULT
 			),
@@ -103,7 +101,6 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
 
 		let redeemer = USER;
 		let amount = 9;
-		let asset = DEFAULT_WRAPPED_CURRENCY;
 
 		ext::vault_registry::try_increase_to_be_redeemed_tokens::<Test>.mock_safe(
 			move |vault_id, amount_wrapped| {
@@ -118,7 +115,6 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
 			Redeem::request_redeem(
 				RuntimeOrigin::signed(redeemer),
 				1,
-				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
 				VAULT
 			),
@@ -130,12 +126,10 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
 #[test]
 fn test_request_redeem_fails_with_vault_not_found() {
 	run_test(|| {
-		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
 				RuntimeOrigin::signed(USER),
 				1500,
-				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
 				VAULT
 			),
@@ -150,12 +144,10 @@ fn test_request_redeem_fails_with_vault_banned() {
 		ext::vault_registry::ensure_not_banned::<Test>
 			.mock_safe(|_| MockResult::Return(Err(VaultRegistryError::VaultBanned.into())));
 
-		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
 				RuntimeOrigin::signed(USER),
 				1500,
-				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
 				VAULT
 			),
@@ -168,12 +160,10 @@ fn test_request_redeem_fails_with_vault_banned() {
 fn test_request_redeem_fails_with_vault_liquidated() {
 	run_test(|| {
 		ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
-		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
 				RuntimeOrigin::signed(USER),
 				3000,
-				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
 				VAULT
 			),
@@ -235,7 +225,6 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
 		assert_ok!(Redeem::request_redeem(
 			RuntimeOrigin::signed(redeemer),
 			amount,
-			asset,
 			stellar_address,
 			VAULT
 		));
@@ -324,7 +313,6 @@ fn test_request_redeem_succeeds_with_self_redeem() {
 		assert_ok!(Redeem::request_redeem(
 			RuntimeOrigin::signed(redeemer),
 			amount,
-			asset,
 			stellar_address,
 			VAULT
 		));
@@ -834,7 +822,6 @@ mod spec_based_tests {
 			assert_ok!(Redeem::request_redeem(
 				RuntimeOrigin::signed(USER),
 				amount_to_redeem,
-				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
 				VAULT
 			));

--- a/pallets/redeem/src/tests.rs
+++ b/pallets/redeem/src/tests.rs
@@ -69,7 +69,7 @@ fn test_request_redeem_fails_with_amount_exceeds_user_balance() {
 		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				amount,
 				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
@@ -116,7 +116,7 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
 
 		assert_err!(
 			Redeem::request_redeem(
-				Origin::signed(redeemer),
+				RuntimeOrigin::signed(redeemer),
 				1,
 				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
@@ -133,7 +133,7 @@ fn test_request_redeem_fails_with_vault_not_found() {
 		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				1500,
 				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
@@ -153,7 +153,7 @@ fn test_request_redeem_fails_with_vault_banned() {
 		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				1500,
 				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
@@ -171,7 +171,7 @@ fn test_request_redeem_fails_with_vault_liquidated() {
 		let asset = DEFAULT_WRAPPED_CURRENCY;
 		assert_err!(
 			Redeem::request_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				3000,
 				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
@@ -233,7 +233,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
 		let btc_fee = Redeem::get_current_inclusion_fee(DEFAULT_WRAPPED_CURRENCY).unwrap();
 
 		assert_ok!(Redeem::request_redeem(
-			Origin::signed(redeemer),
+			RuntimeOrigin::signed(redeemer),
 			amount,
 			asset,
 			stellar_address,
@@ -322,7 +322,7 @@ fn test_request_redeem_succeeds_with_self_redeem() {
 		let btc_fee = Redeem::get_current_inclusion_fee(DEFAULT_WRAPPED_CURRENCY).unwrap();
 
 		assert_ok!(Redeem::request_redeem(
-			Origin::signed(redeemer),
+			RuntimeOrigin::signed(redeemer),
 			amount,
 			asset,
 			stellar_address,
@@ -389,7 +389,7 @@ fn test_liquidation_redeem_succeeds() {
 		);
 
 		assert_ok!(Redeem::liquidation_redeem(
-			Origin::signed(USER),
+			RuntimeOrigin::signed(USER),
 			DEFAULT_CURRENCY_PAIR,
 			total_amount,
 		));
@@ -402,7 +402,7 @@ fn test_execute_redeem_fails_with_redeem_id_not_found() {
 		convert_to.mock_safe(|_, x| MockResult::Return(Ok(x)));
 		assert_err!(
 			Redeem::execute_redeem(
-				Origin::signed(VAULT.account_id),
+				RuntimeOrigin::signed(VAULT.account_id),
 				H256([0u8; 32]),
 				Vec::default(),
 				Vec::default(),
@@ -480,7 +480,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
 		) = stellar_relay::testing_utils::create_dummy_scp_structs_encoded();
 
 		assert_ok!(Redeem::execute_redeem(
-			Origin::signed(USER),
+			RuntimeOrigin::signed(USER),
 			H256([0u8; 32]),
 			transaction_envelope_xdr_encoded,
 			scp_envelopes_xdr_encoded,
@@ -569,7 +569,7 @@ fn test_execute_redeem_succeeds() {
 		) = stellar_relay::testing_utils::create_dummy_scp_structs_encoded();
 
 		assert_ok!(Redeem::execute_redeem(
-			Origin::signed(VAULT.account_id),
+			RuntimeOrigin::signed(VAULT.account_id),
 			H256([0u8; 32]),
 			transaction_envelope_xdr_encoded,
 			scp_envelopes_xdr_encoded,
@@ -595,7 +595,7 @@ fn test_execute_redeem_succeeds() {
 fn test_cancel_redeem_fails_with_redeem_id_not_found() {
 	run_test(|| {
 		assert_err!(
-			Redeem::cancel_redeem(Origin::signed(USER), H256([0u8; 32]), false),
+			Redeem::cancel_redeem(RuntimeOrigin::signed(USER), H256([0u8; 32]), false),
 			TestError::RedeemIdNotFound
 		);
 	})
@@ -625,7 +625,7 @@ fn test_cancel_redeem_fails_with_time_not_expired() {
 		});
 
 		assert_err!(
-			Redeem::cancel_redeem(Origin::signed(USER), H256([0u8; 32]), false),
+			Redeem::cancel_redeem(RuntimeOrigin::signed(USER), H256([0u8; 32]), false),
 			TestError::TimeNotExpired
 		);
 	})
@@ -655,7 +655,7 @@ fn test_cancel_redeem_fails_with_unauthorized_caller() {
 		});
 
 		assert_noop!(
-			Redeem::cancel_redeem(Origin::signed(CAROL), H256([0u8; 32]), true),
+			Redeem::cancel_redeem(RuntimeOrigin::signed(CAROL), H256([0u8; 32]), true),
 			TestError::UnauthorizedRedeemer
 		);
 	})
@@ -701,7 +701,7 @@ fn test_cancel_redeem_succeeds() {
 		});
 		ext::vault_registry::decrease_to_be_redeemed_tokens::<Test>
 			.mock_safe(|_, _| MockResult::Return(Ok(())));
-		assert_ok!(Redeem::cancel_redeem(Origin::signed(USER), H256([0u8; 32]), false));
+		assert_ok!(Redeem::cancel_redeem(RuntimeOrigin::signed(USER), H256([0u8; 32]), false));
 		assert_err!(
 			Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
 			TestError::RedeemCancelled,
@@ -749,7 +749,7 @@ fn test_mint_tokens_for_reimbursed_redeem() {
 		Security::<Test>::set_active_block_number(100);
 		assert_noop!(
 			Redeem::mint_tokens_for_reimbursed_redeem(
-				Origin::signed(VAULT.account_id),
+				RuntimeOrigin::signed(VAULT.account_id),
 				VAULT.currencies.clone(),
 				H256([0u8; 32])
 			),
@@ -772,7 +772,7 @@ fn test_mint_tokens_for_reimbursed_redeem() {
 			MockResult::Return(Ok(()))
 		});
 		assert_ok!(Redeem::mint_tokens_for_reimbursed_redeem(
-			Origin::signed(VAULT.account_id),
+			RuntimeOrigin::signed(VAULT.account_id),
 			VAULT.currencies.clone(),
 			H256([0u8; 32])
 		));
@@ -782,8 +782,11 @@ fn test_mint_tokens_for_reimbursed_redeem() {
 #[test]
 fn test_set_redeem_period_only_root() {
 	run_test(|| {
-		assert_noop!(Redeem::set_redeem_period(Origin::signed(USER), 1), DispatchError::BadOrigin);
-		assert_ok!(Redeem::set_redeem_period(Origin::root(), 1));
+		assert_noop!(
+			Redeem::set_redeem_period(RuntimeOrigin::signed(USER), 1),
+			DispatchError::BadOrigin
+		);
+		assert_ok!(Redeem::set_redeem_period(RuntimeOrigin::root(), 1));
 	})
 }
 
@@ -829,7 +832,7 @@ mod spec_based_tests {
 			});
 
 			assert_ok!(Redeem::request_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				amount_to_redeem,
 				asset,
 				RANDOM_STELLAR_PUBLIC_KEY,
@@ -866,7 +869,7 @@ mod spec_based_tests {
 			);
 
 			assert_ok!(Redeem::liquidation_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				DEFAULT_CURRENCY_PAIR,
 				total_amount.into(),
 			));
@@ -937,7 +940,7 @@ mod spec_based_tests {
 			) = stellar_relay::testing_utils::create_dummy_scp_structs_encoded();
 
 			assert_ok!(Redeem::execute_redeem(
-				Origin::signed(USER),
+				RuntimeOrigin::signed(USER),
 				H256([0u8; 32]),
 				transaction_envelope_xdr_encoded,
 				scp_envelopes_xdr_encoded,
@@ -1013,7 +1016,7 @@ mod spec_based_tests {
 					MockResult::Return(Ok(()))
 				},
 			);
-			assert_ok!(Redeem::cancel_redeem(Origin::signed(USER), H256([0u8; 32]), true));
+			assert_ok!(Redeem::cancel_redeem(RuntimeOrigin::signed(USER), H256([0u8; 32]), true));
 			assert_err!(
 				Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
 				TestError::RedeemCancelled,
@@ -1077,7 +1080,7 @@ mod spec_based_tests {
 				assert_eq!(amount, &wrapped(redeem_request.amount + redeem_request.transfer_fee));
 				MockResult::Return(Ok(()))
 			});
-			assert_ok!(Redeem::cancel_redeem(Origin::signed(USER), H256([0u8; 32]), true));
+			assert_ok!(Redeem::cancel_redeem(RuntimeOrigin::signed(USER), H256([0u8; 32]), true));
 			assert_err!(
 				Redeem::get_open_redeem_request_from_id(&H256([0u8; 32])),
 				TestError::RedeemCancelled,

--- a/pallets/replace/src/mock.rs
+++ b/pallets/replace/src/mock.rs
@@ -19,7 +19,7 @@ use primitives::{VaultCurrencyPair, VaultId};
 use crate as replace;
 use crate::{Config, Error};
 
-type TestExtrinsic = TestXt<Call, ()>;
+type TestExtrinsic = TestXt<RuntimeCall, ()>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -72,7 +72,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -81,7 +81,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -119,16 +119,19 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 impl reward::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = VaultId<AccountId, CurrencyId>;
 	type CurrencyId = CurrencyId;
@@ -142,9 +145,9 @@ parameter_types! {
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
-	Call: From<C>,
+	RuntimeCall: From<C>,
 {
-	type OverarchingCall = Call;
+	type OverarchingCall = RuntimeCall;
 	type Extrinsic = TestExtrinsic;
 }
 pub struct CurrencyConvert;
@@ -178,14 +181,14 @@ impl currency::Config for Test {
 
 impl vault_registry::Config for Test {
 	type PalletId = VaultPalletId;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type Balance = Balance;
 	type WeightInfo = ();
 	type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
@@ -204,7 +207,7 @@ parameter_types! {
 pub type OrganizationId = u128;
 
 impl stellar_relay::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type OrganizationId = OrganizationId;
 	type OrganizationLimit = OrganizationLimit;
 	type ValidatorLimit = ValidatorLimit;
@@ -212,11 +215,11 @@ impl stellar_relay::Config for Test {
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 impl nomination::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
@@ -232,7 +235,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 impl oracle::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
@@ -255,11 +258,11 @@ impl fee::Config for Test {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 
 pub const OLD_VAULT: VaultId<AccountId, CurrencyId> = VaultId {

--- a/pallets/reward/src/mock.rs
+++ b/pallets/reward/src/mock.rs
@@ -41,7 +41,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -50,7 +50,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -69,7 +69,7 @@ parameter_types! {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = AccountId;
 	type CurrencyId = CurrencyId;
@@ -77,7 +77,7 @@ impl Config for Test {
 	type GetWrappedCurrencyId = GetWrappedCurrencyId;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 
 pub const ALICE: AccountId = 1;

--- a/pallets/security/src/mock.rs
+++ b/pallets/security/src/mock.rs
@@ -37,7 +37,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -46,7 +46,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -60,10 +60,10 @@ impl frame_system::Config for Test {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 
 pub struct ExtBuilder;

--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -48,7 +48,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -57,7 +57,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -75,7 +75,7 @@ parameter_types! {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedInner = SignedInner;
 	type SignedFixedPoint = SignedFixedPoint;
 	type CurrencyId = CurrencyId;
@@ -93,22 +93,25 @@ parameter_type_with_key! {
 	};
 }
 impl orml_tokens::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type Balance = Balance;
 	type Amount = RawAmount;
 	type CurrencyId = CurrencyId;
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 
 pub const VAULT: VaultId<AccountId, CurrencyId> = VaultId {

--- a/pallets/stellar-relay/src/mock.rs
+++ b/pallets/stellar-relay/src/mock.rs
@@ -40,7 +40,7 @@ impl system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/pallets/stellar-relay/src/tests.rs
+++ b/pallets/stellar-relay/src/tests.rs
@@ -332,7 +332,7 @@ fn validate_stellar_transaction_fails_without_validators() {
 
 		// Remove all validators
 		assert_ok!(SpacewalkRelay::update_tier_1_validator_set(
-			Origin::root(),
+			RuntimeOrigin::root(),
 			vec![],
 			organizations,
 		));
@@ -348,9 +348,11 @@ fn validate_stellar_transaction_fails_without_validators() {
 		assert!(matches!(result, Err(Error::<Test>::NoValidatorsRegistered)));
 
 		// Remove all validators
-		assert_ok!(
-			SpacewalkRelay::update_tier_1_validator_set(Origin::root(), validators, vec![],)
-		);
+		assert_ok!(SpacewalkRelay::update_tier_1_validator_set(
+			RuntimeOrigin::root(),
+			validators,
+			vec![],
+		));
 		let result =
 			SpacewalkRelay::validate_stellar_transaction(&tx_envelope, &scp_envelopes, &tx_set);
 		assert!(matches!(result, Err(Error::<Test>::NoOrganizationsRegistered)));
@@ -405,7 +407,7 @@ fn validate_stellar_transaction_works_with_all_validators() {
 fn update_tier_1_validator_set_fails_for_non_root_origin() {
 	run_test(|_, _, _| {
 		assert_noop!(
-			SpacewalkRelay::update_tier_1_validator_set(Origin::signed(1), vec![], vec![]),
+			SpacewalkRelay::update_tier_1_validator_set(RuntimeOrigin::signed(1), vec![], vec![]),
 			BadOrigin
 		);
 	});
@@ -423,7 +425,7 @@ fn update_tier_1_validator_set_works() {
 		let validator_set = vec![validator; 3];
 		let organization_set = vec![organization; 3];
 		assert_ok!(SpacewalkRelay::update_tier_1_validator_set(
-			Origin::root(),
+			RuntimeOrigin::root(),
 			validator_set.clone(),
 			organization_set.clone(),
 		));
@@ -454,7 +456,7 @@ fn update_tier_1_validator_set_works() {
 		assert_ne!(organization_set, new_organization_set);
 
 		assert_ok!(SpacewalkRelay::update_tier_1_validator_set(
-			Origin::root(),
+			RuntimeOrigin::root(),
 			new_validator_set.clone(),
 			new_organization_set.clone(),
 		));
@@ -485,7 +487,7 @@ fn update_tier_1_validator_set_fails_when_set_too_large() {
 		let organization_set = vec![organization.clone(); 3];
 		assert_noop!(
 			SpacewalkRelay::update_tier_1_validator_set(
-				Origin::root(),
+				RuntimeOrigin::root(),
 				validator_set,
 				organization_set,
 			),
@@ -497,7 +499,7 @@ fn update_tier_1_validator_set_fails_when_set_too_large() {
 		let organization_set = vec![organization.clone(); 256];
 		assert_noop!(
 			SpacewalkRelay::update_tier_1_validator_set(
-				Origin::root(),
+				RuntimeOrigin::root(),
 				validator_set,
 				organization_set,
 			),

--- a/pallets/vault-registry/src/mock.rs
+++ b/pallets/vault-registry/src/mock.rs
@@ -16,7 +16,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup, One, Zero},
 };
 
-pub(crate) type Extrinsic = TestXt<Call, ()>;
+pub(crate) type Extrinsic = TestXt<RuntimeCall, ()>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -65,7 +65,7 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type Origin = Origin;
+	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Index = Index;
 	type BlockNumber = BlockNumber;
@@ -74,7 +74,7 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = PalletInfo;
@@ -117,16 +117,20 @@ impl orml_tokens::Config for Test {
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
-	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Everything;
-	type MaxReserves = ConstU32<0>; // we don't use named reserves
-	type ReserveIdentifier = (); // we don't use named reserves
+	type OnSlash = ();
+	type OnDeposit = ();
+	type OnTransfer = ();
 	type OnNewTokenAccount = ();
 	type OnKilledTokenAccount = ();
+	type MaxLocks = MaxLocks;
+	type MaxReserves = ConstU32<0>;
+	// we don't use named reserves
+	type ReserveIdentifier = ();
+	type DustRemovalWhitelist = Everything;
 }
 
 impl reward::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type RewardId = VaultId<AccountId, CurrencyId>;
 	type CurrencyId = CurrencyId;
@@ -146,7 +150,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 impl oracle::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
 }
 
@@ -205,7 +209,7 @@ parameter_types! {
 
 impl Config for Test {
 	type PalletId = VaultPalletId;
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type Balance = Balance;
 	type WeightInfo = ();
 	type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
@@ -213,25 +217,25 @@ impl Config for Test {
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
-	Call: From<C>,
+	RuntimeCall: From<C>,
 {
-	type OverarchingCall = Call;
+	type OverarchingCall = RuntimeCall;
 	type Extrinsic = Extrinsic;
 }
 
 impl security::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 }
 
 impl staking::Config for Test {
-	type Event = TestEvent;
+	type RuntimeEvent = TestEvent;
 	type SignedFixedPoint = SignedFixedPoint;
 	type SignedInner = SignedInner;
 	type CurrencyId = CurrencyId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 }
 
-pub type TestEvent = Event;
+pub type TestEvent = RuntimeEvent;
 pub type TestError = Error<Test>;
 pub type TokensError = orml_tokens::Error<Test>;
 


### PR DESCRIPTION
This PR fixes the type issues that arise because the mocks and tests were not updated accordingly when upgrading to v0.9.31 (which I, unfortunately, forgot to add to the last PR because I did not run the tests).

It also removes the `asset` parameter from the `request_{issue/redeem}()` extrinsics which was not used anyways. I originally added it because I thought we would need it eventually.