### PR TITLE
Drop connection after the defined retries and timeouts.  Closing issue #120

### DIFF
--- a/clients/stellar-relay/src/connection/services.rs
+++ b/clients/stellar-relay/src/connection/services.rs
@@ -168,6 +168,7 @@ pub(crate) async fn receiving_service(
 			.await
 		{
 			Ok(Ok(0)) => {
+				retry += 1;
 				log::error!("peeking empty");
 			},
 			Ok(Ok(_)) if lack_bytes_from_prev == 0 => {

--- a/clients/stellar-relay/src/connection/services.rs
+++ b/clients/stellar-relay/src/connection/services.rs
@@ -153,6 +153,7 @@ pub(crate) async fn receiving_service(
 	retries: u8,
 ) -> Result<(), Error> {
 	let mut retry = 0;
+	let mut retry_read = 0;
 	let mut proc_id = 0;
 
 	// holds the number of bytes that were missing from the previous stellar message.
@@ -168,11 +169,16 @@ pub(crate) async fn receiving_service(
 			.await
 		{
 			Ok(Ok(0)) => {
-				retry += 1;
-				log::error!("peeking empty");
+				if retry_read >= retries {
+					return Err(Error::ReadFailed(format!(
+						"Failed to read messages from the stream. Received 0 size more than {retries} times"
+					)))
+				}
+				retry_read += 1;
 			},
 			Ok(Ok(_)) if lack_bytes_from_prev == 0 => {
 				retry = 0;
+				retry_read = 0;
 				// if there are no more bytes lacking from the previous message,
 				// then check the size of next stellar message.
 				// If it's not enough, skip it.
@@ -201,6 +207,7 @@ pub(crate) async fn receiving_service(
 
 			Ok(Ok(_)) => {
 				retry = 0;
+				retry_read = 0;
 				// let's read the continuation number of bytes from the previous message.
 				read_unfinished_message(
 					&mut r_stream,


### PR DESCRIPTION
"peeking empty" happens when we connect to node with incorrect overlay_version:

there is new version that works good without "peeking empty" error: 

`let node_info = NodeInfo::new(19, 25, 23, "v19.5.0".to_string(), network);`

this is the old one that we stuck forever with "peeking empty" error:

`let node_info = NodeInfo::new(19, 21, 19, "v19.1.0".to_string(), network);`

There is no chance that we we will receive any message once we go to this case statement. 

```
Ok(Ok(0)) => {
     log::error!("peeking empty");
}
```

introduce retry_read variable. increment each time received zero size

Closing https://github.com/pendulum-chain/spacewalk/issues/120