### PR TITLE
Fix vault client integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,7 +4413,7 @@ dependencies = [
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
- "num-rational",
+ "num-rational 0.4.1",
  "num-traits",
  "rand 0.8.5",
  "rand_distr",
@@ -4610,6 +4616,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
@@ -4650,12 +4667,24 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -6177,9 +6206,11 @@ dependencies = [
  "sp-std 4.0.0",
  "sp-version",
  "spacewalk-primitives",
+ "spacewalk-runtime-standalone",
  "spacewalk-standalone",
  "substrate-stellar-sdk",
  "subxt",
+ "subxt-client",
  "tempdir",
  "thiserror",
  "tokio",
@@ -6541,6 +6572,95 @@ dependencies = [
  "sp-inherents",
  "sp-keystore 0.12.0",
  "sp-runtime 6.0.0",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-consensus-babe"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
+dependencies = [
+ "async-trait",
+ "fork-tree",
+ "futures 0.3.25",
+ "log",
+ "merlin",
+ "num-bigint 0.2.6",
+ "num-rational 0.2.4",
+ "num-traits",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "rand 0.7.3",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-epochs",
+ "sc-consensus-slots",
+ "sc-keystore",
+ "sc-telemetry",
+ "schnorrkel",
+ "serde",
+ "sp-api",
+ "sp-application-crypto 6.0.0",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-consensus-vrf",
+ "sp-core 6.0.0",
+ "sp-inherents",
+ "sp-io 6.0.0",
+ "sp-keystore 0.12.0",
+ "sp-runtime 6.0.0",
+ "sp-version",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-consensus-epochs"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
+dependencies = [
+ "fork-tree",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-blockchain",
+ "sp-runtime 6.0.0",
+]
+
+[[package]]
+name = "sc-consensus-manual-seal"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
+dependencies = [
+ "assert_matches",
+ "async-trait",
+ "futures 0.3.25",
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-aura",
+ "sc-consensus-babe",
+ "sc-consensus-epochs",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core 6.0.0",
+ "sp-inherents",
+ "sp-keystore 0.12.0",
+ "sp-runtime 6.0.0",
+ "sp-timestamp",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -7963,6 +8083,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-babe"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
+dependencies = [
+ "async-trait",
+ "merlin",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto 6.0.0",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-consensus-vrf",
+ "sp-core 6.0.0",
+ "sp-inherents",
+ "sp-keystore 0.12.0",
+ "sp-runtime 6.0.0",
+ "sp-std 4.0.0",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
@@ -7974,6 +8117,19 @@ dependencies = [
  "sp-runtime 6.0.0",
  "sp-std 4.0.0",
  "sp-timestamp",
+]
+
+[[package]]
+name = "sp-consensus-vrf"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "schnorrkel",
+ "sp-core 6.0.0",
+ "sp-runtime 6.0.0",
+ "sp-std 4.0.0",
 ]
 
 [[package]]
@@ -8811,6 +8967,7 @@ dependencies = [
  "module-replace-rpc",
  "module-vault-registry-rpc",
  "pallet-transaction-payment-rpc",
+ "sc-consensus-manual-seal",
  "sc-rpc",
  "sc-rpc-api",
  "sc-transaction-pool-api",
@@ -8894,6 +9051,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "frame-support",
  "frame-system",
+ "futures 0.3.25",
  "hex-literal 0.2.2",
  "log",
  "pallet-transaction-payment",
@@ -8903,6 +9061,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
+ "sc-consensus-manual-seal",
  "sc-executor",
  "sc-finality-grandpa",
  "sc-keystore",
@@ -9171,7 +9330,7 @@ dependencies = [
  "base64",
  "hex",
  "lazy_static",
- "num-rational",
+ "num-rational 0.4.1",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -9230,6 +9389,26 @@ dependencies = [
  "subxt-metadata",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "subxt-client"
+version = "0.1.0"
+dependencies = [
+ "futures 0.1.31",
+ "futures 0.3.25",
+ "jsonrpsee",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "log",
+ "sc-client-db",
+ "sc-network",
+ "sc-service",
+ "serde_json",
+ "sp-keyring",
+ "subxt",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -10074,6 +10253,7 @@ dependencies = [
  "sp-runtime 6.0.0",
  "sp-std 4.0.0",
  "stellar-relay-lib",
+ "subxt",
  "sysinfo",
  "thiserror",
  "tokio",
@@ -10363,7 +10543,7 @@ dependencies = [
  "downcast-rs",
  "libm",
  "memory_units",
- "num-rational",
+ "num-rational 0.4.1",
  "num-traits",
 ]
 
@@ -10900,111 +11080,6 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "cumulus-client-cli"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-client-collator"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-client-consensus-aura"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-client-consensus-common"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-client-consensus-relay-chain"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-client-network"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-client-service"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-pallet-aura-ext"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-pallet-dmp-queue"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-pallet-parachain-system"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-pallet-xcm"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-pallet-xcmp-queue"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-primitives-core"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-primitives-parachain-inherent"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-primitives-timestamp"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-primitives-utility"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-relay-chain-inprocess-interface"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-relay-chain-interface"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-relay-chain-rpc-interface"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "cumulus-test-relay-sproof-builder"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
-name = "parachain-info"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
-
-[[patch.unused]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
@@ -11235,22 +11310,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
 
 [[patch.unused]]
-name = "sc-consensus-babe"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
-
-[[patch.unused]]
 name = "sc-consensus-babe-rpc"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
-
-[[patch.unused]]
-name = "sc-consensus-epochs"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
-
-[[patch.unused]]
-name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
 
@@ -11267,16 +11327,6 @@ source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee
 [[patch.unused]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
-
-[[patch.unused]]
-name = "sp-consensus-babe"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
-
-[[patch.unused]]
-name = "sp-consensus-vrf"
-version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
 
 [[patch.unused]]
@@ -11298,6 +11348,111 @@ source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee
 name = "try-runtime-cli"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
+
+[[patch.unused]]
+name = "cumulus-client-cli"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-client-collator"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-client-consensus-aura"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-client-consensus-common"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-client-consensus-relay-chain"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-client-network"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-client-service"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-pallet-aura-ext"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-pallet-dmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-pallet-parachain-system"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-pallet-xcm"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-pallet-xcmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-primitives-timestamp"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-primitives-utility"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-relay-chain-inprocess-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-relay-chain-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-relay-chain-rpc-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+
+[[patch.unused]]
+name = "parachain-info"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
 name = "kusama-runtime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6198,6 +6198,7 @@ dependencies = [
  "parity-scale-codec",
  "prometheus 0.12.0",
  "rand 0.7.3",
+ "runtime",
  "serde",
  "serde_json",
  "sp-arithmetic 5.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "clients/runtime",
+    "clients/runtime/client",
     "clients/vault",
     "clients/wallet",
     "clients/service",

--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -62,3 +62,5 @@ substrate-stellar-sdk = { git = "https://github.com/pendulum-chain/substrate-ste
 [dev-dependencies]
 env_logger = "0.8.3"
 tempdir = "0.3.7"
+runtime = { path = ".", features = ["testing-utils"] }
+

--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -13,6 +13,8 @@ testing-utils = [
     "tempdir",
     "rand",
     "testchain",
+    "testchain-runtime",
+    "subxt-client",
 ]
 
 [dependencies]
@@ -41,6 +43,8 @@ sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkad
 # Subxt dependencies
 subxt = "0.25.0"
 jsonrpsee = { version = "0.16.0", features = ["macros", "jsonrpsee-types", "client", "jsonrpsee-ws-client", "jsonrpsee-client-transport"] }
+# Used for performing the integration tests
+subxt-client = { path = "./client", optional = true }
 
 # Needed for the `BalanceWrapper` struct
 module-oracle-rpc-runtime-api = { path = "../../pallets/oracle/rpc/runtime-api" }
@@ -50,6 +54,7 @@ primitives = { path = "../../primitives", package = "spacewalk-primitives" }
 rand = { version = "0.7", optional = true }
 tempdir = { version = "0.3.7", optional = true }
 testchain = { package = "spacewalk-standalone", path = "../../testchain/node", optional = true }
+testchain-runtime = { package = "spacewalk-runtime-standalone", path = "../../testchain/runtime", optional = true }
 
 # Substrate Stellar Dependencies
 substrate-stellar-sdk = { git = "https://github.com/pendulum-chain/substrate-stellar-sdk", branch = "polkadot-v0.9.31" }

--- a/clients/runtime/client/Cargo.toml
+++ b/clients/runtime/client/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "subxt-client"
+version = "0.1.0"
+authors = []
+edition = "2018"
+
+license = "GPL-3.0"
+repository = "https://github.com/paritytech/substrate-subxt"
+documentation = "https://docs.rs/substrate-subxt-client"
+homepage = "https://www.parity.io/"
+description = "Embed a substrate node into your subxt application."
+keywords = ["parity", "substrate", "blockchain"]
+
+[dependencies]
+tokio = { version = "1.10", features = ["time", "rt-multi-thread"] }
+futures = { version = "0.3.9", features = ["compat"], package = "futures" }
+futures01 = { package = "futures", version = "0.1.29" }
+jsonrpsee = "0.16.0"
+jsonrpsee-types = "0.16.0"
+jsonrpsee-core = { version = "0.16.0", features = ["async-client"] }
+
+log = "0.4.13"
+serde_json = "1.0.61"
+thiserror = "1.0.23"
+
+subxt = "0.25.0"
+
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
+
+[target.'cfg(target_arch="x86_64")'.dependencies]
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, features = [
+    "wasmtime",
+] }

--- a/clients/runtime/client/README.md
+++ b/clients/runtime/client/README.md
@@ -1,0 +1,4 @@
+# Testchain client
+
+This package contains code to run a testchain client.
+It is used for running automated integration tests against a testchain.

--- a/clients/runtime/client/src/lib.rs
+++ b/clients/runtime/client/src/lib.rs
@@ -1,0 +1,281 @@
+use futures::{
+	channel::mpsc,
+	future::{select, FutureExt},
+	sink::SinkExt,
+	stream::StreamExt,
+};
+use jsonrpsee_core::{
+	async_trait,
+	client::{
+		Client as JsonRpcClient, ClientBuilder, ReceivedMessage, TransportReceiverT,
+		TransportSenderT,
+	},
+};
+use sc_client_db::BlocksPruning;
+pub use sc_service::{
+	config::{DatabaseSource, KeystoreConfig, WasmExecutionMethod, WasmtimeInstantiationStrategy},
+	Error as ServiceError,
+};
+use sc_service::{
+	config::{NetworkConfiguration, TelemetryEndpoints, TransportConfig},
+	ChainSpec, Configuration, RpcHandlers, TaskManager,
+};
+pub use sp_keyring::AccountKeyring;
+use thiserror::Error;
+use tokio::task;
+
+/// Error thrown by the client.
+#[derive(Debug, Error)]
+pub enum SubxtClientError {
+	/// Failed to parse json rpc message.
+	#[error("{0}")]
+	Json(#[from] serde_json::Error),
+	/// Channel closed.
+	#[error("{0}")]
+	Mpsc(#[from] mpsc::SendError),
+}
+
+/// Sending end.
+pub struct Sender(mpsc::UnboundedSender<String>);
+
+/// Receiving end
+pub struct Receiver(mpsc::UnboundedReceiver<String>);
+
+#[async_trait]
+impl TransportSenderT for Sender {
+	type Error = SubxtClientError;
+
+	async fn send(&mut self, msg: String) -> Result<(), Self::Error> {
+		self.0.send(msg).await?;
+		Ok(())
+	}
+
+	async fn send_ping(&mut self) -> Result<(), Self::Error> {
+		unimplemented!()
+	}
+}
+
+#[async_trait]
+impl TransportReceiverT for Receiver {
+	type Error = SubxtClientError;
+
+	async fn receive(&mut self) -> Result<ReceivedMessage, Self::Error> {
+		let msg = self.0.next().await.expect("channel should be open");
+		Ok(ReceivedMessage::Text(msg))
+	}
+}
+
+/// Client for an embedded substrate node.
+pub struct SubxtClient {
+	rpc: RpcHandlers,
+	sender: Sender,
+	receiver: Receiver,
+}
+
+impl SubxtClient {
+	/// Create a new client.
+	pub fn new(mut task_manager: TaskManager, rpc: RpcHandlers) -> Self {
+		let (to_back, from_front) = mpsc::unbounded();
+		let (to_front, from_back) = mpsc::unbounded();
+
+		let rpc_copy = rpc.clone();
+		task::spawn(
+			select(
+				Box::pin(from_front.for_each(move |message: String| {
+					let rpc = rpc.clone();
+					let mut to_front = to_front.clone();
+					async move {
+						let (resp, mut stream) = rpc.rpc_query(&message).await.unwrap();
+						to_front.send(resp).await.ok();
+						// read the rest of the stream but don't block
+						task::spawn(async move {
+							while let Some(resp) = stream.next().await {
+								to_front.send(resp).await.ok();
+							}
+						});
+					}
+				})),
+				Box::pin(async move {
+					task_manager.future().await.ok();
+				}),
+			)
+			.map(drop),
+		);
+
+		Self { rpc: rpc_copy, sender: Sender(to_back), receiver: Receiver(from_back) }
+	}
+
+	/// Creates a new client from a config.
+	pub fn from_config<C: ChainSpec + 'static>(
+		config: SubxtClientConfig<C>,
+		builder: impl Fn(Configuration) -> Result<(TaskManager, RpcHandlers), ServiceError>,
+	) -> Result<Self, ServiceError> {
+		let config = config.into_service_config();
+		let (task_manager, rpc_handlers) = (builder)(config)?;
+		Ok(Self::new(task_manager, rpc_handlers))
+	}
+}
+
+impl Clone for SubxtClient {
+	fn clone(&self) -> Self {
+		let (to_back, from_front) = mpsc::unbounded();
+		let (to_front, from_back) = mpsc::unbounded();
+
+		let rpc = self.rpc.clone();
+		task::spawn(Box::pin(from_front.for_each(move |message: String| {
+			let rpc = rpc.clone();
+			let mut to_front = to_front.clone();
+			async move {
+				let (resp, mut stream) = rpc.rpc_query(&message).await.unwrap();
+				to_front.send(resp).await.ok();
+				// read the rest of the stream but don't block
+				task::spawn(async move {
+					while let Some(resp) = stream.next().await {
+						to_front.send(resp).await.ok();
+					}
+				});
+			}
+		})));
+
+		Self { rpc: self.rpc.clone(), sender: Sender(to_back), receiver: Receiver(from_back) }
+	}
+}
+
+impl From<SubxtClient> for JsonRpcClient {
+	fn from(client: SubxtClient) -> Self {
+		ClientBuilder::default().build_with_tokio(client.sender, client.receiver)
+	}
+}
+
+/// Role of the node.
+#[derive(Clone, Copy, Debug)]
+pub enum Role {
+	/// Regular full node
+	Full,
+	/// Actual authority
+	Authority(AccountKeyring),
+}
+
+impl From<Role> for sc_service::Role {
+	fn from(role: Role) -> Self {
+		match role {
+			Role::Full => Self::Full,
+			Role::Authority(_) => Self::Authority,
+		}
+	}
+}
+
+impl From<Role> for Option<String> {
+	fn from(role: Role) -> Self {
+		match role {
+			Role::Full => None,
+			Role::Authority(key) => Some(key.to_seed()),
+		}
+	}
+}
+
+/// Client configuration.
+#[derive(Clone)]
+pub struct SubxtClientConfig<C: ChainSpec + 'static> {
+	/// Name of the implementation.
+	pub impl_name: &'static str,
+	/// Version of the implementation.
+	pub impl_version: &'static str,
+	/// Author of the implementation.
+	pub author: &'static str,
+	/// Copyright start year.
+	pub copyright_start_year: i32,
+	/// Database configuration.
+	pub db: DatabaseSource,
+	/// Keystore configuration.
+	pub keystore: KeystoreConfig,
+	/// Chain specification.
+	pub chain_spec: C,
+	/// Role of the node.
+	pub role: Role,
+	/// Enable telemetry on the given port.
+	pub telemetry: Option<u16>,
+	/// Wasm execution method
+	pub wasm_method: WasmExecutionMethod,
+	/// Handle to the tokio runtime. Will be used to spawn futures by the task manager.
+	pub tokio_handle: tokio::runtime::Handle,
+}
+
+impl<C: ChainSpec + 'static> SubxtClientConfig<C> {
+	/// Creates a service configuration.
+	pub fn into_service_config(self) -> Configuration {
+		let mut network = NetworkConfiguration::new(
+			format!("{} (subxt client)", self.chain_spec.name()),
+			"unknown",
+			Default::default(),
+			None,
+		);
+		network.boot_nodes = self.chain_spec.boot_nodes().to_vec();
+		network.transport = TransportConfig::Normal {
+			enable_mdns: true,
+			allow_private_ipv4: true,
+			// wasm_external_transport: None,
+		};
+		let telemetry_endpoints = if let Some(port) = self.telemetry {
+			let endpoints =
+				TelemetryEndpoints::new(vec![(format!("/ip4/127.0.0.1/tcp/{}/ws", port), 0)])
+					.expect("valid config; qed");
+			Some(endpoints)
+		} else {
+			None
+		};
+		let service_config = Configuration {
+			network,
+			impl_name: self.impl_name.to_string(),
+			impl_version: self.impl_version.to_string(),
+			chain_spec: Box::new(self.chain_spec),
+			role: self.role.into(),
+			database: self.db,
+			keystore: self.keystore,
+			max_runtime_instances: 8,
+			announce_block: true,
+			dev_key_seed: self.role.into(),
+			telemetry_endpoints,
+			tokio_handle: self.tokio_handle,
+			default_heap_pages: Default::default(),
+			disable_grandpa: Default::default(),
+			execution_strategies: Default::default(),
+			force_authoring: Default::default(),
+			keystore_remote: Default::default(),
+			offchain_worker: Default::default(),
+			prometheus_config: Default::default(),
+			rpc_cors: Default::default(),
+			rpc_http: Default::default(),
+			rpc_ipc: Default::default(),
+			rpc_ws: Default::default(),
+			rpc_ws_max_connections: Default::default(),
+			rpc_methods: Default::default(),
+			tracing_receiver: Default::default(),
+			tracing_targets: Default::default(),
+			transaction_pool: Default::default(),
+			wasm_method: self.wasm_method,
+			base_path: Default::default(),
+			informant_output_format: Default::default(),
+			state_pruning: Default::default(),
+			wasm_runtime_overrides: Default::default(),
+			rpc_max_payload: Default::default(),
+			ws_max_out_buffer_capacity: Default::default(),
+			runtime_cache_size: 2,
+			rpc_max_request_size: None,
+			rpc_max_response_size: None,
+			rpc_id_provider: None,
+			rpc_max_subs_per_conn: None,
+			trie_cache_maximum_size: None,
+			blocks_pruning: BlocksPruning::KeepAll,
+		};
+
+		log::info!("{}", service_config.impl_name);
+		log::info!("✌️  version {}", service_config.impl_version);
+		log::info!("❤️  by {}, {}", self.author, self.copyright_start_year);
+		log::info!("📋 Chain specification: {}", service_config.chain_spec.name());
+		log::info!("🏷  Node name: {}", service_config.network.node_name);
+		log::info!("👤 Role: {:?}", self.role);
+
+		service_config
+	}
+}

--- a/clients/runtime/src/assets.rs
+++ b/clients/runtime/src/assets.rs
@@ -1,12 +1,8 @@
-use std::{
-	collections::BTreeMap,
-	convert::TryFrom,
-	sync::{Mutex, MutexGuard},
-};
+use std::convert::TryFrom;
 
 use primitives::{CurrencyId::Token, CurrencyInfo, TokenSymbol::*};
 
-use crate::{types::*, CurrencyId, Error};
+use crate::{CurrencyId, Error};
 
 /// Convert a ticker symbol into a `CurrencyId` at runtime
 pub trait TryFromSymbol: Sized {
@@ -22,7 +18,7 @@ impl TryFromSymbol for CurrencyId {
 		if parts.len() == 2 {
 			let issuer = parts[0].trim();
 			let code = parts[1].trim();
-			return CurrencyId::try_from((code, issuer)).map_err(|err| Error::InvalidCurrency)
+			return CurrencyId::try_from((code, issuer)).map_err(|_| Error::InvalidCurrency)
 		}
 
 		// try hardcoded currencies first

--- a/clients/runtime/src/cli.rs
+++ b/clients/runtime/src/cli.rs
@@ -1,7 +1,6 @@
 use crate::{
 	error::{Error, KeyLoadingError},
-	rpc::ShutdownSender,
-	SpacewalkParachain, SpacewalkSigner,
+	ShutdownSender, SpacewalkParachain, SpacewalkSigner,
 };
 use clap::Parser;
 use sp_keyring::AccountKeyring;
@@ -37,7 +36,7 @@ impl ProviderUserOpts {
 			(None, None, Some(keyring)) => {
 				let pair = Pair::from_string(keyring.to_seed().as_str(), None)
 					.map_err(|e| Error::KeyringAccountParsingError)?;
-				(pair, format!("{}", keyring))
+				(pair, format!("{:?}", keyring))
 			},
 			_ => {
 				// should never occur, due to clap constraints

--- a/clients/runtime/src/cli.rs
+++ b/clients/runtime/src/cli.rs
@@ -1,12 +1,14 @@
+use std::{collections::HashMap, num::ParseIntError, sync::Arc, time::Duration};
+
+use clap::Parser;
+use sp_keyring::AccountKeyring;
+use subxt::ext::sp_core::{sr25519::Pair, Pair as _};
+use tokio::sync::RwLock;
+
 use crate::{
 	error::{Error, KeyLoadingError},
 	ShutdownSender, SpacewalkParachain, SpacewalkSigner,
 };
-use clap::Parser;
-use sp_keyring::AccountKeyring;
-use std::{collections::HashMap, num::ParseIntError, sync::Arc, time::Duration};
-use subxt::ext::sp_core::{sr25519::Pair, Pair as _};
-use tokio::sync::RwLock;
 
 #[derive(Parser, Debug, Clone)]
 pub struct ProviderUserOpts {
@@ -35,7 +37,7 @@ impl ProviderUserOpts {
 				(get_credentials_from_file(file_path, keyname)?, keyname.to_string()),
 			(None, None, Some(keyring)) => {
 				let pair = Pair::from_string(keyring.to_seed().as_str(), None)
-					.map_err(|e| Error::KeyringAccountParsingError)?;
+					.map_err(|_| Error::KeyringAccountParsingError)?;
 				(pair, format!("{:?}", keyring))
 			},
 			_ => {

--- a/clients/runtime/src/conn.rs
+++ b/clients/runtime/src/conn.rs
@@ -12,7 +12,7 @@ const RETRY_TIMEOUT: Duration = Duration::from_millis(1000);
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 async fn ws_transport(url: &str) -> Result<(Sender, Receiver), Error> {
-	let url: Uri = url.parse().map_err(|e: InvalidUri| Error::BlockNotFound)?; // TODO change this
+	let url: Uri = url.parse().map_err(|e: InvalidUri| Error::UrlParseError(e))?;
 	WsTransportClientBuilder::default()
 		.build(url)
 		.await

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -1,20 +1,15 @@
 use std::{array::TryFromSliceError, fmt::Debug, io::Error as IoError, num::TryFromIntError};
 
 use codec::Error as CodecError;
+use jsonrpsee::client_transport::ws::{InvalidUri as UrlParseError, WsHandshakeError};
 pub use jsonrpsee::core::Error as JsonRpseeError;
-use jsonrpsee::{
-	client_transport::ws::WsHandshakeError,
-	core::error::Error as RequestError,
-	types::{error::CallError, ErrorObject, ErrorObjectOwned},
-};
 use serde_json::Error as SerdeJsonError;
 use subxt::{
-	error::{DispatchError, Error as BasicError, ModuleError, RpcError, TransactionError},
+	error::{DispatchError, ModuleError, TransactionError},
 	ext::sp_core::crypto::SecretStringError,
 };
 use thiserror::Error;
 use tokio::time::error::Elapsed;
-use url::ParseError as UrlParseError;
 
 use crate::{types::*, ISSUE_MODULE, SYSTEM_MODULE};
 

--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -1,0 +1,203 @@
+#![cfg(feature = "testing-utils")]
+
+use std::{sync::Arc, time::Duration};
+
+use frame_support::assert_ok;
+use futures::{
+	future::{try_join, Either},
+	pin_mut, Future, FutureExt, SinkExt, StreamExt,
+};
+use subxt::{
+	events::StaticEvent as Event,
+	ext::sp_core::{sr25519::Pair, Pair as _},
+};
+use tempdir::TempDir;
+use tokio::{
+	sync::RwLock,
+	time::{sleep, timeout},
+};
+
+pub use subxt_client::SubxtClient;
+use subxt_client::{
+	AccountKeyring, DatabaseSource, KeystoreConfig, Role, SubxtClientConfig, WasmExecutionMethod,
+	WasmtimeInstantiationStrategy,
+};
+
+use crate::{
+	rpc::{OraclePallet, VaultRegistryPallet},
+	CurrencyId, FixedU128, OracleKey, SpacewalkParachain, SpacewalkSigner, VaultId,
+};
+
+/// Start a new instance of the parachain. The second item in the returned tuple must remain in
+/// scope as long as the parachain is active, since dropping it will remove the temporary directory
+/// that the parachain uses
+pub async fn default_provider_client(key: AccountKeyring) -> (SubxtClient, TempDir) {
+	let tmp = TempDir::new("btc-parachain-").expect("failed to create tempdir");
+	let config = SubxtClientConfig {
+		impl_name: "btc-parachain-full-client",
+		impl_version: "0.0.1",
+		author: "Interlay Ltd",
+		copyright_start_year: 2020,
+		db: DatabaseSource::ParityDb { path: tmp.path().join("db") },
+		keystore: KeystoreConfig::Path { path: tmp.path().join("keystore"), password: None },
+		chain_spec: testchain::chain_spec::development_config(),
+		role: Role::Authority(key),
+		telemetry: None,
+		wasm_method: WasmExecutionMethod::Compiled {
+			instantiation_strategy: WasmtimeInstantiationStrategy::LegacyInstanceReuse,
+		},
+		tokio_handle: tokio::runtime::Handle::current(),
+	};
+
+	// enable off chain workers
+	let mut service_config = config.into_service_config();
+	service_config.offchain_worker.enabled = true;
+
+	let (task_manager, rpc_handlers) =
+		testchain::service::start_instant(service_config).await.unwrap();
+
+	let client = SubxtClient::new(task_manager, rpc_handlers);
+
+	(client, tmp)
+}
+
+fn get_pair_from_keyring(keyring: AccountKeyring) -> Result<Pair, String> {
+	let pair = Pair::from_string(keyring.to_seed().as_str(), None)
+		.map_err(|_| "Could not create pair for keyring")?;
+	Ok(pair)
+}
+
+/// Create a new parachain_rpc with the given keyring
+pub async fn setup_provider(client: SubxtClient, key: AccountKeyring) -> SpacewalkParachain {
+	let pair = get_pair_from_keyring(key).unwrap();
+	let signer = SpacewalkSigner::new(pair);
+	let signer = Arc::new(RwLock::new(signer));
+	let shutdown_tx = crate::ShutdownSender::new();
+
+	SpacewalkParachain::new(client.into(), signer, shutdown_tx)
+		.await
+		.expect("Error creating parachain_rpc")
+}
+
+// /// request, pay and execute an issue
+// pub async fn assert_issue(
+// 	parachain_rpc: &SpacewalkParachain,
+// 	btc_rpc: &DynBitcoinCoreApi,
+// 	vault_id: &VaultId,
+// 	amount: u128,
+// ) {
+// 	let issue = parachain_rpc.request_issue(amount, vault_id).await.unwrap();
+//
+// 	let fee_rate = SatPerVbyte(1000);
+//
+// 	let metadata = btc_rpc
+// 		.send_to_address(
+// 			issue.vault_address.to_address(btc_rpc.network()).unwrap(),
+// 			(issue.amount + issue.fee) as u64,
+// 			None,
+// 			fee_rate,
+// 			0,
+// 		)
+// 		.await
+// 		.unwrap();
+//
+// 	parachain_rpc
+// 		.execute_issue(issue.issue_id, &metadata.proof, &metadata.raw_tx)
+// 		.await
+// 		.unwrap();
+// }
+
+const SLEEP_DURATION: Duration = Duration::from_millis(1000);
+const TIMEOUT_DURATION: Duration = Duration::from_secs(20);
+
+async fn wait_for_aggregate(parachain_rpc: &SpacewalkParachain, key: &OracleKey) {
+	while parachain_rpc.has_updated(key).await.unwrap() {
+		// should be false upon aggregate update
+		sleep(SLEEP_DURATION).await;
+	}
+}
+
+pub async fn set_exchange_rate_and_wait(
+	parachain_rpc: &SpacewalkParachain,
+	currency_id: CurrencyId,
+	value: FixedU128,
+) {
+	let key = OracleKey::ExchangeRate(currency_id);
+	assert_ok!(parachain_rpc.feed_values(vec![(key.clone(), value)]).await);
+	parachain_rpc.manual_seal().await;
+	// we need a new block to get on_initialize to run
+	assert_ok!(timeout(TIMEOUT_DURATION, wait_for_aggregate(parachain_rpc, &key)).await);
+}
+
+pub async fn set_bitcoin_fees(parachain_rpc: &SpacewalkParachain, value: FixedU128) {
+	assert_ok!(parachain_rpc.set_bitcoin_fees(value).await);
+	parachain_rpc.manual_seal().await;
+	// we need a new block to get on_initialize to run
+	assert_ok!(
+		timeout(TIMEOUT_DURATION, wait_for_aggregate(parachain_rpc, &OracleKey::FeeEstimation))
+			.await
+	);
+}
+
+/// calculate how much collateral the vault requires to accept an issue of the given size
+pub async fn get_required_vault_collateral_for_issue(
+	parachain_rpc: &SpacewalkParachain,
+	amount: u128,
+	collateral_currency: CurrencyId,
+) -> u128 {
+	parachain_rpc
+		.get_required_collateral_for_wrapped(amount, collateral_currency)
+		.await
+		.unwrap()
+}
+
+/// wait for an event to occur. After the specified error, this will panic. This returns the event.
+pub async fn assert_event<T, F>(duration: Duration, parachain_rpc: SpacewalkParachain, f: F) -> T
+where
+	T: Event + Clone + std::fmt::Debug,
+	F: Fn(T) -> bool,
+{
+	let (tx, mut rx) = futures::channel::mpsc::channel(1);
+	let event_writer = parachain_rpc
+		.on_event::<T, _, _, _>(
+			|event| async {
+				if (f)(event.clone()) {
+					tx.clone().send(event).await.unwrap();
+				}
+			},
+			|_| {},
+		)
+		.fuse();
+	let event_reader = rx.next().fuse();
+	pin_mut!(event_reader, event_writer);
+
+	timeout(duration, async {
+		match futures::future::select(event_writer, event_reader).await {
+			Either::Right((ret, _)) => ret.unwrap(),
+			_ => panic!(),
+		}
+	})
+	.await
+	.unwrap_or_else(|_| panic!("could not find event: {}::{}", T::PALLET, T::EVENT))
+}
+
+/// run `service` in the background, and run `fut`. If the service completes before the
+/// second future, this will panic
+pub async fn test_service<T: Future, U: Future>(service: T, fut: U) -> U::Output {
+	pin_mut!(service, fut);
+	match futures::future::select(service, fut).await {
+		Either::Right((ret, _)) => ret,
+		_ => panic!(),
+	}
+}
+
+pub async fn with_timeout<T: Future>(future: T, duration: Duration) -> T::Output {
+	timeout(duration, future).await.expect("timeout")
+}
+
+pub async fn periodically_produce_blocks(parachain_rpc: SpacewalkParachain) {
+	loop {
+		tokio::time::sleep(Duration::from_millis(500)).await;
+		parachain_rpc.manual_seal().await;
+	}
+}

--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -3,10 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use frame_support::assert_ok;
-use futures::{
-	future::{try_join, Either},
-	pin_mut, Future, FutureExt, SinkExt, StreamExt,
-};
+use futures::{future::Either, pin_mut, Future, FutureExt, SinkExt, StreamExt};
 use subxt::{
 	events::StaticEvent as Event,
 	ext::sp_core::{sr25519::Pair, Pair as _},
@@ -25,7 +22,7 @@ use subxt_client::{
 
 use crate::{
 	rpc::{OraclePallet, VaultRegistryPallet},
-	CurrencyId, FixedU128, OracleKey, SpacewalkParachain, SpacewalkSigner, VaultId,
+	CurrencyId, FixedU128, OracleKey, SpacewalkParachain, SpacewalkSigner,
 };
 
 /// Start a new instance of the parachain. The second item in the returned tuple must remain in
@@ -34,9 +31,9 @@ use crate::{
 pub async fn default_provider_client(key: AccountKeyring) -> (SubxtClient, TempDir) {
 	let tmp = TempDir::new("btc-parachain-").expect("failed to create tempdir");
 	let config = SubxtClientConfig {
-		impl_name: "btc-parachain-full-client",
+		impl_name: "spacewalk-parachain-full-client",
 		impl_version: "0.0.1",
-		author: "Interlay Ltd",
+		author: "SatoshiPay",
 		copyright_start_year: 2020,
 		db: DatabaseSource::ParityDb { path: tmp.path().join("db") },
 		keystore: KeystoreConfig::Path { path: tmp.path().join("keystore"), password: None },
@@ -129,8 +126,8 @@ pub async fn set_exchange_rate_and_wait(
 	assert_ok!(timeout(TIMEOUT_DURATION, wait_for_aggregate(parachain_rpc, &key)).await);
 }
 
-pub async fn set_bitcoin_fees(parachain_rpc: &SpacewalkParachain, value: FixedU128) {
-	assert_ok!(parachain_rpc.set_bitcoin_fees(value).await);
+pub async fn set_stellar_fees(parachain_rpc: &SpacewalkParachain, value: FixedU128) {
+	assert_ok!(parachain_rpc.set_stellar_fees(value).await);
 	parachain_rpc.manual_seal().await;
 	// we need a new block to get on_initialize to run
 	assert_ok!(

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -15,16 +15,20 @@ pub use rpc::{
 	CollateralBalancesPallet, SpacewalkParachain, UtilFuncs, VaultRegistryPallet,
 	DEFAULT_SPEC_NAME, SS58_PREFIX,
 };
+pub use shutdown::{ShutdownReceiver, ShutdownSender};
 pub use types::*;
 
 pub mod cli;
+
+#[cfg(feature = "testing-utils")]
+pub mod integration;
 
 mod assets;
 mod conn;
 mod error;
 mod retry;
 mod rpc;
-
+mod shutdown;
 pub mod types;
 
 pub const TX_FEES: u128 = 2000000000;
@@ -59,6 +63,8 @@ pub mod metadata {
 	use crate::AccountId;
 	#[subxt(substitute_type = "spacewalk_primitives::CurrencyId")]
 	use crate::CurrencyId;
+	#[subxt(substitute_type = "sp_arithmetic::fixed_point::FixedU128")]
+	use crate::FixedU128;
 }
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Default, Clone, Decode, Encode)]

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -4,7 +4,7 @@ pub use sp_arithmetic::{traits as FixedPointTraits, FixedI128, FixedPointNumber,
 use sp_std::marker::PhantomData;
 pub use subxt::ext::sp_core::{crypto::Ss58Codec, sr25519::Pair};
 use subxt::{
-	ext::sp_runtime::{generic::Header, traits::BlakeTwo256, MultiSignature, OpaqueExtrinsic},
+	ext::sp_runtime::{generic::Header, traits::BlakeTwo256, MultiSignature},
 	subxt, Config,
 };
 

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -12,13 +12,16 @@ pub use assets::TryFromSymbol;
 pub use error::{Error, SubxtError};
 pub use retry::{notify_retry, RetryPolicy};
 pub use rpc::{
-	CollateralBalancesPallet, SpacewalkParachain, UtilFuncs, VaultRegistryPallet,
-	DEFAULT_SPEC_NAME, SS58_PREFIX,
+	CollateralBalancesPallet, OraclePallet, SecurityPallet, SpacewalkParachain, UtilFuncs,
+	VaultRegistryPallet, DEFAULT_SPEC_NAME, SS58_PREFIX,
 };
 pub use shutdown::{ShutdownReceiver, ShutdownSender};
 pub use types::*;
 
 pub mod cli;
+
+#[cfg(test)]
+mod tests;
 
 #[cfg(feature = "testing-utils")]
 pub mod integration;

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -912,3 +912,34 @@ impl OraclePallet for SpacewalkParachain {
 		self.fee_rate_update_tx.subscribe()
 	}
 }
+
+#[async_trait]
+pub trait SecurityPallet {
+	async fn get_parachain_status(&self) -> Result<StatusCode, Error>;
+
+	async fn get_error_codes(&self) -> Result<Vec<ErrorCode>, Error>;
+
+	/// Gets the current active block number of the parachain
+	async fn get_current_active_block_number(&self) -> Result<u32, Error>;
+}
+
+#[async_trait]
+impl SecurityPallet for SpacewalkParachain {
+	/// Get the current security status of the parachain.
+	/// Should be one of; `Running`, `Error` or `Shutdown`.
+	async fn get_parachain_status(&self) -> Result<StatusCode, Error> {
+		self.query_finalized_or_error(metadata::storage().security().parachain_status())
+			.await
+	}
+
+	/// Return any `ErrorCode`s set in the security module.
+	async fn get_error_codes(&self) -> Result<Vec<ErrorCode>, Error> {
+		self.query_finalized_or_error(metadata::storage().security().errors()).await
+	}
+
+	/// Gets the current active block number of the parachain
+	async fn get_current_active_block_number(&self) -> Result<u32, Error> {
+		self.query_finalized_or_default(metadata::storage().security().active_block_count())
+			.await
+	}
+}

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -413,14 +413,16 @@ impl SpacewalkParachain {
 			.unwrap();
 
 		// now call with outdated nonce
-		self.api
+		let result = self
+			.api
 			.tx()
 			.create_signed_with_nonce(&call, &signer, 0, Default::default())
 			.unwrap()
 			.submit_and_watch()
-			.await
-			.unwrap_err()
-			.into()
+			.await;
+
+		assert!(result.is_err());
+		result.unwrap_err().into()
 	}
 
 	/// Emulate the POOL_TOO_LOW_PRIORITY error using token transfer extrinsics.
@@ -446,14 +448,16 @@ impl SpacewalkParachain {
 			.unwrap();
 
 		// should call with the same nonce
-		self.api
+		let result = self
+			.api
 			.tx()
 			.create_signed_with_nonce(&call, &signer, nonce, Default::default())
 			.unwrap()
 			.submit_and_watch()
-			.await
-			.unwrap_err()
-			.into()
+			.await;
+
+		assert!(result.is_err());
+		result.unwrap_err().into()
 	}
 }
 

--- a/clients/runtime/src/shutdown.rs
+++ b/clients/runtime/src/shutdown.rs
@@ -1,0 +1,64 @@
+use std::sync::{Arc, RwLock};
+
+use tokio::sync::broadcast::error::{RecvError, SendError};
+
+/// A wrapper arround a tokio broadcast channel that makes sure that
+/// listeners created after a shutdown signal has already been sent
+/// also receive the shutdown signal.
+#[derive(Clone)]
+pub struct ShutdownSender {
+	pub sent_shutdown: Arc<RwLock<bool>>,
+	pub channel: tokio::sync::broadcast::Sender<()>,
+}
+
+impl ShutdownSender {
+	pub fn new() -> Self {
+		let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+		Self { sent_shutdown: Arc::new(RwLock::new(false)), channel: shutdown_tx }
+	}
+
+	pub fn send(&self, value: ()) -> Result<usize, SendError<()>> {
+		// Record that we sent the signal for listeners created in the future.
+		// Note that unwrap is suitable here since the read only fails if a thread
+		// holding the lock has panicked, in which case propagating the panic is
+		// generally advised to prevent operating on unexpected state.
+		*self.sent_shutdown.write().unwrap() = true;
+
+		self.channel.send(value)
+	}
+
+	pub fn subscribe(&self) -> ShutdownReceiver {
+		let subscription = self.channel.subscribe();
+		// Check if signal was already sent before we started listening.
+		// Note that unwrap is suitable here since the read only fails if a thread
+		// holding the lock has panicked, in which case propagating the panic is
+		// generally advised to prevent operating on unexpected state.
+		let sent = *self.sent_shutdown.read().unwrap();
+		ShutdownReceiver { received_shutdown: sent, inner: subscription }
+	}
+
+	pub fn receiver_count(&self) -> usize {
+		self.channel.receiver_count()
+	}
+}
+
+impl Default for ShutdownSender {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+pub struct ShutdownReceiver {
+	received_shutdown: bool,
+	inner: tokio::sync::broadcast::Receiver<()>,
+}
+
+impl ShutdownReceiver {
+	pub async fn recv(&mut self) -> Result<(), RecvError> {
+		if self.received_shutdown {
+			Ok(())
+		} else {
+			self.inner.recv().await
+		}
+	}
+}

--- a/clients/runtime/src/tests.rs
+++ b/clients/runtime/src/tests.rs
@@ -1,0 +1,134 @@
+#![cfg(test)]
+
+use std::{convert::TryInto, time::Duration};
+
+use sp_keyring::AccountKeyring;
+
+use primitives::{StellarPublicKeyRaw, TokenSymbol};
+
+use crate::{integration::*, FeedValuesEvent, OracleKey, VaultId};
+
+use super::{
+	CollateralBalancesPallet, CurrencyId, FixedPointNumber, FixedU128, OraclePallet,
+	SecurityPallet, StatusCode, Token, TryFromSymbol, VaultRegistryPallet,
+};
+
+const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(TokenSymbol::KSM);
+const DEFAULT_WRAPPED_CURRENCY: CurrencyId = CurrencyId::AlphaNum4 {
+	code: *b"USDC",
+	issuer: [
+		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
+		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
+	],
+};
+
+fn dummy_public_key() -> StellarPublicKeyRaw {
+	[0u8; 32]
+}
+
+async fn set_exchange_rate(client: SubxtClient) {
+	let oracle_provider = setup_provider(client, AccountKeyring::Bob).await;
+	let key = OracleKey::ExchangeRate(DEFAULT_TESTING_CURRENCY);
+	let exchange_rate = FixedU128::saturating_from_rational(1u128, 100u128);
+	oracle_provider
+		.feed_values(vec![(key, exchange_rate)])
+		.await
+		.expect("Unable to set exchange rate");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_getters() {
+	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
+	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
+
+	tokio::join!(
+		async {
+			assert_eq!(
+				parachain_rpc.get_free_balance(DEFAULT_TESTING_CURRENCY).await.unwrap(),
+				1 << 60
+			);
+		},
+		async {
+			assert_eq!(parachain_rpc.get_parachain_status().await.unwrap(), StatusCode::Error);
+		},
+		// async {
+		// 	assert!(parachain_rpc.get_replace_dust_amount().await.unwrap() > 0);
+		// },
+		async {
+			assert!(parachain_rpc.get_current_active_block_number().await.unwrap() == 0);
+		}
+	);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_tx_matching() {
+	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
+	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
+
+	// This conversion is necessary for now because subxt uses newer versions of the sp_xxx
+	// dependencies
+	let recipient = subxt::ext::sp_runtime::AccountId32::from(AccountKeyring::Bob.to_raw_public());
+	let err = parachain_rpc.get_invalid_tx_error(recipient).await;
+	assert!(err.is_invalid_transaction().is_some())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_too_low_priority_matching() {
+	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
+	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
+
+	// This conversion is necessary for now because subxt uses newer versions of the sp_xxx
+	// dependencies
+	let recipient = subxt::ext::sp_runtime::AccountId32::from(AccountKeyring::Bob.to_raw_public());
+	let err = parachain_rpc.get_too_low_priority_error(recipient).await;
+	assert!(err.is_pool_too_low_priority().is_some())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subxt_processing_events_after_dispatch_error() {
+	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
+	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
+
+	let oracle_provider = setup_provider(client.clone(), AccountKeyring::Bob).await;
+	let invalid_oracle = setup_provider(client, AccountKeyring::Dave).await;
+
+	let event_listener = crate::integration::assert_event::<FeedValuesEvent, _>(
+		Duration::from_secs(80),
+		parachain_rpc.clone(),
+		|_| true,
+	);
+
+	let key = OracleKey::ExchangeRate(DEFAULT_TESTING_CURRENCY);
+	let exchange_rate = FixedU128::saturating_from_rational(1u128, 100u128);
+
+	let result = tokio::join!(
+		event_listener,
+		invalid_oracle.feed_values(vec![(key.clone(), exchange_rate)]),
+		oracle_provider.feed_values(vec![(key, exchange_rate)])
+	);
+
+	// ensure first set_exchange_rate failed and second succeeded.
+	result.1.unwrap_err();
+	result.2.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_register_vault() {
+	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
+	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
+	set_exchange_rate(client.clone()).await;
+
+	// This conversion is necessary for now because subxt uses newer versions of the sp_xxx
+	// dependencies
+	let account_id =
+		subxt::ext::sp_runtime::AccountId32::from(AccountKeyring::Alice.to_raw_public());
+	let vault_id = VaultId::new(account_id, DEFAULT_TESTING_CURRENCY, DEFAULT_WRAPPED_CURRENCY);
+
+	parachain_rpc.register_public_key(dummy_public_key()).await.unwrap();
+	parachain_rpc
+		.register_vault(&vault_id, 3 * TokenSymbol::KSM.one())
+		.await
+		.unwrap();
+	parachain_rpc.get_vault(&vault_id).await.unwrap();
+	assert_eq!(parachain_rpc.get_public_key().await.unwrap(), Some(dummy_public_key()));
+}

--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -1,7 +1,7 @@
 pub use subxt::ext::sp_core::sr25519::Pair as KeyPair;
 
 pub use metadata_aliases::*;
-pub use primitives::{CurrencyId, TokenSymbol};
+pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol};
 
 use crate::{metadata, Config, SpacewalkRuntime, SS58_PREFIX};
 
@@ -22,7 +22,9 @@ mod metadata_aliases {
 		runtime_types::{
 			frame_system::pallet::Error as SystemPalletError,
 			issue::pallet::Error as IssuePalletError,
-			spacewalk_primitives::oracle::Key as OracleKey, vault_registry::types::VaultStatus,
+			security::types::{ErrorCode, StatusCode},
+			spacewalk_primitives::oracle::Key as OracleKey,
+			vault_registry::types::VaultStatus,
 		},
 		vault_registry::events::{
 			DepositCollateral as DepositCollateralEvent, LiquidateVault as LiquidateVaultEvent,

--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -1,7 +1,7 @@
 pub use subxt::ext::sp_core::sr25519::Pair as KeyPair;
 
 pub use metadata_aliases::*;
-pub use primitives::CurrencyId;
+pub use primitives::{CurrencyId, TokenSymbol};
 
 use crate::{metadata, Config, SpacewalkRuntime, SS58_PREFIX};
 
@@ -12,15 +12,17 @@ pub type BlockNumber = u32;
 pub type Index = u32;
 pub type H256 = subxt::ext::sp_core::H256;
 pub type SpacewalkSigner = subxt::tx::PairSigner<SpacewalkRuntime, KeyPair>;
+pub type FixedU128 = sp_arithmetic::FixedU128;
 
 pub type StellarPublicKey = [u8; 32];
 
 mod metadata_aliases {
 	pub use metadata::{
+		oracle::events::FeedValues as FeedValuesEvent,
 		runtime_types::{
 			frame_system::pallet::Error as SystemPalletError,
-			issue::pallet::Error as IssuePalletError, sp_arithmetic::fixed_point::FixedU128,
-			vault_registry::types::VaultStatus,
+			issue::pallet::Error as IssuePalletError,
+			spacewalk_primitives::oracle::Key as OracleKey, vault_registry::types::VaultStatus,
 		},
 		vault_registry::events::{
 			DepositCollateral as DepositCollateralEvent, LiquidateVault as LiquidateVaultEvent,

--- a/clients/service/src/lib.rs
+++ b/clients/service/src/lib.rs
@@ -14,7 +14,6 @@ use runtime::{
 	ShutdownSender, SpacewalkParachain, SpacewalkSigner,
 };
 pub use trace::init_subscriber;
-use wallet::StellarWallet;
 
 mod cli;
 mod error;

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -66,5 +66,7 @@ env_logger = "0.9.0"
 # Workspace dependencies
 runtime = { path = "../runtime", features = ["testing-utils"] }
 
+subxt = { version = "0.25.0" }
+
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }

--- a/clients/vault/src/error.rs
+++ b/clients/vault/src/error.rs
@@ -1,14 +1,10 @@
-use hex::FromHexError;
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
-use sp_runtime::traits::LookupError;
 use sp_std::str::Utf8Error;
 use thiserror::Error;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
-use runtime::{Error as RuntimeError, SubxtError};
-use service::Error as ServiceError;
-use stellar_relay::sdk::StellarSdkError;
+use runtime::Error as RuntimeError;
 use wallet::Error as WalletError;
 
 #[derive(Error, Debug)]

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -6,10 +6,10 @@ use tokio::time::sleep;
 use tokio_stream::wrappers::BroadcastStream;
 
 use runtime::{
-	CurrencyId, Error as RuntimeError, FixedPointNumber, FixedU128, PrettyPrint,
+	CurrencyId, Error as RuntimeError, FixedPointNumber, FixedU128, PrettyPrint, ShutdownSender,
 	SpacewalkParachain, StellarPublicKey, UtilFuncs, VaultId, H256,
 };
-use service::{spawn_cancelable, Error as ServiceError, ShutdownSender};
+use service::{spawn_cancelable, Error as ServiceError};
 use wallet::StellarWallet;
 
 use crate::{error::Error, system::VaultData, VaultIdManager};

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -1,18 +1,10 @@
-use std::{collections::HashMap, convert::TryInto, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
-use futures::{future::Either, stream::StreamExt, try_join, TryStreamExt};
-use governor::RateLimiter;
-use tokio::time::sleep;
-use tokio_stream::wrappers::BroadcastStream;
-
-use runtime::{
-	CurrencyId, Error as RuntimeError, FixedPointNumber, FixedU128, PrettyPrint, ShutdownSender,
-	SpacewalkParachain, StellarPublicKey, UtilFuncs, VaultId, H256,
-};
+use runtime::{CurrencyId, ShutdownSender, SpacewalkParachain, StellarPublicKey, VaultId, H256};
 use service::{spawn_cancelable, Error as ServiceError};
 use wallet::StellarWallet;
 
-use crate::{error::Error, system::VaultData, VaultIdManager};
+use crate::{error::Error, VaultIdManager};
 
 #[derive(Debug, Clone, PartialEq)]
 struct Deadline {

--- a/clients/vault/src/main.rs
+++ b/clients/vault/src/main.rs
@@ -1,9 +1,4 @@
-use std::{
-	io::Write,
-	net::{Ipv4Addr, SocketAddr},
-	path::PathBuf,
-	sync::Arc,
-};
+use std::{io::Write, path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use futures::Future;
@@ -11,8 +6,8 @@ use sysinfo::{System, SystemExt};
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 
-use runtime::{KeyPair, SpacewalkSigner, Ss58Codec, DEFAULT_SPEC_NAME, SS58_PREFIX};
-use service::{warp, warp::Filter, ConnectionManager, Error as ServiceError, ServiceConfig};
+use runtime::{SpacewalkSigner, DEFAULT_SPEC_NAME};
+use service::{ConnectionManager, Error as ServiceError, ServiceConfig};
 use signal_hook::consts::*;
 use signal_hook_tokio::Signals;
 use vault::{

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -1,12 +1,9 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
 use lazy_static::lazy_static;
 use tokio_metrics::TaskMetrics;
 
-use runtime::prometheus::{
-	gather, proto::MetricFamily, Encoder, Gauge, GaugeVec, IntCounter, IntGauge, IntGaugeVec, Opts,
-	Registry, TextEncoder,
-};
+use runtime::prometheus::IntCounter;
 use service::Error as ServiceError;
 
 use crate::Error;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -14,9 +14,10 @@ use tokio::{sync::RwLock, time::sleep};
 use runtime::{
 	cli::{parse_duration_minutes, parse_duration_ms},
 	CollateralBalancesPallet, CurrencyId, Error as RuntimeError, PrettyPrint, RegisterVaultEvent,
-	SpacewalkParachain, TryFromSymbol, UtilFuncs, VaultCurrencyPair, VaultId, VaultRegistryPallet,
+	ShutdownSender, SpacewalkParachain, TryFromSymbol, UtilFuncs, VaultCurrencyPair, VaultId,
+	VaultRegistryPallet,
 };
-use service::{wait_or_shutdown, Error as ServiceError, Service, ShutdownSender};
+use service::{wait_or_shutdown, Error as ServiceError, Service};
 use wallet::StellarWallet;
 
 use crate::{

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -392,7 +392,7 @@ impl VaultService {
 	}
 
 	async fn maybe_register_public_key(&mut self) -> Result<(), Error> {
-		if let Some(faucet_url) = &self.config.faucet_url {
+		if let Some(_faucet_url) = &self.config.faucet_url {
 			// TODO fund account with faucet
 		}
 
@@ -445,7 +445,7 @@ impl VaultService {
 							},
 						)
 						.await?;
-				} else if let Some(faucet_url) = &self.config.faucet_url {
+				} else if let Some(_faucet_url) = &self.config.faucet_url {
 					tracing::info!("[{}] Automatically registering...", vault_id.pretty_print());
 					// TODO
 					// faucet::fund_and_register(&self.spacewalk_parachain, faucet_url, &vault_id)

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -1,10 +1,32 @@
-use frame_support::assert_ok;
-use futures::{Future, FutureExt};
-use runtime::{integration::*, types::*, SpacewalkPallet, SpacewalkParachain, UtilFuncs};
-use sp_keyring::AccountKeyring;
 use std::time::Duration;
 
+use async_trait::async_trait;
+use frame_support::assert_ok;
+use futures::{
+	channel::mpsc,
+	future::{join, join3, join5},
+	Future, FutureExt, SinkExt, TryStreamExt,
+};
+use sp_core::ByteArray;
+use sp_keyring::AccountKeyring;
+
+use runtime::{
+	integration::*, types::*, CurrencyId::Token, FixedPointNumber, FixedU128, SpacewalkParachain,
+	UtilFuncs, VaultRegistryPallet,
+};
+use stellar_relay::sdk::SecretKey;
+
 const TIMEOUT: Duration = Duration::from_secs(90);
+
+const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(TokenSymbol::AMPE);
+const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(TokenSymbol::KSM);
+const DEFAULT_WRAPPED_CURRENCY: CurrencyId = CurrencyId::AlphaNum4 {
+	code: *b"USDC",
+	issuer: [
+		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
+		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
+	],
+};
 
 const STELLAR_VAULT_SECRET_KEY: &str = "SB6WHKIU2HGVBRNKNOEOQUY4GFC4ZLG5XPGWLEAHTIZXBXXYACC76VSQ";
 
@@ -15,12 +37,29 @@ where
 	service::init_subscriber();
 	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
 
+	// Has to be Bob because he is set as `authorized_oracle` in the genesis config
 	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Bob).await;
+
+	set_exchange_rate_and_wait(
+		&parachain_rpc,
+		DEFAULT_TESTING_CURRENCY,
+		FixedU128::from(100000000),
+	)
+	.await;
+	set_exchange_rate_and_wait(
+		&parachain_rpc,
+		DEFAULT_NATIVE_CURRENCY,
+		FixedU128::saturating_from_rational(1u128, 100u128),
+	)
+	.await;
+	set_bitcoin_fees(&parachain_rpc, FixedU128::from(1)).await;
 
 	execute(client).await
 }
 
-async fn test_with_vault<F, R>(execute: impl FnOnce(SubxtClient, SpacewalkParachain) -> F) -> R
+async fn test_with_vault<F, R>(
+	execute: impl FnOnce(SubxtClient, VaultId, SpacewalkParachain) -> F,
+) -> R
 where
 	F: Future<Output = R>,
 {
@@ -28,110 +67,83 @@ where
 	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
 
 	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Bob).await;
+	set_exchange_rate_and_wait(
+		&parachain_rpc,
+		DEFAULT_TESTING_CURRENCY,
+		FixedU128::from(100000000),
+	)
+	.await;
+	set_exchange_rate_and_wait(
+		&parachain_rpc,
+		DEFAULT_NATIVE_CURRENCY,
+		FixedU128::saturating_from_rational(1u128, 100u128),
+	)
+	.await;
+	set_bitcoin_fees(&parachain_rpc, FixedU128::from(1)).await;
 
 	let vault_provider = setup_provider(client.clone(), AccountKeyring::Charlie).await;
 
-	execute(client, vault_provider).await
+	let account_id = AccountKeyring::Charlie.to_raw_public();
+	// Convert to the subxt AccountId type because unfortunately there is a version mismatch between
+	// the sp_xxx dependencies subxt uses and the ones we use
+	let account_id = subxt::ext::sp_runtime::AccountId32::from(account_id);
+
+	let vault_id = VaultId::new(account_id, DEFAULT_TESTING_CURRENCY, DEFAULT_WRAPPED_CURRENCY);
+
+	execute(client, vault_id, vault_provider).await
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_deposit() {
-	let tx_string: &str = r#"{
-  "_links": { },
-  "_embedded": {
-    "records": [
-      {
-        "_links": { },
-        "id": "0eb09b01df05990221197c67b5c7a03157008e270a690b31f3809b5083506895",
-        "paging_token": "876173332480",
-        "successful": true,
-        "hash": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
-        "ledger": 176,
-        "created_at": "2022-03-16T10:02:39Z",
-        "source_account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-        "source_account_sequence": "1",
-        "fee_account": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
-        "fee_charged": "1100",
-        "max_fee": "1100",
-        "operation_count": 11,
-        "envelope_xdr": "AAAAAgAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAABEwAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAAAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAAAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx7qh6aAFYAAAAAAAAAAARW/AX3AAAAQDVB8fT2ZXF0PZqtZX9brK0kz+P4G8VKs1DkDklP6ULsvXRexXFBdH4xG8xRAsR1HJeEBH278hiBNNvUwNw6zgzGYc0bAAAAQLgZUU/oYGL7frWDQhJHhCQu9JmfqN03PrJq4/cJrN1OSUWXnmLc94sv8m2L+cxl2p0skr2Jxy+vt1Lcxkv7wAI4WbfcAAAAQHvZEVqlygIProf3jVTZohDWm2WUNrFAFXf1LctTqDCQBHph14Eo+APwrTURLLYTIvNoXeGzBKbL03SsOARWcQLkyoKVAAAAQHAvKv2/Ro4+cNh6bKQO/G9NNiUozYysGwG1GvJQkFjwy/OTsL6WBfuI0Oye84lVBVrQVk2EY1ERFhgdMpuFSg4=",
-        "result_xdr": "AAAAAAAABEwAAAAAAAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        "result_meta_xdr": "AAAAAgAAAAIAAAADAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcN4Lazp2P7tAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcN4Lazp2P7tAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAALAAAAAwAAAAMAAACwAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/u0AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAACwAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx9cTtJ2fu0AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAsAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMfXE7Sdn7tAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMfXEkAWMTtAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAADAAAAAwAAALAAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DH1xJAFjE7QAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAALAAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DHuqZK7/07QAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAACwAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx7qmSu/9O0AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAACwAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wx7qk1miOu0AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAsAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMe6pNZojrtAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMe6o2HhIDtAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAADAAAAAwAAALAAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DHuqNh4SA7QAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAALAAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DHuqHtWbG7QAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAACwAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMAAACwAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAsAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAACwAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAsAAAAAAAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAsAAAAAEAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAABVEVTVAAAAADaWli6I7jrXwtHJjIfg70E3zw65H14W5UE3RV6xmHNGwAAAAAAAAAAf/////////8AAAABAAAAAAAAAAAAAAADAAAAsAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAsAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAALAAAAAAAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAACAAAAAwAAALAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAAAVRFU1QAAAAA2lpYuiO4618LRyYyH4O9BN88OuR9eFuVBN0VesZhzRsAAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAQAAALAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAAAVRFU1QAAAAA2lpYuiO4618LRyYyH4O9BN88OuR9eFuVBN0VesZhzRsAAAkYTnKgAH//////////AAAAAQAAAAAAAAAAAAAAAgAAAAMAAACwAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAEAAACwAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAB//////////wAAAAEAAAAAAAAAAAAAAAMAAAADAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcMe6oe1ZsbtAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAsAAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAAO5rFtAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAASgQftlATD/2m8HJvzNU1zvvyUFoT8JGpYKosypl8kSEMe6oemgBWAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA",
-        "fee_meta_xdr": "AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAACwAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/u0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
-        "memo_type": "none",
-        "signatures": [
-          "NUHx9PZlcXQ9mq1lf1usrSTP4/gbxUqzUOQOSU/pQuy9dF7FcUF0fjEbzFECxHUcl4QEfbvyGIE029TA3DrODA==",
-          "uBlRT+hgYvt+tYNCEkeEJC70mZ+o3Tc+smrj9wms3U5JRZeeYtz3iy/ybYv5zGXanSySvYnHL6+3UtzGS/vAAg==",
-          "e9kRWqXKAg+uh/eNVNmiENabZZQ2sUAVd/Uty1OoMJAEemHXgSj4A/CtNREsthMi82hd4bMEpsvTdKw4BFZxAg==",
-          "cC8q/b9Gjj5w2HpspA78b002JSjNjKwbAbUa8lCQWPDL85OwvpYF+4jQ7J7ziVUFWtBWTYRjUREWGB0ym4VKDg=="
-        ],
-        "valid_after": "1970-01-01T00:00:00Z"
-      }
-    ]
-  }
-}"#;
+async fn test_issue_overpayment_succeeds() {
+	test_with_vault(|client, vault_id, vault_provider| async move {
+		let relayer_provider = setup_provider(client.clone(), AccountKeyring::Bob).await;
+		let user_provider = setup_provider(client.clone(), AccountKeyring::Dave).await;
 
-	let transaction: vault::service::HorizonTransactionsResponse =
-		serde_json::from_str(tx_string).unwrap();
-	let tx_xdr = &transaction._embedded.records[0].envelope_xdr;
+		let secret = SecretKey::from_encoding(STELLAR_VAULT_SECRET_KEY).unwrap();
+		let public_key = secret.get_public().clone().into_binary();
 
-	test_with_vault(|client, vault_provider| async move {
-		let deposit_listener = vault::service::poll_horizon_for_new_transactions(
-			vault_provider.clone(),
-			STELLAR_VAULT_SECRET_KEY.to_string(),
-		);
-
-		assert_ok!(vault_provider.report_stellar_transaction(tx_xdr).await);
-
-		test_service(deposit_listener.map(Result::unwrap), async {}).await;
-	})
-	.await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_redeem() {
-	test_with_vault(|client, vault_provider| async move {
-		let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
-
-		// redeem handling
-		let redeem_listener = vault::service::listen_for_redeem_requests(
-			shutdown_tx,
-			vault_provider.clone(),
-			STELLAR_VAULT_SECRET_KEY.to_string(),
-		);
-
-		test_service(redeem_listener.map(Result::unwrap), async {
-			let asset_code = "USDC".as_bytes();
-			let asset_issuer =
-				"GAKNDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC".as_bytes();
-			let amount: u128 = 100000000;
-
-			let vault_keypair =
-				stellar_relay::sdk::SecretKey::from_encoding(STELLAR_VAULT_SECRET_KEY).unwrap();
-			let stellar_vault_pubkey = *vault_keypair.get_public().as_binary();
-
-			tracing::info!("hex key 0x{}", hex::encode(stellar_vault_pubkey));
-
-			// Execute a redeem
-			assert_ok!(
-				vault_provider
-					.redeem(
-						&asset_code.to_vec(),
-						&asset_issuer.to_vec(),
-						amount,
-						stellar_vault_pubkey.clone()
-					)
-					.await,
-			);
-
-			// Expect that a RedeemEvent is registered by the vault provider
-			let event = assert_event::<RedeemEvent, _>(TIMEOUT, vault_provider, |_| true).await;
-			assert_eq!(event.asset_code, asset_code);
-			assert_eq!(event.asset_issuer, asset_issuer);
-			assert_eq!(event.stellar_vault_id, stellar_vault_pubkey);
-			assert_eq!(event.amount, amount);
-		})
+		let issue_amount = 100000;
+		let over_payment_factor = 3;
+		let vault_collateral = get_required_vault_collateral_for_issue(
+			&vault_provider,
+			issue_amount * over_payment_factor,
+			vault_id.collateral_currency(),
+		)
 		.await;
+
+		assert_ok!(
+			vault_provider
+				.register_vault_with_public_key(&vault_id, vault_collateral, public_key)
+				.await
+		);
+
+		// TODO add the rest
 	})
 	.await;
+}
+
+type StellarPublicKey = [u8; 32];
+
+#[async_trait]
+trait SpacewalkParachainExt {
+	async fn register_vault_with_public_key(
+		&self,
+		vault_id: &VaultId,
+		collateral: u128,
+		public_key: StellarPublicKey,
+	) -> Result<(), runtime::Error>;
+}
+
+#[async_trait]
+impl SpacewalkParachainExt for SpacewalkParachain {
+	async fn register_vault_with_public_key(
+		&self,
+		vault_id: &VaultId,
+		collateral: u128,
+		public_key: StellarPublicKey,
+	) -> Result<(), runtime::Error> {
+		self.register_public_key(public_key).await.unwrap();
+		self.register_vault(vault_id, collateral).await.unwrap();
+		Ok(())
+	}
 }

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -2,17 +2,12 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use frame_support::assert_ok;
-use futures::{
-	channel::mpsc,
-	future::{join, join3, join5},
-	Future, FutureExt, SinkExt, TryStreamExt,
-};
-use sp_core::ByteArray;
+use futures::Future;
 use sp_keyring::AccountKeyring;
 
 use runtime::{
 	integration::*, types::*, CurrencyId::Token, FixedPointNumber, FixedU128, SpacewalkParachain,
-	UtilFuncs, VaultRegistryPallet,
+	VaultRegistryPallet,
 };
 use stellar_relay::sdk::SecretKey;
 
@@ -52,7 +47,7 @@ where
 		FixedU128::saturating_from_rational(1u128, 100u128),
 	)
 	.await;
-	set_bitcoin_fees(&parachain_rpc, FixedU128::from(1)).await;
+	set_stellar_fees(&parachain_rpc, FixedU128::from(1)).await;
 
 	execute(client).await
 }
@@ -79,7 +74,7 @@ where
 		FixedU128::saturating_from_rational(1u128, 100u128),
 	)
 	.await;
-	set_bitcoin_fees(&parachain_rpc, FixedU128::from(1)).await;
+	set_stellar_fees(&parachain_rpc, FixedU128::from(1)).await;
 
 	let vault_provider = setup_provider(client.clone(), AccountKeyring::Charlie).await;
 

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -16,7 +16,7 @@ pub struct StellarWallet {
 
 impl StellarWallet {
 	pub fn from_secret_encoded(x: &String) -> Result<Self, Error> {
-		let secret_key = SecretKey::from_encoding(x).map_err(|e| Error::InvalidSecretKey)?;
+		let secret_key = SecretKey::from_encoding(x).map_err(|_| Error::InvalidSecretKey)?;
 
 		let wallet = StellarWallet { secret_key };
 		Ok(wallet)

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -6,25 +6,26 @@ version = "1.2.0"
 
 [dependencies]
 jsonrpc-core = "18.0.0"
-jsonrpsee = {version = "0.16.0", features = ["server", "macros"]}
+jsonrpsee = { version = "0.16.0", features = ["server", "macros"] }
 
 # Parachain dependencies
-primitives = {package = "spacewalk-primitives", path = "../primitives"}
+primitives = { package = "spacewalk-primitives", path = "../primitives" }
 
-module-issue-rpc = {path = "../pallets/issue/rpc"}
-module-redeem-rpc = {path = "../pallets/redeem/rpc"}
-module-replace-rpc = {path = "../pallets/replace/rpc"}
-module-vault-registry-rpc = {path = "../pallets/vault-registry/rpc"}
+module-issue-rpc = { path = "../pallets/issue/rpc" }
+module-redeem-rpc = { path = "../pallets/redeem/rpc" }
+module-replace-rpc = { path = "../pallets/replace/rpc" }
+module-vault-registry-rpc = { path = "../pallets/vault-registry/rpc" }
 
 # Substrate dependencies
-sc-rpc = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sc-rpc-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sc-transaction-pool-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sp-arithmetic = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
-pallet-transaction-payment-rpc = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
-substrate-frame-rpc-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31"}
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }

--- a/testchain/node/Cargo.toml
+++ b/testchain/node/Cargo.toml
@@ -21,6 +21,7 @@ hex-literal = "0.2.1"
 log = "0.4.8"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.85"
+futures = "0.3.15"
 
 # Parachain dependencies
 primitives = { package = "spacewalk-primitives", path = "../../primitives" }
@@ -33,6 +34,7 @@ sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", features = ["wasmtime"] }
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }

--- a/testchain/node/src/chain_spec.rs
+++ b/testchain/node/src/chain_spec.rs
@@ -10,7 +10,7 @@ use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
-use primitives::{CurrencyId::Token, VaultCurrencyPair, AMPE, DOT, KSM};
+use primitives::{CurrencyId::Token, VaultCurrencyPair, AMPE, DOT, KSM, PEN};
 use spacewalk_runtime::{
 	AccountId, AuraConfig, BalancesConfig, CurrencyId, FeeConfig, FieldLength, GenesisConfig,
 	GetWrappedCurrencyId, GrandpaConfig, IssueConfig, NominationConfig, OracleConfig, Organization,
@@ -271,6 +271,7 @@ fn testnet_genesis(
 					vec![
 						(k.clone(), Token(DOT), 1 << 60),
 						(k.clone(), Token(KSM), 1 << 60),
+						(k.clone(), Token(PEN), 1 << 60),
 						(k.clone(), Token(AMPE), 1 << 60),
 					]
 				})
@@ -296,20 +297,20 @@ fn testnet_genesis(
 			minimum_collateral_vault: vec![(Token(DOT), 0), (Token(KSM), 0)],
 			punishment_delay: DAYS,
 			secure_collateral_threshold: vec![
-				(default_pair(Token(DOT)), FixedU128::checked_from_rational(150, 100).unwrap()),
-				(default_pair(Token(KSM)), FixedU128::checked_from_rational(150, 100).unwrap()),
+				(default_pair(Token(DOT)), FixedU128::checked_from_rational(260, 100).unwrap()),
+				(default_pair(Token(KSM)), FixedU128::checked_from_rational(260, 100).unwrap()),
 			], /* 150% */
 			premium_redeem_threshold: vec![
-				(default_pair(Token(DOT)), FixedU128::checked_from_rational(135, 100).unwrap()),
-				(default_pair(Token(KSM)), FixedU128::checked_from_rational(135, 100).unwrap()),
+				(default_pair(Token(DOT)), FixedU128::checked_from_rational(200, 100).unwrap()),
+				(default_pair(Token(KSM)), FixedU128::checked_from_rational(200, 100).unwrap()),
 			], /* 135% */
 			liquidation_collateral_threshold: vec![
-				(default_pair(Token(DOT)), FixedU128::checked_from_rational(110, 100).unwrap()),
-				(default_pair(Token(KSM)), FixedU128::checked_from_rational(110, 100).unwrap()),
+				(default_pair(Token(DOT)), FixedU128::checked_from_rational(150, 100).unwrap()),
+				(default_pair(Token(KSM)), FixedU128::checked_from_rational(150, 100).unwrap()),
 			], /* 110% */
 			system_collateral_ceiling: vec![
-				(default_pair(Token(DOT)), 1000 * DOT.one()),
-				(default_pair(Token(KSM)), 1000 * KSM.one()),
+				(default_pair(Token(DOT)), 60_000 * DOT.one()),
+				(default_pair(Token(KSM)), 60_000 * KSM.one()),
 			],
 		},
 		fee: FeeConfig {

--- a/testchain/node/src/command.rs
+++ b/testchain/node/src/command.rs
@@ -91,7 +91,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, .. } =
-					spacewalk_service::new_partial(&config)?;
+					spacewalk_service::new_partial(&config, false)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -99,7 +99,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, .. } =
-					spacewalk_service::new_partial(&config)?;
+					spacewalk_service::new_partial(&config, false)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
 		},
@@ -107,7 +107,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, .. } =
-					spacewalk_service::new_partial(&config)?;
+					spacewalk_service::new_partial(&config, false)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
 		},
@@ -115,7 +115,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, .. } =
-					spacewalk_service::new_partial(&config)?;
+					spacewalk_service::new_partial(&config, false)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -127,7 +127,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, .. } =
-					spacewalk_service::new_partial(&config)?;
+					spacewalk_service::new_partial(&config, false)?;
 				let aux_revert = Box::new(|client, _, blocks| {
 					sc_finality_grandpa::revert(client, blocks)?;
 					Ok(())
@@ -152,7 +152,7 @@ pub fn run() -> Result<()> {
 						},
 					BenchmarkCmd::Block(cmd) => {
 						let PartialComponents { client, .. } =
-							spacewalk_service::new_partial(&config)?;
+							spacewalk_service::new_partial(&config, false)?;
 						cmd.run(client)
 					},
 					#[cfg(not(feature = "runtime-benchmarks"))]
@@ -163,7 +163,7 @@ pub fn run() -> Result<()> {
 					#[cfg(feature = "runtime-benchmarks")]
 					BenchmarkCmd::Storage(cmd) => {
 						let PartialComponents { client, backend, .. } =
-							spacewalk_service::new_partial(&config)?;
+							spacewalk_service::new_partial(&config, false)?;
 						let db = backend.expose_db();
 						let storage = backend.expose_storage();
 
@@ -171,7 +171,7 @@ pub fn run() -> Result<()> {
 					},
 					BenchmarkCmd::Overhead(cmd) => {
 						let PartialComponents { client, .. } =
-							spacewalk_service::new_partial(&config)?;
+							spacewalk_service::new_partial(&config, false)?;
 						let ext_builder = RemarkBuilder::new(client.clone());
 
 						cmd.run(
@@ -184,7 +184,7 @@ pub fn run() -> Result<()> {
 					},
 					BenchmarkCmd::Extrinsic(cmd) => {
 						let PartialComponents { client, .. } =
-							spacewalk_service::new_partial(&config)?;
+							spacewalk_service::new_partial(&config, false)?;
 						// Register the *Remark* and *TKA* builders.
 						let ext_factory = ExtrinsicFactory(vec![
 							Box::new(RemarkBuilder::new(client.clone())),

--- a/testchain/node/src/service.rs
+++ b/testchain/node/src/service.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
-use sc_client_api::{BlockBackend, ExecutorProvider, HeaderBackend};
+use sc_client_api::BlockBackend;
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_executor::NativeElseWasmExecutor;
 use sc_finality_grandpa::SharedVoterState;
@@ -11,10 +11,9 @@ use sc_service::{
 	TaskManager,
 };
 use sc_telemetry::{Telemetry, TelemetryWorker};
-use sp_api::ConstructRuntimeApi;
-use sp_consensus_aura::sr25519::{AuthorityId as AuraId, AuthorityPair as AuraPair};
+use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 
-use primitives::{Block, Hash};
+use primitives::Block;
 use spacewalk_runtime::RuntimeApi;
 
 // Native executor instance.
@@ -418,8 +417,6 @@ pub async fn start_instant(
 				sender: None,
 			}
 		});
-
-		let client_for_cidp = client.clone();
 
 		let authorship_future =
 			sc_consensus_manual_seal::run_manual_seal(sc_consensus_manual_seal::ManualSealParams {

--- a/testchain/node/src/service.rs
+++ b/testchain/node/src/service.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use sc_client_api::{BlockBackend, ExecutorProvider};
+use futures::StreamExt;
+use sc_client_api::{BlockBackend, ExecutorProvider, HeaderBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_executor::NativeElseWasmExecutor;
 use sc_finality_grandpa::SharedVoterState;
@@ -10,9 +11,10 @@ use sc_service::{
 	TaskManager,
 };
 use sc_telemetry::{Telemetry, TelemetryWorker};
-use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
+use sp_api::ConstructRuntimeApi;
+use sp_consensus_aura::sr25519::{AuthorityId as AuraId, AuthorityPair as AuraPair};
 
-use primitives::Block;
+use primitives::{Block, Hash};
 use spacewalk_runtime::RuntimeApi;
 
 // Native executor instance.
@@ -42,6 +44,7 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
 pub fn new_partial(
 	config: &Configuration,
+	instant_seal: bool,
 ) -> Result<
 	sc_service::PartialComponents<
 		FullClient,
@@ -99,6 +102,13 @@ pub fn new_partial(
 
 	let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
+	// TODO check if this is needed
+	// let select_chain = if instant_seal {
+	// 	Some(LongestChain::new(backend.clone()))
+	// } else {
+	// 	None
+	// };
+
 	let transaction_pool = sc_transaction_pool::BasicPool::new_full(
 		config.transaction_pool.clone(),
 		config.role.is_authority().into(),
@@ -115,8 +125,16 @@ pub fn new_partial(
 	)?;
 
 	let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+	let registry = config.prometheus_registry();
 
-	let import_queue =
+	let import_queue = if instant_seal {
+		// instance sealing
+		sc_consensus_manual_seal::import_queue(
+			Box::new(client.clone()),
+			&task_manager.spawn_essential_handle(),
+			registry,
+		)
+	} else {
 		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
 			block_import: grandpa_block_import.clone(),
 			justification_import: Some(Box::new(grandpa_block_import.clone())),
@@ -133,10 +151,11 @@ pub fn new_partial(
 				Ok((slot, timestamp))
 			},
 			spawner: &task_manager.spawn_essential_handle(),
-			registry: config.prometheus_registry(),
+			registry,
 			check_for_equivocation: Default::default(),
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
-		})?;
+		})?
+	};
 
 	Ok(sc_service::PartialComponents {
 		client,
@@ -168,7 +187,7 @@ pub fn new_full(mut config: Configuration) -> Result<(TaskManager, RpcHandlers),
 		select_chain,
 		transaction_pool,
 		other: (block_import, grandpa_link, mut telemetry),
-	} = new_partial(&config)?;
+	} = new_partial(&config, false)?;
 
 	if let Some(url) = &config.keystore_remote {
 		match remote_keystore(url) {
@@ -223,8 +242,12 @@ pub fn new_full(mut config: Configuration) -> Result<(TaskManager, RpcHandlers),
 		let pool = transaction_pool.clone();
 
 		Box::new(move |deny_unsafe, _| {
-			let deps =
-				spacewalk_rpc::FullDeps { client: client.clone(), pool: pool.clone(), deny_unsafe };
+			let deps = spacewalk_rpc::FullDeps {
+				client: client.clone(),
+				pool: pool.clone(),
+				deny_unsafe,
+				command_sink: None,
+			};
 
 			spacewalk_rpc::create_full(deps).map_err(Into::into)
 		})
@@ -333,5 +356,127 @@ pub fn new_full(mut config: Configuration) -> Result<(TaskManager, RpcHandlers),
 	}
 
 	network_starter.start_network();
+	Ok((task_manager, rpc_handlers))
+}
+
+pub async fn start_instant(
+	config: Configuration,
+) -> sc_service::error::Result<(TaskManager, RpcHandlers)> {
+	let sc_service::PartialComponents {
+		client,
+		backend,
+		mut task_manager,
+		import_queue,
+		keystore_container,
+		select_chain,
+		transaction_pool,
+		other: (_, _, mut telemetry),
+	} = new_partial(&config, true)?;
+
+	let (network, system_rpc_tx, tx_handler_controller, network_starter) =
+		sc_service::build_network(sc_service::BuildNetworkParams {
+			config: &config,
+			client: client.clone(),
+			transaction_pool: transaction_pool.clone(),
+			spawn_handle: task_manager.spawn_handle(),
+			import_queue,
+			block_announce_validator_builder: None,
+			warp_sync: None,
+		})?;
+
+	if config.offchain_worker.enabled {
+		sc_service::build_offchain_workers(
+			&config,
+			task_manager.spawn_handle(),
+			client.clone(),
+			network.clone(),
+		);
+	};
+
+	let prometheus_registry = config.prometheus_registry().cloned();
+
+	let role = config.role.clone();
+
+	let command_sink = if role.is_authority() {
+		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+			task_manager.spawn_handle(),
+			client.clone(),
+			transaction_pool.clone(),
+			prometheus_registry.as_ref(),
+			telemetry.as_ref().map(|x| x.handle()),
+		);
+
+		// Channel for the rpc handler to communicate with the authorship task.
+		let (command_sink, commands_stream) = futures::channel::mpsc::channel(1024);
+
+		let pool = transaction_pool.pool().clone();
+		let import_stream = pool.validated_pool().import_notification_stream().map(|_| {
+			sc_consensus_manual_seal::rpc::EngineCommand::SealNewBlock {
+				create_empty: true,
+				finalize: true,
+				parent_hash: None,
+				sender: None,
+			}
+		});
+
+		let client_for_cidp = client.clone();
+
+		let authorship_future =
+			sc_consensus_manual_seal::run_manual_seal(sc_consensus_manual_seal::ManualSealParams {
+				block_import: client.clone(),
+				env: proposer_factory,
+				client: client.clone(),
+				pool: transaction_pool.clone(),
+				commands_stream: futures::stream_select!(commands_stream, import_stream),
+				select_chain,
+				consensus_data_provider: None,
+				create_inherent_data_providers: move |_, ()| async move {
+					Ok(sp_timestamp::InherentDataProvider::from_system_time())
+				},
+			});
+
+		// we spawn the future on a background thread managed by service.
+		task_manager.spawn_essential_handle().spawn_blocking(
+			"instant-seal",
+			Some("block-authoring"),
+			authorship_future,
+		);
+		Some(command_sink)
+	} else {
+		None
+	};
+
+	let rpc_builder = {
+		let client = client.clone();
+		let transaction_pool = transaction_pool.clone();
+
+		move |deny_unsafe, _| {
+			let deps = spacewalk_rpc::FullDeps {
+				client: client.clone(),
+				pool: transaction_pool.clone(),
+				deny_unsafe,
+				command_sink: command_sink.clone(),
+			};
+
+			spacewalk_rpc::create_full(deps).map_err(Into::into)
+		}
+	};
+
+	let rpc_handlers = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+		rpc_builder: Box::new(rpc_builder),
+		client: client.clone(),
+		transaction_pool,
+		task_manager: &mut task_manager,
+		config,
+		keystore: keystore_container.sync_keystore(),
+		backend,
+		network,
+		system_rpc_tx,
+		tx_handler_controller,
+		telemetry: telemetry.as_mut(),
+	})?;
+
+	network_starter.start_network();
+
 	Ok((task_manager, rpc_handlers))
 }


### PR DESCRIPTION
This PR adds and fixes the previously removed integration tests for the vault client. For this, the subxt-client package, whose purpose is to be able to run a standalone chain for testing purposes, was re-added. Also, other tests for the runtime were added (two of which fail unfortunately, but I don't know how to emulate the error properly).

This also adds the RPC APIs for the oracle and security pallets because they were used in the tests. 

PS: The testchain node was changed so that it can be run with manual-seal consensus, meaning that you can call a function that will force the runtime to author a new block immediately. It will not produce blocks automatically. This is convenient because now the tests can manually author blocks with a simple function call instead of waiting 6 seconds.