### PR TITLE
Add handling for redeem/replace events to vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10264,6 +10264,7 @@ dependencies = [
  "jsonrpc-core-client",
  "lazy_static",
  "mockall 0.8.3",
+ "nonzero_ext",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -11124,6 +11125,126 @@ dependencies = [
 ]
 
 [[patch.unused]]
+name = "kusama-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "pallet-xcm"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-cli"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-client"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-core-primitives"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-node-core-av-store"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-node-core-pvf"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-node-network-protocol"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-node-primitives"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-node-subsystem"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-node-subsystem-util"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-overseer"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-parachain"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-primitives"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-runtime-common"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-runtime-parachains"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-service"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "polkadot-statement-table"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "rococo-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "westend-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "xcm-builder"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "xcm-executor"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "xcm-simulator"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
@@ -11392,126 +11513,6 @@ source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee
 name = "try-runtime-cli"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
-
-[[patch.unused]]
-name = "kusama-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "pallet-xcm"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-cli"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-client"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-core-primitives"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-node-core-av-store"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-node-core-pvf"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-node-network-protocol"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-node-primitives"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-node-subsystem"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-node-subsystem-util"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-overseer"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-parachain"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-primitives"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-runtime-common"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-runtime-parachains"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-service"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "polkadot-statement-table"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "rococo-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "westend-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "xcm-builder"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "xcm-executor"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "xcm-simulator"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
 name = "cumulus-client-cli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10382,6 +10382,7 @@ name = "wallet"
 version = "1.0.0"
 dependencies = [
  "async-trait",
+ "base64",
  "mockall 0.8.3",
  "parity-scale-codec",
  "reqwest",
@@ -11125,124 +11126,109 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "kusama-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-cli"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "pallet-xcm"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-collator"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-cli"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-consensus-aura"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-client"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-consensus-common"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-core-primitives"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-consensus-relay-chain"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-node-core-av-store"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-network"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-node-core-pvf"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-client-service"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-node-network-protocol"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-pallet-aura-ext"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-node-primitives"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-pallet-dmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-node-subsystem"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-pallet-parachain-system"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-node-subsystem-util"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-pallet-xcm"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-overseer"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-pallet-xcmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-parachain"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-primitives"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-primitives-timestamp"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-runtime-common"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-primitives-utility"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-runtime-parachains"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-relay-chain-inprocess-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-service"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-relay-chain-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "polkadot-statement-table"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-relay-chain-rpc-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "rococo-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
-name = "westend-runtime"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "xcm-builder"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "xcm-executor"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
-
-[[patch.unused]]
-name = "xcm-simulator"
-version = "0.9.31"
-source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+name = "parachain-info"
+version = "0.1.0"
+source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
 
 [[patch.unused]]
 name = "beefy-gadget"
@@ -11515,106 +11501,121 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-jsonrpsee-v0.9.31#2af8d593224fecd988589b5126dcd158e6d0d2da"
 
 [[patch.unused]]
-name = "cumulus-client-cli"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "kusama-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-client-collator"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "pallet-xcm"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-client-consensus-aura"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-cli"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-client-consensus-common"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-client"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-client-consensus-relay-chain"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-core-primitives"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-client-network"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-node-core-av-store"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-client-service"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-node-core-pvf"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-pallet-aura-ext"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-node-network-protocol"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-pallet-dmp-queue"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-node-primitives"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-pallet-parachain-system"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-node-subsystem"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-pallet-xcm"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-node-subsystem-util"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-pallet-xcmp-queue"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-overseer"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-primitives-core"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-parachain"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-primitives-parachain-inherent"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-primitives"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-primitives-timestamp"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-primitives-utility"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-runtime-common"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-relay-chain-inprocess-interface"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-runtime-parachains"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-relay-chain-interface"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-service"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-relay-chain-rpc-interface"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "polkadot-statement-table"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "cumulus-test-relay-sproof-builder"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "rococo-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
 
 [[patch.unused]]
-name = "parachain-info"
-version = "0.1.0"
-source = "git+https://github.com/paritytech//cumulus?branch=polkadot-v0.9.31#fb8c5a3d0800ebdebe14bd0e708d2a348f976d9e"
+name = "westend-runtime"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "xcm-builder"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "xcm-executor"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"
+
+[[patch.unused]]
+name = "xcm-simulator"
+version = "0.9.31"
+source = "git+https://github.com/paritytech//polkadot?branch=release-v0.9.31#32dd0c9cfcd1a1bda821747f6ab334f0e3577558"

--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -4,6 +4,8 @@ use std::{sync::Arc, time::Duration};
 
 use frame_support::assert_ok;
 use futures::{future::Either, pin_mut, Future, FutureExt, SinkExt, StreamExt};
+use sp_runtime::traits::StaticLookup;
+use substrate_stellar_sdk::{Asset, XdrCodec};
 use subxt::{
 	events::StaticEvent as Event,
 	ext::sp_core::{sr25519::Pair, Pair as _},
@@ -76,33 +78,6 @@ pub async fn setup_provider(client: SubxtClient, key: AccountKeyring) -> Spacewa
 	SpacewalkParachain::new(client.into(), signer, shutdown_tx)
 		.await
 		.expect("Error creating parachain_rpc")
-}
-
-/// request, pay and execute an issue
-pub async fn assert_issue(
-	parachain_rpc: &SpacewalkParachain,
-	wallet: StellarWallet,
-	vault_id: &VaultId,
-	amount: u128,
-) {
-	let issue = parachain_rpc.request_issue(amount, vault_id).await.unwrap();
-
-	// TODO change this to set up the relay helper and then send the transaction
-	// let metadata = btc_rpc
-	// 	.send_to_address(
-	// 		issue.vault_address.to_address(btc_rpc.network()).unwrap(),
-	// 		(issue.amount + issue.fee) as u64,
-	// 		None,
-	// 		fee_rate,
-	// 		0,
-	// 	)
-	// 	.await
-	// 	.unwrap();
-	//
-	// parachain_rpc
-	// 	.execute_issue(issue.issue_id, &metadata.proof, &metadata.raw_tx)
-	// 	.await
-	// 	.unwrap();
 }
 
 const SLEEP_DURATION: Duration = Duration::from_millis(1000);

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -15,9 +15,9 @@ pub use assets::TryFromSymbol;
 pub use error::{Error, SubxtError};
 pub use retry::{notify_retry, RetryPolicy};
 pub use rpc::{
-	CollateralBalancesPallet, IssuePallet, OraclePallet, ReplacePallet, SecurityPallet,
-	SpacewalkParachain, StellarRelayPallet, SudoPallet, UtilFuncs, VaultRegistryPallet,
-	DEFAULT_SPEC_NAME, SS58_PREFIX,
+	CollateralBalancesPallet, IssuePallet, OraclePallet, RedeemPallet, ReplacePallet,
+	SecurityPallet, SpacewalkParachain, StellarRelayPallet, SudoPallet, UtilFuncs,
+	VaultRegistryPallet, DEFAULT_SPEC_NAME, SS58_PREFIX,
 };
 pub use shutdown::{ShutdownReceiver, ShutdownSender};
 pub use types::*;

--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -16,7 +16,7 @@ pub type FixedU128 = sp_arithmetic::FixedU128;
 
 pub type IssueId = H256;
 
-pub type StellarPublicKey = [u8; 32];
+pub type StellarPublicKeyRaw = [u8; 32];
 
 mod metadata_aliases {
 	use std::collections::HashMap;

--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -27,6 +27,9 @@ mod metadata_aliases {
 			RequestIssue as RequestIssueEvent,
 		},
 		oracle::events::FeedValues as FeedValuesEvent,
+		redeem::events::{
+			ExecuteRedeem as ExecuteRedeemEvent, RequestRedeem as RequestRedeemEvent,
+		},
 		replace::events::{
 			AcceptReplace as AcceptReplaceEvent, CancelReplace as CancelReplaceEvent,
 			ExecuteReplace as ExecuteReplaceEvent, RequestReplace as RequestReplaceEvent,
@@ -64,6 +67,13 @@ mod metadata_aliases {
 			CurrencyId,
 		>;
 
+	pub type SpacewalkRedeemRequest =
+		metadata::runtime_types::spacewalk_primitives::redeem::RedeemRequest<
+			AccountId,
+			BlockNumber,
+			Balance,
+			CurrencyId,
+		>;
 	// pub use crate::metadata::runtime_types::spacewalk_primitives::CurrencyId;
 
 	pub type SpacewalkIssueRequest =

--- a/clients/service/src/lib.rs
+++ b/clients/service/src/lib.rs
@@ -96,7 +96,7 @@ impl<Config: Clone + Send + 'static, F: Fn()> ConnectionManager<Config, F> {
 				Err(err) => {
 					tracing::warn!("Disconnected: {}", err);
 				},
-				_ => {
+				Ok(_) => {
 					tracing::warn!("Disconnected");
 				},
 			}

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -14,27 +14,28 @@ multi-address = ["runtime/multi-address"]
 [dependencies]
 async-trait = "0.1.40"
 base64 = { version = '0.13.0', default-features = false, features = ['alloc'] }
+bincode = "1.3.3"
 clap = "3.1"
 futures = "0.3.5"
 git-version = "0.3.4"
+governor = "0.5.0"
 hex = "0.4.2"
+itertools = "0.10.5"
+lazy_static = "1.4"
+nonzero_ext = "0.3.0"
 parity-scale-codec = "3.0.0"
 reqwest = { version = "0.11", features = ["json"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = "1.0.136"
 serde_json = { version = '1.0.45', default-features = false, features = ['alloc'] }
-bincode = "1.3.3"
-lazy_static = "1.4"
 sha2 = "0.8.2"
-itertools = "0.10.5"
-governor = "0.5.0"
-sysinfo = "0.26.1"
 signal-hook = "0.3.14"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+sysinfo = "0.26.1"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tokio-stream = { version = "0.1.9", features = ["sync"] }
 tokio-metrics = { version = "0.1.0", default-features = false }
+tokio-stream = { version = "0.1.9", features = ["sync"] }
 
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = { version = "0.2.5" }

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -182,7 +182,7 @@ impl Request {
 	/// Make a stellar transfer to fulfil the request
 	#[tracing::instrument(
 	name = "transfer_stellar_asset",
-	skip(self),
+	skip(self, wallet),
 	fields(
 	request_type = ?self.request_type,
 	request_id = ?self.hash,
@@ -197,6 +197,13 @@ impl Request {
 		let memo_hash = self.hash.0;
 
 		let mut wallet = wallet.write().await;
+		tracing::info!(
+			"Sending {:?} stroops of {:?} to {:?} from {:?}",
+			stroop_amount,
+			self.asset.clone(),
+			destination_public_key,
+			wallet,
+		);
 		let result = wallet
 			.send_payment_to_address(
 				destination_public_key.clone(),

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -338,8 +338,7 @@ pub async fn execute_open_requests(
 					let vault_id_manager = vault_id_manager.clone();
 					let proof_ops = proof_ops.clone();
 					spawn_cancelable(shutdown_tx.subscribe(), async move {
-						let tx_env = TransactionEnvelope::from_xdr(&transaction.envelope_xdr);
-						match tx_env {
+						match transaction.to_envelope() {
 							Ok(tx_env) => {
 								let slot = transaction.ledger as Slot;
 
@@ -452,7 +451,7 @@ fn get_request_for_stellar_tx(
 	let h256 = H256::from_slice(&hash);
 	let request = hash_map.get(&h256)?;
 
-	let envelope = tx.envelope().ok()?;
+	let envelope = tx.to_envelope().ok()?;
 	let paid_amount = envelope
 		.get_payment_amount_for_asset_to(request.stellar_address.clone(), request.asset.clone());
 

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -1,15 +1,30 @@
-use std::{sync::Arc, time::Duration};
+use std::{convert::TryInto, sync::Arc, time::Duration};
 
-use runtime::{CurrencyId, ShutdownSender, SpacewalkParachain, StellarPublicKey, VaultId, H256};
+use futures::{future::Either, StreamExt};
+use sp_arithmetic::FixedPointNumber;
+use sp_runtime::traits::StaticLookup;
+use tokio::sync::RwLock;
+
+use primitives::stellar::PublicKey;
+use runtime::{
+	types::FixedU128, CurrencyId, OraclePallet, RedeemPallet, ReplacePallet, SecurityPallet,
+	ShutdownSender, SpacewalkParachain, SpacewalkRedeemRequest, SpacewalkReplaceRequest,
+	StellarPublicKeyRaw, StellarRelayPallet, UtilFuncs, VaultId, VaultRegistryPallet, H256,
+};
 use service::{spawn_cancelable, Error as ServiceError};
+use stellar_relay_lib::sdk::{TransactionEnvelope, XdrCodec};
 use wallet::StellarWallet;
 
-use crate::{error::Error, VaultIdManager};
+use crate::{
+	error::Error,
+	oracle::{types::Slot, Proof, ProofExt, ProofStatus},
+	system::VaultData,
+	VaultIdManager,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 struct Deadline {
 	parachain: u32,
-	bitcoin: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -19,7 +34,7 @@ pub struct Request {
 	deadline: Option<Deadline>,
 	amount: u128,
 	asset: CurrencyId,
-	stellar_address: StellarPublicKey,
+	stellar_address: StellarPublicKeyRaw,
 	request_type: RequestType,
 	vault_id: VaultId,
 	fee_budget: Option<u128>,
@@ -32,7 +47,206 @@ pub enum RequestType {
 }
 
 impl Request {
-	// TODO
+	fn duration_to_parachain_blocks(duration: Duration) -> Result<u32, Error> {
+		let num_blocks = duration.as_millis() / (runtime::MILLISECS_PER_BLOCK as u128);
+		Ok(num_blocks.try_into()?)
+	}
+
+	fn calculate_deadline(
+		opentime: u32,
+		period: u32,
+		payment_margin: Duration,
+	) -> Result<Deadline, Error> {
+		let margin_parachain_blocks = Self::duration_to_parachain_blocks(payment_margin)?;
+		// if margin > period, we allow deadline to be before opentime. The rest of the code
+		// can deal with the expired deadline as normal.
+		let parachain_deadline = opentime
+			.checked_add(period)
+			.ok_or(Error::ArithmeticOverflow)?
+			.checked_sub(margin_parachain_blocks)
+			.ok_or(Error::ArithmeticUnderflow)?;
+
+		Ok(Deadline { parachain: parachain_deadline })
+	}
+
+	/// Constructs a Request for the given InterBtcRedeemRequest
+	pub fn from_redeem_request(
+		hash: H256,
+		request: SpacewalkRedeemRequest,
+		payment_margin: Duration,
+	) -> Result<Request, Error> {
+		Ok(Request {
+			hash,
+			deadline: Some(Self::calculate_deadline(
+				request.opentime,
+				request.period,
+				payment_margin,
+			)?),
+			amount: request.amount,
+			asset: request.asset,
+			stellar_address: request.stellar_address,
+			request_type: RequestType::Redeem,
+			vault_id: request.vault,
+			fee_budget: Some(request.transfer_fee),
+		})
+	}
+
+	/// Constructs a Request for the given SpacewalkReplaceRequest
+	pub fn from_replace_request(
+		hash: H256,
+		request: SpacewalkReplaceRequest,
+		payment_margin: Duration,
+	) -> Result<Request, Error> {
+		Ok(Request {
+			hash,
+			deadline: Some(Self::calculate_deadline(
+				request.accept_time,
+				request.period,
+				payment_margin,
+			)?),
+			amount: request.amount,
+			asset: request.asset,
+			stellar_address: request.stellar_address,
+			request_type: RequestType::Replace,
+			vault_id: request.old_vault,
+			fee_budget: None,
+		})
+	}
+
+	/// Makes the stellar transfer and executes the request
+	pub async fn pay_and_execute<
+		P: ReplacePallet
+			+ StellarRelayPallet
+			+ RedeemPallet
+			+ SecurityPallet
+			+ VaultRegistryPallet
+			+ OraclePallet
+			+ UtilFuncs
+			+ Clone
+			+ Send
+			+ Sync,
+	>(
+		&self,
+		parachain_rpc: P,
+		vault: VaultData,
+		proof_ops: Arc<RwLock<dyn ProofExt>>,
+	) -> Result<(), Error> {
+		// ensure the deadline has not expired yet
+		if let Some(ref deadline) = self.deadline {
+			if parachain_rpc.get_current_active_block_number().await? >= deadline.parachain {
+				return Err(Error::DeadlineExpired)
+			}
+		}
+
+		let (tx_env, slot) = self.transfer_stellar_asset(vault.stellar_wallet).await?;
+
+		let ops_read = proof_ops.read().await;
+		// TODO refactor this once the improved 'OracleAgent' is implemented
+		let proof: Proof = loop {
+			let proof_status_result = ops_read.get_proof(slot as Slot).await;
+			match proof_status_result {
+				Ok(proof_status) => match proof_status {
+					ProofStatus::Proof(p) => break p,
+					ProofStatus::LackingEnvelopes => {},
+					ProofStatus::NoEnvelopesFound => {},
+					ProofStatus::NoTxSetFound => {},
+					ProofStatus::WaitForTxSet => {},
+				},
+				Err(e) => {
+					tracing::error!("Error while fetching proof: {:?}", e);
+				},
+			}
+		};
+
+		self.execute(parachain_rpc, tx_env, proof).await
+	}
+
+	/// Make a stellar transfer to fulfil the request
+	#[tracing::instrument(
+	name = "transfer_stellar_asset",
+	skip(self),
+	fields(
+	request_type = ?self.request_type,
+	request_id = ?self.hash,
+	)
+	)]
+	async fn transfer_stellar_asset(
+		&self,
+		wallet: Arc<StellarWallet>,
+	) -> Result<(TransactionEnvelope, u32), Error> {
+		let destination_public_key = PublicKey::from_binary(self.stellar_address);
+		let stellar_asset =
+			primitives::AssetConversion::lookup(self.asset).map_err(|_| Error::LookupError)?;
+		let stroop_amount = self.amount as i64;
+		let memo_hash = self.hash.0;
+
+		let result = wallet
+			.send_payment_to_address(
+				destination_public_key.clone(),
+				stellar_asset,
+				stroop_amount,
+				memo_hash,
+			)
+			.await;
+
+		match result {
+			Ok((response, tx_env)) => {
+				let slot = response.ledger;
+				tracing::info!(
+					"Successfully sent stellar payment to {:?} for {}",
+					destination_public_key,
+					self.amount
+				);
+				Ok((tx_env, slot))
+			},
+			Err(e) => Err(Error::StellarWalletError(e)),
+		}
+	}
+
+	/// Executes the request. Upon failure it will retry
+	async fn execute<P: ReplacePallet + RedeemPallet>(
+		&self,
+		parachain_rpc: P,
+		tx_env: TransactionEnvelope,
+		proof: Proof,
+	) -> Result<(), Error> {
+		// select the execute function based on request_type
+		let execute = match self.request_type {
+			RequestType::Redeem => RedeemPallet::execute_redeem,
+			RequestType::Replace => ReplacePallet::execute_replace,
+		};
+
+		// Encode the proof components
+		let tx_env_encoded = tx_env.to_base64_xdr();
+		let (scp_envelopes_encoded, tx_set_encoded) = proof.encode();
+
+		// Retry until success or timeout, explicitly handle the cases
+		// where the redeem has expired or the rpc has disconnected
+		runtime::notify_retry(
+			|| {
+				(execute)(
+					&parachain_rpc,
+					self.hash,
+					tx_env_encoded.as_slice(),
+					scp_envelopes_encoded.as_bytes(),
+					tx_set_encoded.as_bytes(),
+				)
+			},
+			|result| async {
+				match result {
+					Ok(ok) => Ok(ok),
+					Err(err) if err.is_rpc_disconnect_error() =>
+						Err(runtime::RetryPolicy::Throw(err)),
+					Err(err) => Err(runtime::RetryPolicy::Skip(err)),
+				}
+			},
+		)
+		.await?;
+
+		tracing::info!("Executed request #{:?}", self.hash);
+
+		Ok(())
+	}
 }
 
 /// Queries the parachain for open requests and executes them. It checks the

--- a/clients/vault/src/lib.rs
+++ b/clients/vault/src/lib.rs
@@ -13,20 +13,23 @@ mod error;
 mod execution;
 pub mod metrics;
 pub mod process;
+mod redeem;
 mod system;
 
 mod issue;
 pub mod oracle;
 
 pub mod service {
+	pub use wallet::listen_for_new_transactions;
+
 	pub use crate::{
 		cancellation::{CancellationScheduler, IssueCanceller, ReplaceCanceller},
 		issue::{
 			listen_for_executed_issues, listen_for_issue_cancels, listen_for_issue_requests,
 			process_issues_with_proofs, IssueFilter,
 		},
+		redeem::listen_for_redeem_requests,
 	};
-	pub use wallet::listen_for_new_transactions;
 }
 
 /// At startup we wait until a new block has arrived before we start event listeners.

--- a/clients/vault/src/lib.rs
+++ b/clients/vault/src/lib.rs
@@ -27,6 +27,7 @@ pub mod service {
 
 	pub use crate::{
 		cancellation::{CancellationScheduler, IssueCanceller, ReplaceCanceller},
+		execution::execute_open_requests,
 		issue::{
 			listen_for_executed_issues, listen_for_issue_cancels, listen_for_issue_requests,
 			process_issues_with_proofs, IssueFilter,

--- a/clients/vault/src/lib.rs
+++ b/clients/vault/src/lib.rs
@@ -2,6 +2,9 @@
 
 use std::time::Duration;
 
+use governor::Quota;
+use nonzero_ext::*;
+
 pub use system::{VaultIdManager, VaultService, VaultServiceConfig, ABOUT, AUTHORS, NAME, VERSION};
 // Used for integration test
 pub use system::inner_create_handler;
@@ -35,3 +38,6 @@ pub mod service {
 /// At startup we wait until a new block has arrived before we start event listeners.
 /// This constant defines the rate at which we check whether the chain height has increased.
 pub const CHAIN_HEIGHT_POLLING_INTERVAL: Duration = Duration::from_millis(500);
+
+/// explicitly yield at most once per second
+pub const YIELD_RATE: Quota = Quota::per_second(nonzero!(1u32));

--- a/clients/vault/src/lib.rs
+++ b/clients/vault/src/lib.rs
@@ -17,6 +17,7 @@ mod execution;
 pub mod metrics;
 pub mod process;
 mod redeem;
+mod replace;
 mod system;
 
 mod issue;
@@ -33,6 +34,9 @@ pub mod service {
 			process_issues_with_proofs, IssueFilter,
 		},
 		redeem::listen_for_redeem_requests,
+		replace::{
+			listen_for_accept_replace, listen_for_execute_replace, listen_for_replace_requests,
+		},
 	};
 }
 

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -21,6 +21,7 @@ pub fn increment_restart_counter() {
 pub async fn publish_tokio_metrics(
 	mut metrics_iterators: HashMap<String, impl Iterator<Item = TaskMetrics>>,
 ) -> Result<(), ServiceError<Error>> {
-	// TODO
+	// TODO: publish metrics to prometheus
+	// We don't need this for now
 	Ok(())
 }

--- a/clients/vault/src/oracle/handler.rs
+++ b/clients/vault/src/oracle/handler.rs
@@ -1,5 +1,6 @@
-use async_trait::async_trait;
 use std::convert::TryFrom;
+
+use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
 
 use stellar_relay_lib::{
@@ -130,6 +131,7 @@ impl ScpMessageActor {
 				Some(msg) = self.action_receiver.recv() => {
 						self.handle_message(msg, &overlay_conn).await;
 				}
+				else => continue,
 			}
 		}
 	}

--- a/clients/vault/src/oracle/mod.rs
+++ b/clients/vault/src/oracle/mod.rs
@@ -12,4 +12,4 @@ mod constants;
 mod errors;
 mod handler;
 pub mod storage;
-mod types;
+pub mod types;

--- a/clients/vault/src/redeem.rs
+++ b/clients/vault/src/redeem.rs
@@ -1,0 +1,75 @@
+use std::time::Duration;
+
+use runtime::{InterBtcParachain, RedeemPallet, RequestRedeemEvent, SpacewalkParachain};
+use service::{spawn_cancelable, Error as ServiceError, ShutdownSender};
+use stellar_relay_lib::sdk::PublicKey;
+
+use crate::{
+	execution::*,
+	metrics::publish_expected_bitcoin_balance,
+	system::{VaultData, VaultIdManager},
+	Error,
+};
+
+/// Listen for RequestRedeemEvent directed at this vault; upon reception, transfer
+/// bitcoin and call execute_redeem
+///
+/// # Arguments
+///
+/// * `parachain_rpc` - the parachain RPC handle
+/// * `payment_margin` - the duration after which a redeem request is considered expired
+pub async fn listen_for_redeem_requests(
+	shutdown_tx: ShutdownSender,
+	parachain_rpc: SpacewalkParachain,
+	vault_id_manager: VaultIdManager,
+	payment_margin: Duration,
+) -> Result<(), ServiceError<Error>> {
+	parachain_rpc
+		.on_event::<RequestRedeemEvent, _, _, _>(
+			|event| async {
+				tracing::info!("Received redeem request: {:?}", event);
+
+				let vault = match vault_id_manager.get_vault(&event.vault_id).await {
+					Some(x) => x,
+					None => return, // event not directed at this vault
+				};
+
+				// let _ = publish_expected_bitcoin_balance(&vault, parachain_rpc.clone()).await;
+
+				// within this event callback, we captured the arguments of
+				// listen_for_redeem_requests by reference. Since spawn requires static lifetimes,
+				// we will need to capture the arguments by value rather than by reference, so clone
+				// these:
+				let parachain_rpc = parachain_rpc.clone();
+				// Spawn a new task so that we handle these events concurrently
+				spawn_cancelable(shutdown_tx.subscribe(), async move {
+					tracing::info!("Executing redeem #{:?}", event.redeem_id);
+					let result = async {
+						let request = Request::from_redeem_request(
+							event.redeem_id,
+							parachain_rpc.get_redeem_request(event.redeem_id).await?,
+							payment_margin,
+						)?;
+						request.pay_and_execute(parachain_rpc, vault).await
+					}
+					.await;
+
+					match result {
+						Ok(_) => tracing::info!(
+							"Completed redeem request #{} with amount {}",
+							event.redeem_id,
+							event.amount
+						),
+						Err(e) => tracing::error!(
+							"Failed to process redeem request #{}: {}",
+							event.redeem_id,
+							e.to_string()
+						),
+					}
+				});
+			},
+			|error| tracing::error!("Error reading redeem event: {}", error.to_string()),
+		)
+		.await?;
+	Ok(())
+}

--- a/clients/vault/src/redeem.rs
+++ b/clients/vault/src/redeem.rs
@@ -19,7 +19,8 @@ use crate::{
 /// # Arguments
 ///
 /// * `parachain_rpc` - the parachain RPC handle
-/// * `payment_margin` - the duration after which a redeem request is considered expired
+/// * `payment_margin` - minimum time to the the redeem execution deadline to make the stellar
+///   payment.
 pub async fn listen_for_redeem_requests(
 	shutdown_tx: ShutdownSender,
 	parachain_rpc: SpacewalkParachain,

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -216,3 +216,143 @@ pub async fn listen_for_execute_replace(
 		.await?;
 	Ok(())
 }
+
+#[cfg(all(test, feature = "standalone-metadata"))]
+mod tests {
+	use std::{str::FromStr, sync::Arc};
+
+	use async_trait::async_trait;
+
+	use primitives::{TokenSymbol::AMPE, DOT};
+	use runtime::{
+		AccountId, Balance, CurrencyId, Error as RuntimeError, SpacewalkReplaceRequest,
+		SpacewalkVault, StellarPublicKeyRaw, Token, VaultId, H256,
+	};
+
+	use super::*;
+
+	macro_rules! assert_err {
+		($result:expr, $err:pat) => {{
+			match $result {
+				Err($err) => (),
+				Ok(v) => panic!("assertion failed: Ok({:?})", v),
+				_ => panic!("expected: Err($err)"),
+			}
+		}};
+	}
+
+	mockall::mock! {
+	Provider {}
+
+	#[async_trait]
+	pub trait VaultRegistryPallet {
+		async fn get_vault(&self, vault_id: &VaultId) -> Result<SpacewalkVault, RuntimeError>;
+		async fn get_vaults_by_account_id(&self, account_id: &AccountId) -> Result<Vec<VaultId>, RuntimeError>;
+		async fn get_all_vaults(&self) -> Result<Vec<SpacewalkVault>, RuntimeError>;
+		async fn register_vault(&self, vault_id: &VaultId, collateral: u128) -> Result<(), RuntimeError>;
+		async fn deposit_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+		async fn withdraw_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+		async fn get_public_key(&self) -> Result<Option<StellarPublicKeyRaw>, RuntimeError>;
+		async fn register_public_key(&self, public_key: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
+		async fn get_required_collateral_for_wrapped(&self, amount: u128, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
+		async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
+		async fn get_vault_total_collateral(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
+		async fn get_collateralization_from_vault(&self, vault_id: VaultId, only_issued: bool) -> Result<u128, RuntimeError>;
+	}
+
+	#[async_trait]
+	pub trait ReplacePallet {
+		async fn request_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+		async fn withdraw_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+		async fn accept_replace(&self, new_vault: &VaultId, old_vault: &VaultId, amount: u128, collateral: u128, stellar_address: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
+		async fn execute_replace(&self, replace_id: H256, tx_env: &[u8], scp_envs: &[u8], tx_set: &[u8]) -> Result<(), RuntimeError>;
+		async fn cancel_replace(&self, replace_id: H256) -> Result<(), RuntimeError>;
+		async fn get_new_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+		async fn get_old_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+		async fn get_replace_period(&self) -> Result<u32, RuntimeError>;
+		async fn get_replace_request(&self, replace_id: H256) -> Result<SpacewalkReplaceRequest, RuntimeError>;
+		async fn get_replace_dust_amount(&self) -> Result<u128, RuntimeError>;
+	}
+
+
+	#[async_trait]
+	pub trait CollateralBalancesPallet {
+		async fn get_free_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+		async fn get_free_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+		async fn get_reserved_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+		async fn get_reserved_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+		async fn transfer_to(&self, recipient: &AccountId, amount: u128, currency_id: CurrencyId) -> Result<(), RuntimeError>;         }
+	}
+
+	impl Clone for MockProvider {
+		fn clone(&self) -> Self {
+			// NOTE: expectations dropped
+			Self::default()
+		}
+	}
+
+	fn dummy_vault_id() -> VaultId {
+		VaultId::new(AccountId::new([1u8; 32]), Token(DOT), Token(AMPE))
+	}
+
+	const STELLAR_VAULT_SECRET_KEY: &str =
+		"SB6WHKIU2HGVBRNKNOEOQUY4GFC4ZLG5XPGWLEAHTIZXBXXYACC76VSQ";
+
+	#[tokio::test]
+	async fn test_handle_replace_request_with_insufficient_balance() {
+		let is_public_network = false;
+		let wallet = StellarWallet::from_secret_encoded(
+			&STELLAR_VAULT_SECRET_KEY.to_string(),
+			is_public_network,
+		)
+		.unwrap();
+		let wallet_arc = Arc::new(RwLock::new(wallet));
+
+		let mut parachain_rpc = MockProvider::default();
+		parachain_rpc
+			.expect_get_required_collateral_for_wrapped()
+			.returning(|_, _| Ok(51));
+		parachain_rpc.expect_get_required_collateral_for_vault().returning(|_| Ok(50));
+		parachain_rpc.expect_get_vault_total_collateral().returning(|_| Ok(100));
+
+		let event = RequestReplaceEvent {
+			old_vault_id: dummy_vault_id(),
+			amount: Default::default(),
+			asset: Default::default(),
+			griefing_collateral: Default::default(),
+		};
+		assert_err!(
+			handle_replace_request(parachain_rpc, wallet_arc, &event, &dummy_vault_id()).await,
+			Error::InsufficientFunds
+		);
+	}
+
+	#[tokio::test]
+	async fn test_handle_replace_request_with_sufficient_balance() {
+		let is_public_network = false;
+		let wallet = StellarWallet::from_secret_encoded(
+			&STELLAR_VAULT_SECRET_KEY.to_string(),
+			is_public_network,
+		)
+		.unwrap();
+		let wallet_arc = Arc::new(RwLock::new(wallet));
+
+		let mut parachain_rpc = MockProvider::default();
+		parachain_rpc
+			.expect_get_required_collateral_for_wrapped()
+			.returning(|_, _| Ok(50));
+		parachain_rpc.expect_get_required_collateral_for_vault().returning(|_| Ok(50));
+		parachain_rpc.expect_get_vault_total_collateral().returning(|_| Ok(100));
+		parachain_rpc.expect_accept_replace().returning(|_, _, _, _, _| Ok(()));
+
+		let event = RequestReplaceEvent {
+			old_vault_id: dummy_vault_id(),
+			amount: Default::default(),
+			asset: Default::default(),
+			griefing_collateral: Default::default(),
+		};
+		handle_replace_request(parachain_rpc, wallet_arc, &event, &dummy_vault_id())
+			.await
+			.unwrap();
+	}
+}

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -1,0 +1,218 @@
+use std::{sync::Arc, time::Duration};
+
+use futures::{channel::mpsc::Sender, future::try_join3, SinkExt};
+use tokio::sync::RwLock;
+
+use runtime::{
+	AcceptReplaceEvent, CollateralBalancesPallet, ExecuteReplaceEvent, PrettyPrint, ReplacePallet,
+	RequestReplaceEvent, ShutdownSender, SpacewalkParachain, UtilFuncs, VaultId,
+	VaultRegistryPallet,
+};
+use service::{spawn_cancelable, Error as ServiceError};
+use wallet::StellarWallet;
+
+use crate::{
+	cancellation::Event, error::Error, execution::Request, oracle::ProofExt, system::VaultIdManager,
+};
+
+/// Listen for AcceptReplaceEvent directed at this vault and continue the replacement
+/// procedure by transferring the corresponding stellar assets and calling execute_replace
+///
+/// # Arguments
+///
+/// * `parachain_rpc` - the parachain RPC handle
+pub async fn listen_for_accept_replace(
+	shutdown_tx: ShutdownSender,
+	parachain_rpc: SpacewalkParachain,
+	vault_id_manager: VaultIdManager,
+	payment_margin: Duration,
+	proof_ops: Arc<RwLock<dyn ProofExt>>,
+) -> Result<(), ServiceError<Error>> {
+	let parachain_rpc = &parachain_rpc;
+	let vault_id_manager = &vault_id_manager;
+	let shutdown_tx = &shutdown_tx;
+	let proof_ops = &proof_ops;
+	parachain_rpc
+		.on_event::<AcceptReplaceEvent, _, _, _>(
+			|event| async move {
+				let vault = match vault_id_manager.get_vault(&event.old_vault_id).await {
+					Some(x) => x,
+					None => return, // event not directed at this vault
+				};
+				tracing::info!("Received accept replace event: {:?}", event);
+
+				// let _ = publish_expected_bitcoin_balance(&vault, parachain_rpc.clone()).await;
+
+				// within this event callback, we captured the arguments of
+				// listen_for_redeem_requests by reference. Since spawn requires static lifetimes,
+				// we will need to capture the arguments by value rather than by reference, so clone
+				// these:
+				let parachain_rpc = parachain_rpc.clone();
+				let proof_ops = proof_ops.clone();
+				// Spawn a new task so that we handle these events concurrently
+				spawn_cancelable(shutdown_tx.subscribe(), async move {
+					tracing::info!("Executing accept replace #{:?}", event.replace_id);
+
+					let result = async {
+						let request = Request::from_replace_request(
+							event.replace_id,
+							parachain_rpc.get_replace_request(event.replace_id).await?,
+							payment_margin,
+						)?;
+						request.pay_and_execute(parachain_rpc, vault, proof_ops).await
+					}
+					.await;
+
+					match result {
+						Ok(_) => tracing::info!(
+							"Completed accept replace request #{} with amount {}",
+							event.replace_id,
+							event.amount
+						),
+						Err(e) => tracing::error!(
+							"Failed to process accept replace request #{}: {}",
+							event.replace_id,
+							e.to_string()
+						),
+					}
+				});
+			},
+			|error| tracing::error!("Error reading accept_replace_event: {}", error.to_string()),
+		)
+		.await?;
+	Ok(())
+}
+
+/// Listen for RequestReplaceEvent, and attempt to accept it
+///
+/// # Arguments
+///
+/// * `parachain_rpc` - the parachain RPC handle
+/// * `event_channel` - the channel over which to signal events
+/// * `accept_replace_requests` - if true, we attempt to accept replace requests
+pub async fn listen_for_replace_requests(
+	parachain_rpc: SpacewalkParachain,
+	vault_id_manager: VaultIdManager,
+	event_channel: Sender<Event>,
+	accept_replace_requests: bool,
+) -> Result<(), ServiceError<Error>> {
+	let parachain_rpc = &parachain_rpc;
+	let vault_id_manager = &vault_id_manager;
+	let event_channel = &event_channel;
+	parachain_rpc
+		.on_event::<RequestReplaceEvent, _, _, _>(
+			|event| async move {
+				if parachain_rpc.is_this_vault(&event.old_vault_id) {
+					// don't respond to requests we placed ourselves
+					return
+				}
+
+				tracing::info!(
+					"Received replace request from {} for amount {}",
+					event.old_vault_id.pretty_print(),
+					event.amount
+				);
+
+				if accept_replace_requests {
+					for (vault_id, wallet) in vault_id_manager.get_vault_stellar_wallets().await {
+						match handle_replace_request(
+							parachain_rpc.clone(),
+							wallet.clone(),
+							&event,
+							&vault_id,
+						)
+						.await
+						{
+							Ok(_) => {
+								tracing::info!(
+									"[{}] Accepted replace request from {}",
+									vault_id.pretty_print(),
+									event.old_vault_id.pretty_print()
+								);
+								// try to send the event, but ignore the returned result since
+								// the only way it can fail is if the channel is closed
+								let _ = event_channel.clone().send(Event::Opened).await;
+
+								return // no need to iterate over the rest of the vault ids
+							},
+							Err(e) => tracing::error!(
+								"[{}] Failed to accept replace request from {}: {}",
+								vault_id.pretty_print(),
+								event.old_vault_id.pretty_print(),
+								e.to_string()
+							),
+						}
+					}
+				}
+			},
+			|error| tracing::error!("Error reading replace event: {}", error.to_string()),
+		)
+		.await?;
+	Ok(())
+}
+
+/// Attempts to accept a replace request. Does not retry RPC calls upon
+/// failure, since nothing is at stake at this point
+pub async fn handle_replace_request<
+	'a,
+	P: CollateralBalancesPallet + ReplacePallet + VaultRegistryPallet,
+>(
+	parachain_rpc: P,
+	wallet: Arc<RwLock<StellarWallet>>,
+	event: &'a RequestReplaceEvent,
+	vault_id: &'a VaultId,
+) -> Result<(), Error> {
+	let collateral_currency = vault_id.collateral_currency();
+
+	let (required_replace_collateral, current_collateral, used_collateral) = try_join3(
+		parachain_rpc.get_required_collateral_for_wrapped(event.amount, collateral_currency),
+		parachain_rpc.get_vault_total_collateral(vault_id.clone()),
+		parachain_rpc.get_required_collateral_for_vault(vault_id.clone()),
+	)
+	.await?;
+
+	let total_required_collateral = required_replace_collateral.saturating_add(used_collateral);
+
+	if current_collateral < total_required_collateral {
+		Err(Error::InsufficientFunds)
+	} else {
+		let wallet = wallet.read().await;
+		Ok(parachain_rpc
+			.accept_replace(
+				vault_id,
+				&event.old_vault_id,
+				event.amount,
+				0, // do not lock any additional collateral
+				wallet.get_public_key_raw(),
+			)
+			.await?)
+	}
+}
+
+/// Listen for ExecuteReplaceEvent directed at this vault and continue the replacement
+/// procedure by transferring bitcoin and calling execute_replace
+///
+/// # Arguments
+///
+/// * `event_channel` - the channel over which to signal events
+pub async fn listen_for_execute_replace(
+	parachain_rpc: SpacewalkParachain,
+	event_channel: Sender<Event>,
+) -> Result<(), ServiceError<Error>> {
+	let event_channel = &event_channel;
+	let parachain_rpc = &parachain_rpc;
+	parachain_rpc
+		.on_event::<ExecuteReplaceEvent, _, _, _>(
+			|event| async move {
+				if &event.new_vault_id.account_id == parachain_rpc.get_account_id() {
+					tracing::info!("Received event: execute replace #{:?}", event.replace_id);
+					// try to send the event, but ignore the returned result since
+					// the only way it can fail is if the channel is closed
+					let _ = event_channel.clone().send(Event::Executed(event.replace_id)).await;
+				}
+			},
+			|error| tracing::error!("Error reading redeem event: {}", error.to_string()),
+		)
+		.await?;
+	Ok(())
+}

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -306,14 +306,14 @@ async fn run_and_monitor_tasks(
 		})
 		.unzip();
 
-	let tokio_metrics = tokio::spawn(wait_or_shutdown(
-		shutdown_tx.clone(),
-		publish_tokio_metrics(metrics_iterators),
-	));
+	// We don't use metrics for now
+	// let tokio_metrics = tokio::spawn(wait_or_shutdown(
+	// 	shutdown_tx.clone(),
+	// 	publish_tokio_metrics(metrics_iterators),
+	// ));
 
-	match join(tokio_metrics, join_all(tasks)).await {
-		(Ok(Err(err)), _) => Err(err),
-		(_, results) => results
+	match join_all(tasks).await {
+		results => results
 			.into_iter()
 			.find(|res| matches!(res, Ok(Err(_))))
 			.and_then(|res| res.ok())
@@ -713,7 +713,7 @@ pub async fn inner_create_handler(
 		tier1_node_ip
 	);
 
-	let node_info = NodeInfo::new(19, 25, 23, "v19.5.0".to_string(), network);
+	let node_info = NodeInfo::new(19, 26, 23, "v19.6.0".to_string(), network);
 	let cfg = ConnConfig::new(tier1_node_ip, 11625, stellar_vault_secret_key, 0, true, true, false);
 
 	create_handler(node_info, cfg, is_public_network).await.map_err(|e| {

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -222,7 +222,7 @@ pub struct VaultServiceConfig {
 	pub auto_register: Vec<(String, String, Option<u128>)>,
 
 	/// Minimum time to the the redeem/replace execution deadline to make the stellar payment.
-	#[clap(long, value_parser = parse_duration_minutes, default_value = "120")]
+	#[clap(long, value_parser = parse_duration_minutes, default_value = "1")]
 	pub payment_margin_minutes: Duration,
 }
 

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -524,6 +524,8 @@ async fn test_issue_cancel_succeeds() {
 			// The account of the 'user_provider' is used to request a new issue that
 			// will be canceled in the next step
 			let issue = user_provider.request_issue(issue_amount, &vault_id).await.unwrap();
+			// First await the event that the issue has been requested
+			assert_event::<RequestIssueEvent, _>(TIMEOUT, user_provider.clone(), |_| true).await;
 			assert_eq!(issue_set.read().await.len(), 1);
 
 			match user_provider.cancel_issue(issue.issue_id).await {

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -749,6 +749,7 @@ async fn test_automatic_issue_execution_succeeds() {
 				)
 				.await;
 			assert!(result.is_ok());
+			drop(wallet);
 
 			tracing::warn!("Sent payment to address. Ledger is {:?}", result.unwrap().0.ledger);
 
@@ -794,6 +795,7 @@ async fn test_automatic_issue_execution_succeeds() {
 				issue_set.clone(),
 			),
 		);
+		drop(wallet);
 
 		test_service(service, fut_user).await;
 	})
@@ -887,6 +889,7 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 				)
 				.await;
 			assert!(result.is_ok());
+			drop(wallet);
 
 			tracing::info!("Sent payment to address. Ledger is {:?}", result.unwrap().0.ledger);
 

--- a/clients/wallet/Cargo.toml
+++ b/clients/wallet/Cargo.toml
@@ -6,6 +6,7 @@ version = "1.0.0"
 
 [dependencies]
 async-trait = "0.1.40"
+base64 = "0.13.1"
 parity-scale-codec = "3.0.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0.136"

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -15,4 +15,6 @@ pub enum Error {
 	HorizonSubmissionError(String),
 	#[error("Could not parse string: {0}")]
 	Utf8Error(#[from] std::str::Utf8Error),
+	#[error("Could not decode XDR")]
+	DecodeError,
 }

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -1,12 +1,13 @@
-use substrate_stellar_sdk::{horizon::FetchError, StellarSdkError};
+use reqwest::Error as FetchError;
+use substrate_stellar_sdk::StellarSdkError;
 use thiserror::Error;
 
-#[derive(PartialEq, Clone, Debug, Error)]
+#[derive(Debug, Error)]
 pub enum Error {
 	#[error("Server returned rpc error")]
 	InvalidSecretKey,
-	#[error("Error fetching horizon data")]
-	HttpFetchingError,
+	#[error("Error fetching horizon data: {0}")]
+	HttpFetchingError(#[from] FetchError),
 	#[error("Oracle returned error")]
 	OracleError,
 	#[error("Could not build transaction: {0}")]

--- a/clients/wallet/src/horizon.rs
+++ b/clients/wallet/src/horizon.rs
@@ -251,10 +251,10 @@ impl HorizonClient for reqwest::Client {
 		self.get(url)
 			.send()
 			.await
-			.map_err(|_| Error::HttpFetchingError)?
+			.map_err(|e| Error::HttpFetchingError(e))?
 			.json::<HorizonTransactionsResponse>()
 			.await
-			.map_err(|_| Error::HttpFetchingError)
+			.map_err(|e| Error::HttpFetchingError(e))
 	}
 
 	async fn get_account(
@@ -268,10 +268,10 @@ impl HorizonClient for reqwest::Client {
 		self.get(url)
 			.send()
 			.await
-			.map_err(|_| Error::HttpFetchingError)?
+			.map_err(|e| Error::HttpFetchingError(e))?
 			.json::<HorizonAccountResponse>()
 			.await
-			.map_err(|_| Error::HttpFetchingError)
+			.map_err(|e| Error::HttpFetchingError(e))
 	}
 
 	async fn submit_transaction(
@@ -291,10 +291,10 @@ impl HorizonClient for reqwest::Client {
 			.form(&params)
 			.send()
 			.await
-			.map_err(|_| Error::HttpFetchingError)?
+			.map_err(|e| Error::HttpFetchingError(e))?
 			.json::<TransactionResponse>()
 			.await
-			.map_err(|_| Error::HttpFetchingError)
+			.map_err(|e| Error::HttpFetchingError(e))
 	}
 }
 

--- a/clients/wallet/src/horizon.rs
+++ b/clients/wallet/src/horizon.rs
@@ -52,9 +52,6 @@ where
 // ref https://developers.stellar.org/api/introduction/response-format/
 #[derive(Deserialize, Debug)]
 pub struct HorizonTransactionsResponse {
-	// We don't care about specifics of pagination, so we just tell serde that this will be a
-	// generic json value
-	pub _links: serde_json::Value,
 	pub _embedded: EmbeddedTransactions,
 }
 
@@ -135,10 +132,6 @@ impl TransactionResponse {
 
 #[derive(Deserialize, Debug)]
 pub struct HorizonAccountResponse {
-	// We don't care about specifics of pagination, so we just tell serde that this will be a
-	// generic json value
-	pub _links: serde_json::Value,
-
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub id: Vec<u8>,
 	#[serde(deserialize_with = "de_string_to_bytes")]
@@ -150,9 +143,6 @@ pub struct HorizonAccountResponse {
 
 #[derive(Deserialize, Debug)]
 pub struct HorizonClaimableBalanceResponse {
-	// We don't care about specifics of pagination, so we just tell serde that this will be a
-	// generic json value
-	pub _links: serde_json::Value,
 	pub _embedded: EmbeddedClaimableBalance,
 }
 

--- a/clients/wallet/src/horizon.rs
+++ b/clients/wallet/src/horizon.rs
@@ -123,7 +123,7 @@ impl TransactionResponse {
 		}
 	}
 
-	pub fn envelope(&self) -> Result<TransactionEnvelope, Error> {
+	pub fn to_envelope(&self) -> Result<TransactionEnvelope, Error> {
 		let envelope = TransactionEnvelope::from_base64_xdr(self.envelope_xdr.clone())
 			.map_err(|_| Error::DecodeError);
 		envelope

--- a/clients/wallet/src/lib.rs
+++ b/clients/wallet/src/lib.rs
@@ -1,6 +1,6 @@
 use substrate_stellar_sdk::Hash;
 
-pub use horizon::listen_for_new_transactions;
+pub use horizon::{listen_for_new_transactions, TransactionResponse};
 pub use stellar_wallet::StellarWallet;
 
 pub mod error;

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -16,6 +16,10 @@ use crate::{
 pub struct StellarWallet {
 	secret_key: SecretKey,
 	is_public_network: bool,
+	/// The last used account sequence number. We need this when sending multiple transactions in a
+	/// batch because otherwise the transactions would be rejected since the sequence number is not
+	/// increased on the network.
+	last_account_sequence: i64,
 }
 
 impl StellarWallet {
@@ -26,7 +30,7 @@ impl StellarWallet {
 		let secret_key =
 			SecretKey::from_encoding(secret_key).map_err(|_| Error::InvalidSecretKey)?;
 
-		let wallet = StellarWallet { secret_key, is_public_network };
+		let wallet = StellarWallet { secret_key, is_public_network, last_account_sequence: 0 };
 		Ok(wallet)
 	}
 
@@ -68,11 +72,12 @@ impl StellarWallet {
 	}
 
 	pub async fn send_payment_to_address(
-		&self,
+		&mut self,
 		destination_address: PublicKey,
 		asset: Asset,
 		stroop_amount: i64,
 		memo_hash: Hash,
+		stroop_fee_per_operation: u32,
 	) -> Result<(TransactionResponse, TransactionEnvelope), Error> {
 		let horizon_client = reqwest::Client::new();
 
@@ -80,14 +85,19 @@ impl StellarWallet {
 		let account_id_string =
 			std::str::from_utf8(&public_key_encoded).map_err(|e| Error::Utf8Error(e))?;
 		let account = horizon_client.get_account(account_id_string, self.is_public_network).await?;
-		let next_sequence_number = account.sequence + 1;
+		// Either use the local one or the one from the network depending on which one is higher.
+		let next_sequence_number = if self.last_account_sequence > account.sequence {
+			self.last_account_sequence + 1
+		} else {
+			account.sequence + 1
+		};
 
-		let fee_per_operation = 100;
+		self.last_account_sequence = next_sequence_number;
 
 		let mut transaction = Transaction::new(
 			self.get_public_key(),
 			next_sequence_number,
-			Some(fee_per_operation),
+			Some(stroop_fee_per_operation),
 			Preconditions::PrecondNone,
 			Some(Memo::MemoHash(memo_hash)),
 		)

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -1,3 +1,5 @@
+use std::fmt::Formatter;
+
 use substrate_stellar_sdk::{
 	horizon::Horizon,
 	network::{Network, PUBLIC_NETWORK, TEST_NETWORK},
@@ -12,7 +14,7 @@ use crate::{
 	types::StellarPublicKeyRaw,
 };
 
-#[derive(Clone, PartialEq, Debug, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StellarWallet {
 	secret_key: SecretKey,
 	is_public_network: bool,
@@ -132,6 +134,19 @@ impl StellarWallet {
 			.await?;
 
 		Ok((transaction_response, envelope))
+	}
+}
+
+impl std::fmt::Debug for StellarWallet {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		let public_key_encoded = self.get_public_key().to_encoding();
+		let account_id_string =
+			std::str::from_utf8(&public_key_encoded).map_err(|e| std::fmt::Error)?;
+		write!(
+			f,
+			"StellarWallet [public key: {}, public network: {}]",
+			account_id_string, self.is_public_network
+		)
 	}
 }
 

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -46,7 +46,7 @@ impl StellarWallet {
 		self.is_public_network
 	}
 
-	pub fn get_latest_transactions(
+	pub async fn get_latest_transactions(
 		&self,
 		cursor: PagingToken,
 		limit: i64,
@@ -58,13 +58,11 @@ impl StellarWallet {
 		let account_id =
 			std::str::from_utf8(&public_key_encoded).map_err(|e| Error::Utf8Error(e))?;
 
-		let transactions = horizon_client.get_transactions(
-			account_id,
-			self.is_public_network,
-			cursor,
-			limit,
-			order_ascending,
-		)?;
+		let transactions_response = horizon_client
+			.get_transactions(account_id, self.is_public_network, cursor, limit, order_ascending)
+			.await?;
+
+		let transactions = transactions_response._embedded.records;
 
 		Ok(transactions)
 	}

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -8,7 +8,7 @@ use substrate_stellar_sdk::{
 
 use crate::{
 	error::Error,
-	horizon::{HorizonClient, TransactionResponse},
+	horizon::{HorizonClient, PagingToken, TransactionResponse},
 	types::StellarPublicKeyRaw,
 };
 
@@ -44,6 +44,29 @@ impl StellarWallet {
 
 	pub fn is_public_network(&self) -> bool {
 		self.is_public_network
+	}
+
+	pub fn get_latest_transactions(
+		&self,
+		cursor: PagingToken,
+		limit: i64,
+		order_ascending: bool,
+	) -> Result<Vec<TransactionResponse>, Error> {
+		let horizon_client = reqwest::Client::new();
+
+		let public_key_encoded = self.get_public_key().to_encoding();
+		let account_id =
+			std::str::from_utf8(&public_key_encoded).map_err(|e| Error::Utf8Error(e))?;
+
+		let transactions = horizon_client.get_transactions(
+			account_id,
+			self.is_public_network,
+			cursor,
+			limit,
+			order_ascending,
+		)?;
+
+		Ok(transactions)
 	}
 
 	pub async fn send_payment_to_address(


### PR DESCRIPTION
Adds the handling for redeem and replace events to the vault client.
Also adds the last missing integration tests.

The `send_payment_to_address()` function of the StellarWallet struct now requires a mutable reference to `self` because it now uses and sets a local account sequence number. This number is necessary because, when calling this function multiple times before a ledger close, all transactions would be created with the same sequence number, meaning that only one of them can go through and the others are rejected by the stellar network. Keeping a local copy of this sequence number mitigates this problem because we can increase it for every new transaction call.