### PR TITLE
Use DataProvider type in oracle from Pallet config

### DIFF
--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -11,7 +11,7 @@ extern crate mocktopus;
 use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "testing-utils")]
 use frame_support::dispatch::DispatchResult;
-use frame_support::{dispatch::DispatchError, traits::Time, transactional};
+use frame_support::{dispatch::DispatchError, transactional};
 #[cfg(test)]
 use mocktopus::macros::mockable;
 use scale_info::TypeInfo;
@@ -46,10 +46,6 @@ pub mod types;
 
 pub mod dia;
 
-// pub(crate) type MomentOf<T> = <<T as Config>::Time as Time>::Moment;
-// pub(crate) type TimestampedValueOf<T> = TimestampedValue<<T as Config>::OracleValue,
-// MomentOf<T>>;
-
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::pallet_prelude::*;
@@ -72,15 +68,10 @@ pub mod pallet {
 		/// Weight information for the extrinsics in this module.
 		type WeightInfo: WeightInfo;
 
-		// type Time: Time;
-		// type OracleKey: Parameter + Member;
-		// type OracleValue: Parameter + Member + Ord;
-		// type DataProvider: DataProviderExtended<Self::OracleKey, TimestampedValueOf<Self>>;
-
-		// type DataProvider: DataProviderExtended<
-		// 	OracleKey,
-		// 	TimestampedValue<Self::UnsignedFixedPoint, Self::Moment>,
-		// >;
+		type DataProvider: DataProviderExtended<
+			OracleKey,
+			TimestampedValue<Self::UnsignedFixedPoint, Self::Moment>,
+		>;
 	}
 
 	#[pallet::event]
@@ -94,12 +85,8 @@ pub mod pallet {
 		AggregateUpdated {
 			values: Vec<(OracleKey, Option<T::UnsignedFixedPoint>)>,
 		},
-		OracleAdded {
-			oracle_id: T::AccountId,
-			name: Vec<u8>,
-		},
-		OracleRemoved {
-			oracle_id: T::AccountId,
+		OracleKeysUpdated {
+			oracle_keys: Vec<OracleKey>,
 		},
 	}
 
@@ -121,29 +108,6 @@ pub mod pallet {
 		}
 	}
 
-	/// Current medianized value for the given key
-	#[pallet::storage]
-	pub type Aggregate<T: Config> =
-		StorageMap<_, Blake2_128Concat, OracleKey, UnsignedFixedPoint<T>>;
-
-	#[pallet::storage]
-	pub type RawValues<T: Config> = StorageDoubleMap<
-		_,
-		Blake2_128Concat,
-		OracleKey,
-		Blake2_128Concat,
-		T::AccountId,
-		TimestampedValue<UnsignedFixedPoint<T>, T::Moment>,
-	>;
-
-	#[pallet::storage]
-	/// if a key is present, it means the values have been updated
-	pub type RawValuesUpdated<T: Config> = StorageMap<_, Blake2_128Concat, OracleKey, bool>;
-
-	/// Time until which the aggregate is valid
-	#[pallet::storage]
-	pub type ValidUntil<T: Config> = StorageMap<_, Blake2_128Concat, OracleKey, T::Moment>;
-
 	/// Maximum delay (milliseconds) for a reported value to be used
 	#[pallet::storage]
 	#[pallet::getter(fn max_delay)]
@@ -153,12 +117,6 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn oracle_keys)]
 	pub type OracleKeys<T: Config> = StorageValue<_, Vec<OracleKey>, ValueQuery>;
-
-	// Oracles allowed to set the exchange rate, maps to the name
-	#[pallet::storage]
-	#[pallet::getter(fn authorized_oracles)]
-	pub type AuthorizedOracles<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::AccountId, Vec<u8>, ValueQuery>;
 
 	#[pallet::type_value]
 	pub(super) fn DefaultForStorageVersion() -> Version {
@@ -192,14 +150,7 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			// T::Moment doesn't implement serialize so we use
-			// From<u32> as bound by AtLeast32Bit
 			MaxDelay::<T>::put(T::Moment::from(self.max_delay));
-
-			for (ref who, name) in self.authorized_oracles.iter() {
-				AuthorizedOracles::<T>::insert(who, name);
-			}
-
 			OracleKeys::<T>::put(self.oracle_keys.clone());
 		}
 	}
@@ -211,60 +162,20 @@ pub mod pallet {
 	// The pallet's dispatchable functions.
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		/// Feeds data from the oracles, e.g., the exchange rates. This function
-		/// is intended to be API-compatible with orml-oracle.
+		/// set oracle keys
 		///
 		/// # Arguments
-		///
-		/// * `values` - a vector of (key, value) pairs to submit
-		#[pallet::call_index(0)]
-		#[pallet::weight(<T as Config>::WeightInfo::feed_values(values.len() as u32))]
-		pub fn feed_values(
-			origin: OriginFor<T>,
-			values: Vec<(OracleKey, T::UnsignedFixedPoint)>,
-		) -> DispatchResultWithPostInfo {
-			let signer = ensure_signed(origin)?;
-
-			// fail if the signer is not an authorized oracle
-			ensure!(Self::is_authorized(&signer), Error::<T>::InvalidOracleSource);
-
-			Self::_feed_values(signer, values);
-			Ok(Pays::No.into())
-		}
-
-		/// Adds an authorized oracle account (only executable by the Root account)
-		///
-		/// # Arguments
-		/// * `account_id` - the account Id of the oracle
-		/// * `name` - a descriptive name for the oracle
-		#[pallet::call_index(1)]
-		#[pallet::weight(<T as Config>::WeightInfo::insert_authorized_oracle())]
-		#[transactional]
-		pub fn insert_authorized_oracle(
-			origin: OriginFor<T>,
-			account_id: T::AccountId,
-			name: Vec<u8>,
-		) -> DispatchResult {
-			ensure_root(origin)?;
-			Self::insert_oracle(account_id.clone(), name.clone());
-			Self::deposit_event(Event::OracleAdded { oracle_id: account_id, name });
-			Ok(())
-		}
-
-		/// Removes an authorized oracle account (only executable by the Root account)
-		///
-		/// # Arguments
-		/// * `account_id` - the account Id of the oracle
+		/// * `oracle_key` - list of oracle keys
 		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::remove_authorized_oracle())]
 		#[transactional]
-		pub fn remove_authorized_oracle(
+		pub fn update_oracle_key(
 			origin: OriginFor<T>,
-			account_id: T::AccountId,
+			oracle_key: Vec<OracleKey>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			<AuthorizedOracles<T>>::remove(account_id.clone());
-			Self::deposit_event(Event::OracleRemoved { oracle_id: account_id });
+			<OracleKeys<T>>::put(oracle_key.clone());
+			Self::deposit_event(Event::OracleKeysUpdated { oracle_keys: oracle_key });
 			Ok(())
 		}
 	}
@@ -274,26 +185,30 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	// public only for testing purposes
 	pub fn begin_block(_height: T::BlockNumber) {
-		// read to a temporary value, because we can't alter the map while we iterate over it
-		let raw_values_updated: Vec<_> = RawValuesUpdated::<T>::iter().collect();
+		let oracle_keys: Vec<_> = OracleKeys::<T>::get();
 
 		let current_time = Self::get_current_time();
 
 		let mut updated_items = Vec::new();
-		for (key, is_updated) in raw_values_updated.iter() {
-			if *is_updated || Self::is_outdated(key, current_time) {
-				let new_value = Self::update_aggregate(key);
-				updated_items.push((key.clone(), new_value));
+		let max_delay = Self::get_max_delay();
+		for key in oracle_keys.iter() {
+			let price = T::DataProvider::get_no_op(key);
+			let Some(price) = price else{
+				continue;
+			};
+			let is_outdated = current_time > price.timestamp + max_delay;
+			if !is_outdated {
+				updated_items.push((key.clone(), Some(price.value)));
 			}
 		}
 
+		let updated_items_len = updated_items.len();
 		if !updated_items.is_empty() {
 			Self::deposit_event(Event::<T>::AggregateUpdated { values: updated_items });
 		}
 
 		let current_status_is_online = Self::is_oracle_online();
-		let new_status_is_online = !raw_values_updated.is_empty() &&
-			raw_values_updated.iter().all(|(key, _)| Aggregate::<T>::get(key).is_some());
+		let new_status_is_online = updated_items_len == oracle_keys.len();
 
 		if current_status_is_online != new_status_is_online {
 			if new_status_is_online {
@@ -304,13 +219,14 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	// TODO
 	// public only for testing purposes
 	pub fn _feed_values(oracle: T::AccountId, values: Vec<(OracleKey, T::UnsignedFixedPoint)>) {
 		for (key, value) in values.iter() {
 			let timestamped =
 				TimestampedValue { timestamp: Self::get_current_time(), value: *value };
-			RawValues::<T>::insert(key, &oracle, timestamped);
-			RawValuesUpdated::<T>::insert(key, true);
+			// RawValues::<T>::insert(key, &oracle, timestamped);
+			// RawValuesUpdated::<T>::insert(key, true);
 		}
 
 		Self::deposit_event(Event::<T>::FeedValues { oracle_id: oracle, values });
@@ -322,7 +238,10 @@ impl<T: Config> Pallet<T> {
 	pub fn get_price(key: OracleKey) -> Result<UnsignedFixedPoint<T>, DispatchError> {
 		ext::security::ensure_parachain_status_running::<T>()?;
 
-		Aggregate::<T>::get(key).ok_or_else(|| Error::<T>::MissingExchangeRate.into())
+		let Some(price) = T::DataProvider::get_no_op(&key) else{
+			 return Err(Error::<T>::MissingExchangeRate.into());
+		};
+		Ok(price.value)
 	}
 
 	pub fn convert(
@@ -368,45 +287,12 @@ impl<T: Config> Pallet<T> {
 			.unique_saturated_into())
 	}
 
-	fn update_aggregate(key: &OracleKey) -> Option<T::UnsignedFixedPoint> {
-		RawValuesUpdated::<T>::insert(key, false);
-		let mut raw_values: Vec<_> =
-			RawValues::<T>::iter_prefix(key).map(|(_, value)| value).collect();
-		let min_timestamp = Self::get_current_time().saturating_sub(Self::get_max_delay());
-		raw_values.retain(|value| value.timestamp >= min_timestamp);
-		if raw_values.is_empty() {
-			Aggregate::<T>::remove(key);
-			ValidUntil::<T>::remove(key);
-			None
-		} else {
-			let valid_until = raw_values
-				.iter()
-				.map(|x| x.timestamp)
-				.min()
-				.map(|timestamp| timestamp + Self::get_max_delay())
-				.unwrap_or_default(); // Unwrap will never fail, but if somehow it did, we retry next block
-
-			let mid_index = raw_values.len() / 2;
-			let (_, value, _) =
-				raw_values.select_nth_unstable_by(mid_index as usize, |a, b| a.value.cmp(&b.value));
-
-			Aggregate::<T>::insert(key, value.value);
-			ValidUntil::<T>::insert(key, valid_until);
-			Some(value.value)
-		}
-	}
-
 	/// Private getters and setters
-
-	fn is_outdated(key: &OracleKey, current_time: T::Moment) -> bool {
-		let valid_until = ValidUntil::<T>::get(key);
-		matches!(valid_until, Some(t) if current_time > t)
-	}
-
 	fn get_max_delay() -> T::Moment {
 		<MaxDelay<T>>::get()
 	}
 
+	/// TODO
 	/// Set the current exchange rate. ONLY FOR TESTING.
 	///
 	/// # Arguments
@@ -417,8 +303,9 @@ impl<T: Config> Pallet<T> {
 		currency_id: CurrencyId,
 		exchange_rate: UnsignedFixedPoint<T>,
 	) -> DispatchResult {
-		Aggregate::<T>::insert(OracleKey::ExchangeRate(currency_id), exchange_rate);
+		// Aggregate::<T>::insert(OracleKey::ExchangeRate(currency_id), exchange_rate);
 		// this is useful for benchmark tests
+		//TODO for testing get data from DataProvider as DataFeed trait
 		Self::recover_from_oracle_offline();
 		Ok(())
 	}
@@ -439,15 +326,5 @@ impl<T: Config> Pallet<T> {
 	/// Returns the current timestamp
 	fn get_current_time() -> T::Moment {
 		<pallet_timestamp::Pallet<T>>::get()
-	}
-
-	/// Add a new authorized oracle
-	fn insert_oracle(oracle: T::AccountId, name: Vec<u8>) {
-		<AuthorizedOracles<T>>::insert(oracle, name)
-	}
-
-	/// True if oracle is authorized
-	fn is_authorized(oracle: &T::AccountId) -> bool {
-		<AuthorizedOracles<T>>::contains_key(oracle)
 	}
 }

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -169,13 +169,13 @@ pub mod pallet {
 		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::remove_authorized_oracle())]
 		#[transactional]
-		pub fn update_oracle_key(
+		pub fn update_oracle_keys(
 			origin: OriginFor<T>,
-			oracle_key: Vec<OracleKey>,
+			oracle_keys: Vec<OracleKey>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			<OracleKeys<T>>::put(oracle_key.clone());
-			Self::deposit_event(Event::OracleKeysUpdated { oracle_keys: oracle_key });
+			<OracleKeys<T>>::put(oracle_keys.clone());
+			Self::deposit_event(Event::OracleKeysUpdated { oracle_keys: oracle_keys });
 			Ok(())
 		}
 	}


### PR DESCRIPTION
- add `DataProvider` to oracle pallet config
- Add new Storage `Vec<OracleKeys>`
- Add new extrinsic to update the Storage with `oracle_keys`
- load prices `on_initialize` to track the price status and move parachain offline or online
- remove unused `Storages`