### PR TITLE
use thread local to fix unit tests when mock pallet oracle

### DIFF
--- a/pallets/oracle/src/dia.rs
+++ b/pallets/oracle/src/dia.rs
@@ -4,6 +4,8 @@ pub use primitives::{oracle::Key as OracleKey, CurrencyId, TruncateFixedPointToI
 use sp_std::marker;
 
 use sp_runtime::traits::Convert;
+use sp_std::{convert::TryInto, vec::Vec};
+use sp_std::vec;
 
 pub struct MockDiaOracleConvertor;
 


### PR DESCRIPTION
use thread_lock macros when mock DIA oracle feeder and dia oracle provider