### PR TITLE
Compatibility done! Oracle pallet + issue pallets works fine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,7 @@ version = "1.0.0"
 dependencies = [
  "base64",
  "currency",
+ "dia-oracle",
  "fee",
  "frame-benchmarking",
  "frame-support",

--- a/pallets/issue/Cargo.toml
+++ b/pallets/issue/Cargo.toml
@@ -55,6 +55,8 @@ oracle = { path = "../oracle", features = ['testing-utils'] }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.33" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.33" }
 
+dia-oracle = { git = "https://github.com/TorstenStueber/oracle-pallet", branch = "master", default-features = false }
+
 [features]
 default = ["std"]
 std = [

--- a/pallets/issue/src/mock.rs
+++ b/pallets/issue/src/mock.rs
@@ -4,6 +4,7 @@ use frame_support::{
 	PalletId,
 };
 use mocktopus::{macros::mockable, mocking::clear_mocks};
+use oracle::{dia::{DiaOracleAdapter, MockConvertPrice, MockDiaOracleConvertor, MockMoment}, oracle_mock::{MockDiaOracle, DataCollector}};
 use orml_traits::parameter_type_with_key;
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -225,6 +226,15 @@ impl staking::Config for Test {
 impl oracle::Config for Test {
 	type RuntimeEvent = TestEvent;
 	type WeightInfo = ();
+	type DataProvider = DiaOracleAdapter<
+		MockDiaOracle,
+		UnsignedFixedPoint,
+		Moment,
+		MockDiaOracleConvertor,
+		MockConvertPrice,
+		MockMoment,
+	>;
+	type DataFeedProvider = DataCollector;
 }
 
 parameter_types! {
@@ -362,12 +372,12 @@ where
 {
 	clear_mocks();
 	ExtBuilder::build().execute_with(|| {
-		assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
+		assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(1,
 			DEFAULT_COLLATERAL_CURRENCY,
 			UnsignedFixedPoint::one()
 		));
 
-		assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
+		assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(1,
 			DEFAULT_WRAPPED_CURRENCY,
 			UnsignedFixedPoint::one()
 		));

--- a/pallets/issue/src/tests.rs
+++ b/pallets/issue/src/tests.rs
@@ -83,7 +83,7 @@ fn get_dummy_request_id() -> H256 {
 #[test]
 fn test_request_issue_banned_fails() {
 	run_test(|| {
-		assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
+		assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(1,
 			DEFAULT_COLLATERAL_CURRENCY,
 			FixedU128::one()
 		));

--- a/pallets/oracle/src/benchmarking.rs
+++ b/pallets/oracle/src/benchmarking.rs
@@ -19,36 +19,6 @@ benchmarks! {
 
 		Timestamp::<T>::set_timestamp(1000u32.into());
 	}
-
-	feed_values {
-		let u in 1 .. 1000u32;
-
-		let origin: T::AccountId = account("origin", 0, 0);
-		<AuthorizedOracles<T>>::insert(origin.clone(), Vec::<u8>::new());
-
-		let key = OracleKey::ExchangeRate(Token(DOT));
-		let values:Vec<_> = (0 .. u).map(|x| (key.clone(), UnsignedFixedPoint::<T>::checked_from_rational(1, x+1).unwrap())).collect();
-	}: _(RawOrigin::Signed(origin), values)
-	verify {
-		let key = OracleKey::ExchangeRate(Token(DOT));
-		crate::Pallet::<T>::begin_block(0u32.into());
-		assert!(Aggregate::<T>::get(key).is_some());
-	}
-
-	insert_authorized_oracle {
-		let origin: T::AccountId = account("origin", 0, 0);
-	}: _(RawOrigin::Root, origin.clone(), "Origin".as_bytes().to_vec())
-	verify {
-		assert!(Oracle::<T>::is_authorized(&origin));
-	}
-
-	remove_authorized_oracle {
-		let origin: T::AccountId = account("origin", 0, 0);
-		Oracle::<T>::insert_oracle(origin.clone(), "Origin".as_bytes().to_vec());
-	}: _(RawOrigin::Root, origin.clone())
-	verify {
-		assert!(!Oracle::<T>::is_authorized(&origin));
-	}
 }
 
 impl_benchmark_test_suite!(Oracle, crate::mock::ExtBuilder::build(), crate::mock::Test);

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -39,16 +39,18 @@ mod benchmarking;
 
 mod default_weights;
 #[cfg(test)]
-#[cfg_attr(test,cfg(feature = "testing-utils"))]
+#[cfg_attr(test, cfg(feature = "testing-utils"))]
 mod tests;
 
 #[cfg(test)]
-#[cfg_attr(test,cfg(feature = "testing-utils"))]
-mod mock;
+#[cfg_attr(test, cfg(feature = "testing-utils"))]
+pub mod mock;
 
 pub mod types;
 
 pub mod dia;
+#[cfg(feature = "testing-utils")]
+pub mod oracle_mock;
 use orml_oracle::DataFeeder;
 
 #[frame_support::pallet]
@@ -174,8 +176,6 @@ pub mod pallet {
 	// The pallet's dispatchable functions.
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-
-
 		/// Feeds data from the oracles, e.g., the exchange rates. This function
 		/// is intended to be API-compatible with orml-oracle.
 		///
@@ -343,13 +343,14 @@ impl<T: Config> Pallet<T> {
 	/// * `exchange_rate` - i.e. planck per satoshi
 	#[cfg(feature = "testing-utils")]
 	pub fn _set_exchange_rate(
+		oracle: T::AccountId,
 		currency_id: CurrencyId,
 		exchange_rate: UnsignedFixedPoint<T>,
 	) -> DispatchResult {
 		// Aggregate::<T>::insert(OracleKey::ExchangeRate(currency_id), exchange_rate);
 		// this is useful for benchmark tests
 		//TODO for testing get data from DataProvider as DataFeed trait
-		// Self::_feed_values(T::AccountId::default(), vec![(currency_id, exchange_rate)]);
+		Self::_feed_values(oracle, vec![((OracleKey::ExchangeRate(currency_id)), exchange_rate)]);
 		Self::recover_from_oracle_offline();
 		Ok(())
 	}
@@ -372,9 +373,9 @@ impl<T: Config> Pallet<T> {
 		<pallet_timestamp::Pallet<T>>::get()
 	}
 
-	fn get_timestamped(key: &OracleKey) -> Option<TimestampedValue<T::UnsignedFixedPoint, T::Moment>> {
+	fn get_timestamped(
+		key: &OracleKey,
+	) -> Option<TimestampedValue<T::UnsignedFixedPoint, T::Moment>> {
 		T::DataProvider::get_no_op(key)
 	}
 }
-
-

--- a/pallets/oracle/src/mock.rs
+++ b/pallets/oracle/src/mock.rs
@@ -26,6 +26,7 @@ pub use primitives::{CurrencyId::Token, TokenSymbol::*};
 use crate::{
 	self as oracle,
 	dia::{DiaOracleAdapter, MockConvertPrice, MockDiaOracleConvertor, MockMoment},
+	oracle_mock::{DataCollector, MockDiaOracle},
 	Config, Error, OracleKeys,
 };
 
@@ -155,79 +156,6 @@ impl currency::Config for Test {
 	type AssetConversion = primitives::AssetConversion;
 	type BalanceConversion = primitives::BalanceConversion;
 	type CurrencyConversion = CurrencyConvert;
-}
-
-#[derive(Clone)]
-struct Data {
-	pub key: (Vec<u8>, Vec<u8>),
-	pub price: u128,
-	pub timestamp: u64,
-}
-
-thread_local! {
-	static COINS: RefCell<Vec<Data>>  = RefCell::new(vec![]);
-}
-
-pub struct MockDiaOracle;
-impl DiaOracle for MockDiaOracle {
-	fn get_coin_info(
-		blockchain: Vec<u8>,
-		symbol: Vec<u8>,
-	) -> Result<dia_oracle::CoinInfo, sp_runtime::DispatchError> {
-		let key = (blockchain, symbol);
-		let mut result: Option<Data> = None;
-		COINS.with(|c| {
-			let r = c.borrow();
-			for i in &*r {
-				if i.key == key.clone() {
-					result = Some(i.clone());
-					break
-				}
-			}
-		});
-		let Some(result) = result else {
-			return Err(sp_runtime::DispatchError::Other(""));
-		};
-		let mut coin_info = CoinInfo::default();
-		coin_info.price = result.price;
-		coin_info.last_update_timestamp = result.timestamp;
-
-		Ok(coin_info)
-	}
-
-	fn get_value(
-		blockchain: Vec<u8>,
-		symbol: Vec<u8>,
-	) -> Result<dia_oracle::PriceInfo, sp_runtime::DispatchError> {
-		todo!()
-	}
-}
-
-pub struct DataCollector;
-impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
-	fn get(key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
-		todo!()
-	}
-}
-impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
-	for DataCollector
-{
-	fn feed_value(
-		who: AccountId,
-		key: Key,
-		value: TimestampedValue<UnsignedFixedPoint, Moment>,
-	) -> sp_runtime::DispatchResult {
-		let key = MockDiaOracleConvertor::convert(key).unwrap();
-		let r = value.value.into_inner();
-
-		let data = Data { key, price: r, timestamp: value.timestamp };
-
-		COINS.with(|coins| {
-			let mut r = coins.borrow_mut();
-			r.push(data)
-		});
-		Ok(())
-	}
 }
 
 impl Config for Test {

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -1,0 +1,87 @@
+#[cfg(feature = "testing-utils")]
+use std::{cell::RefCell, sync::RwLock};
+
+use dia_oracle::{CoinInfo, DiaOracle};
+use orml_oracle::{DataProvider, TimestampedValue};
+use sp_runtime::traits::Convert;
+
+use crate::dia::MockDiaOracleConvertor;
+use sp_arithmetic::{FixedI128, FixedU128};
+pub type UnsignedFixedPoint = FixedU128;
+use primitives::oracle::Key;
+type Moment = u64;
+
+#[derive(Clone)]
+struct Data {
+	pub key: (Vec<u8>, Vec<u8>),
+	pub price: u128,
+	pub timestamp: u64,
+}
+
+thread_local! {
+	static COINS: RefCell<Vec<Data>> = RefCell::new(vec![]);
+}
+
+pub type AccountId = u64;
+
+pub struct MockDiaOracle;
+impl DiaOracle for MockDiaOracle {
+	fn get_coin_info(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<dia_oracle::CoinInfo, sp_runtime::DispatchError> {
+		let key = (blockchain, symbol);
+		let mut result: Option<Data> = None;
+		COINS.with(|c| {
+			let r = c.borrow();
+			for i in &*r {
+				if i.key == key.clone() {
+					result = Some(i.clone());
+					break
+				}
+			}
+		});
+		let Some(result) = result else {
+			return Err(sp_runtime::DispatchError::Other(""));
+		};
+		let mut coin_info = CoinInfo::default();
+		coin_info.price = result.price;
+		coin_info.last_update_timestamp = result.timestamp;
+
+		Ok(coin_info)
+	}
+
+	fn get_value(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<dia_oracle::PriceInfo, sp_runtime::DispatchError> {
+		todo!()
+	}
+}
+
+pub struct DataCollector;
+impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
+	for DataCollector
+{
+	fn feed_value(
+		who: AccountId,
+		key: Key,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		let key = MockDiaOracleConvertor::convert(key).unwrap();
+		let r = value.value.into_inner();
+
+		let data = Data { key, price: r, timestamp: value.timestamp };
+
+		COINS.with(|coins| {
+			let mut r = coins.borrow_mut();
+			r.push(data)
+		});
+		Ok(())
+	}
+}


### PR DESCRIPTION
- finish oracle pallet to be compatible with other spacewalk pallets
- create oracle_mock rs file in oracle pallet to introduce easy way mock oracle pallet in test runtime in other pallets.
- issue pallet tests passed successfully 