### PR TITLE
Spacewalk oracle refactoring

### DIFF
--- a/pallets/nomination/src/mock.rs
+++ b/pallets/nomination/src/mock.rs
@@ -6,9 +6,7 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{
-		DataCollector, MockConvertMoment, MockConvertPrice, MockDiaOracle, MockOracleKeyConvertor,
-	},
+	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
 };
 use orml_traits::parameter_type_with_key;
 use sp_arithmetic::{FixedI128, FixedU128};
@@ -365,4 +363,70 @@ where
 		System::set_block_number(1);
 		test();
 	});
+}
+
+thread_local! {
+	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+}
+
+pub struct MockDiaOracle;
+impl DiaOracle for MockDiaOracle {
+	fn get_coin_info(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<dia_oracle::CoinInfo, sp_runtime::DispatchError> {
+		let key = (blockchain, symbol);
+		let mut result: Option<Data> = None;
+		COINS.with(|c| {
+			let r = c.borrow();
+			for i in &*r {
+				if i.key == key.clone() {
+					result = Some(i.clone());
+					break
+				}
+			}
+		});
+		let Some(result) = result else {
+			return Err(sp_runtime::DispatchError::Other(""));
+		};
+		let mut coin_info = CoinInfo::default();
+		coin_info.price = result.price;
+		coin_info.last_update_timestamp = result.timestamp;
+
+		Ok(coin_info)
+	}
+
+	fn get_value(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<dia_oracle::PriceInfo, sp_runtime::DispatchError> {
+		todo!()
+	}
+}
+
+pub struct DataCollector;
+impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
+	for DataCollector
+{
+	fn feed_value(
+		who: AccountId,
+		key: Key,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		let key = MockOracleKeyConvertor::convert(key).unwrap();
+		let r = value.value.into_inner();
+
+		let data = Data { key, price: r, timestamp: value.timestamp };
+
+		COINS.with(|coins| {
+			let mut r = coins.borrow_mut();
+			r.push(data)
+		});
+		Ok(())
+	}
 }

--- a/pallets/nomination/src/mock.rs
+++ b/pallets/nomination/src/mock.rs
@@ -7,15 +7,18 @@ use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
 	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use orml_traits::parameter_type_with_key;
+use primitives::oracle::Key;
 use sp_arithmetic::{FixedI128, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, TestXt},
-	traits::{BlakeTwo256, IdentityLookup, One, Zero},
+	traits::{BlakeTwo256, Convert, IdentityLookup, One, Zero},
 	FixedPointNumber,
 };
+use std::cell::RefCell;
 
 pub use currency::testing_constants::{
 	DEFAULT_COLLATERAL_CURRENCY, DEFAULT_NATIVE_CURRENCY, DEFAULT_WRAPPED_CURRENCY,
@@ -374,7 +377,7 @@ impl DiaOracle for MockDiaOracle {
 	fn get_coin_info(
 		blockchain: Vec<u8>,
 		symbol: Vec<u8>,
-	) -> Result<dia_oracle::CoinInfo, sp_runtime::DispatchError> {
+	) -> Result<CoinInfo, sp_runtime::DispatchError> {
 		let key = (blockchain, symbol);
 		let mut result: Option<Data> = None;
 		COINS.with(|c| {
@@ -397,24 +400,22 @@ impl DiaOracle for MockDiaOracle {
 	}
 
 	fn get_value(
-		blockchain: Vec<u8>,
-		symbol: Vec<u8>,
-	) -> Result<dia_oracle::PriceInfo, sp_runtime::DispatchError> {
+		_blockchain: Vec<u8>,
+		_symbol: Vec<u8>,
+	) -> Result<PriceInfo, sp_runtime::DispatchError> {
 		todo!()
 	}
 }
 
 pub struct DataCollector;
 impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
-	fn get(key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+	fn get(_key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
 		todo!()
 	}
 }
-impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
-	for DataCollector
-{
+impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> for DataCollector {
 	fn feed_value(
-		who: AccountId,
+		_who: AccountId,
 		key: Key,
 		value: TimestampedValue<UnsignedFixedPoint, Moment>,
 	) -> sp_runtime::DispatchResult {

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -25,7 +25,7 @@ use sp_std::{convert::TryInto, vec::Vec};
 
 use currency::Amount;
 pub use default_weights::{SubstrateWeight, WeightInfo};
-use orml_oracle::{DataProviderExtended, TimestampedValue};
+use orml_oracle::DataProviderExtended;
 pub use pallet::*;
 pub use primitives::{oracle::Key as OracleKey, CurrencyId, TruncateFixedPointToInt};
 use security::{ErrorCode, StatusCode};
@@ -42,6 +42,11 @@ mod default_weights;
 #[cfg_attr(test, cfg(feature = "testing-utils"))]
 mod tests;
 
+#[cfg(feature = "testing-utils")]
+pub use dia_oracle::{CoinInfo, DiaOracle, PriceInfo};
+#[cfg(feature = "testing-utils")]
+pub use orml_oracle::{DataFeeder, DataProvider, TimestampedValue};
+
 #[cfg(test)]
 #[cfg_attr(test, cfg(feature = "testing-utils"))]
 pub mod mock;
@@ -51,7 +56,6 @@ pub mod types;
 pub mod dia;
 #[cfg(feature = "testing-utils")]
 pub mod oracle_mock;
-use orml_oracle::DataFeeder;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -77,13 +81,13 @@ pub mod pallet {
 
 		type DataProvider: DataProviderExtended<
 			OracleKey,
-			TimestampedValue<Self::UnsignedFixedPoint, Self::Moment>,
+			orml_oracle::TimestampedValue<Self::UnsignedFixedPoint, Self::Moment>,
 		>;
 
 		#[cfg(feature = "testing-utils")]
 		type DataFeedProvider: orml_oracle::DataFeeder<
 			OracleKey,
-			TimestampedValue<Self::UnsignedFixedPoint, Self::Moment>,
+			orml_oracle::TimestampedValue<Self::UnsignedFixedPoint, Self::Moment>,
 			Self::AccountId,
 		>;
 	}
@@ -258,7 +262,8 @@ impl<T: Config> Pallet<T> {
 		let mut oracle_keys: Vec<_> = <OracleKeys<T>>::get();
 
 		for (k, v) in values.clone() {
-			let timestamped = TimestampedValue { timestamp: Self::get_current_time(), value: v };
+			let timestamped =
+				orml_oracle::TimestampedValue { timestamp: Self::get_current_time(), value: v };
 			T::DataFeedProvider::feed_value(oracle.clone(), k.clone(), timestamped)
 				.expect("Expect store value by key");
 			if !oracle_keys.contains(&k) {
@@ -370,7 +375,7 @@ impl<T: Config> Pallet<T> {
 
 	fn get_timestamped(
 		key: &OracleKey,
-	) -> Option<TimestampedValue<T::UnsignedFixedPoint, T::Moment>> {
+	) -> Option<orml_oracle::TimestampedValue<T::UnsignedFixedPoint, T::Moment>> {
 		T::DataProvider::get_no_op(key)
 	}
 }

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -350,6 +350,7 @@ impl<T: Config> Pallet<T> {
 		// Aggregate::<T>::insert(OracleKey::ExchangeRate(currency_id), exchange_rate);
 		// this is useful for benchmark tests
 		//TODO for testing get data from DataProvider as DataFeed trait
+		use sp_std::vec;
 		Self::_feed_values(oracle, vec![((OracleKey::ExchangeRate(currency_id)), exchange_rate)]);
 		Self::recover_from_oracle_offline();
 		Ok(())

--- a/pallets/oracle/src/mock.rs
+++ b/pallets/oracle/src/mock.rs
@@ -26,9 +26,7 @@ pub use primitives::{CurrencyId::Token, TokenSymbol::*};
 use crate::{
 	self as oracle,
 	dia::DiaOracleAdapter,
-	oracle_mock::{
-		MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor, Data,
-	},
+	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
 	Config, Error, OracleKeys,
 };
 
@@ -230,9 +228,6 @@ where
 	});
 }
 
-
-
-
 thread_local! {
 	static COINS: RefCell<Vec<Data>> = RefCell::new(vec![]);
 }
@@ -298,4 +293,3 @@ impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, 
 		Ok(())
 	}
 }
-

--- a/pallets/oracle/src/mock.rs
+++ b/pallets/oracle/src/mock.rs
@@ -27,7 +27,7 @@ use crate::{
 	self as oracle,
 	dia::DiaOracleAdapter,
 	oracle_mock::{
-		DataCollector, MockConvertMoment, MockConvertPrice, MockDiaOracle, MockOracleKeyConvertor,
+		MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor, Data,
 	},
 	Config, Error, OracleKeys,
 };
@@ -229,3 +229,73 @@ where
 		// COINS.write().unwrap().clear();
 	});
 }
+
+
+
+
+thread_local! {
+	static COINS: RefCell<Vec<Data>> = RefCell::new(vec![]);
+}
+
+pub struct MockDiaOracle;
+impl DiaOracle for MockDiaOracle {
+	fn get_coin_info(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<dia_oracle::CoinInfo, sp_runtime::DispatchError> {
+		let key = (blockchain, symbol);
+		let mut result: Option<Data> = None;
+		COINS.with(|c| {
+			let r = c.borrow();
+			for i in &*r {
+				if i.key == key.clone() {
+					result = Some(i.clone());
+					break
+				}
+			}
+		});
+		let Some(result) = result else {
+			return Err(sp_runtime::DispatchError::Other(""));
+		};
+		let mut coin_info = CoinInfo::default();
+		coin_info.price = result.price;
+		coin_info.last_update_timestamp = result.timestamp;
+
+		Ok(coin_info)
+	}
+
+	fn get_value(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<dia_oracle::PriceInfo, sp_runtime::DispatchError> {
+		todo!()
+	}
+}
+
+pub struct DataCollector;
+impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
+	for DataCollector
+{
+	fn feed_value(
+		who: AccountId,
+		key: Key,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		let key = MockOracleKeyConvertor::convert(key).unwrap();
+		let r = value.value.into_inner();
+
+		let data = Data { key, price: r, timestamp: value.timestamp };
+
+		COINS.with(|coins| {
+			let mut r = coins.borrow_mut();
+			r.push(data)
+		});
+		Ok(())
+	}
+}
+

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "testing-utils")]
 // use std::{cell::RefCell, sync::RwLock};
-
 use dia_oracle::{CoinInfo, DiaOracle};
 use orml_oracle::{DataProvider, TimestampedValue};
 use sp_runtime::traits::Convert;

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "testing-utils")]
-use std::{cell::RefCell, sync::RwLock};
+// use std::{cell::RefCell, sync::RwLock};
 
 use dia_oracle::{CoinInfo, DiaOracle};
 use orml_oracle::{DataProvider, TimestampedValue};
@@ -11,78 +11,10 @@ use primitives::{oracle::Key, CurrencyId};
 type Moment = u64;
 
 #[derive(Clone)]
-struct Data {
+pub struct Data {
 	pub key: (Vec<u8>, Vec<u8>),
 	pub price: u128,
 	pub timestamp: u64,
-}
-
-thread_local! {
-	static COINS: RefCell<Vec<Data>> = RefCell::new(vec![]);
-}
-
-pub type AccountId = u64;
-
-pub struct MockDiaOracle;
-impl DiaOracle for MockDiaOracle {
-	fn get_coin_info(
-		blockchain: Vec<u8>,
-		symbol: Vec<u8>,
-	) -> Result<dia_oracle::CoinInfo, sp_runtime::DispatchError> {
-		let key = (blockchain, symbol);
-		let mut result: Option<Data> = None;
-		COINS.with(|c| {
-			let r = c.borrow();
-			for i in &*r {
-				if i.key == key.clone() {
-					result = Some(i.clone());
-					break
-				}
-			}
-		});
-		let Some(result) = result else {
-			return Err(sp_runtime::DispatchError::Other(""));
-		};
-		let mut coin_info = CoinInfo::default();
-		coin_info.price = result.price;
-		coin_info.last_update_timestamp = result.timestamp;
-
-		Ok(coin_info)
-	}
-
-	fn get_value(
-		blockchain: Vec<u8>,
-		symbol: Vec<u8>,
-	) -> Result<dia_oracle::PriceInfo, sp_runtime::DispatchError> {
-		todo!()
-	}
-}
-
-pub struct DataCollector;
-impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
-	fn get(key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
-		todo!()
-	}
-}
-impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
-	for DataCollector
-{
-	fn feed_value(
-		who: AccountId,
-		key: Key,
-		value: TimestampedValue<UnsignedFixedPoint, Moment>,
-	) -> sp_runtime::DispatchResult {
-		let key = MockOracleKeyConvertor::convert(key).unwrap();
-		let r = value.value.into_inner();
-
-		let data = Data { key, price: r, timestamp: value.timestamp };
-
-		COINS.with(|coins| {
-			let mut r = coins.borrow_mut();
-			r.push(data)
-		});
-		Ok(())
-	}
 }
 
 pub struct MockOracleKeyConvertor;

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -8,6 +8,7 @@ use sp_arithmetic::{FixedI128, FixedU128};
 pub type UnsignedFixedPoint = FixedU128;
 use primitives::{oracle::Key, CurrencyId};
 type Moment = u64;
+use sp_std::{vec, vec::Vec};
 
 #[derive(Clone)]
 pub struct Data {

--- a/pallets/redeem/src/mock.rs
+++ b/pallets/redeem/src/mock.rs
@@ -6,10 +6,13 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{
-		DataCollector, MockConvertMoment, MockConvertPrice, MockDiaOracle, MockOracleKeyConvertor,
-	},
+	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
+use primitives::oracle::Key;
+use sp_runtime::traits::Convert;
+use std::cell::RefCell;
+
 use orml_traits::parameter_type_with_key;
 pub use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -403,4 +406,68 @@ where
 		System::set_block_number(1);
 		test();
 	});
+}
+
+thread_local! {
+	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+}
+
+pub struct MockDiaOracle;
+impl DiaOracle for MockDiaOracle {
+	fn get_coin_info(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<CoinInfo, sp_runtime::DispatchError> {
+		let key = (blockchain, symbol);
+		let mut result: Option<Data> = None;
+		COINS.with(|c| {
+			let r = c.borrow();
+			for i in &*r {
+				if i.key == key.clone() {
+					result = Some(i.clone());
+					break
+				}
+			}
+		});
+		let Some(result) = result else {
+			return Err(sp_runtime::DispatchError::Other(""));
+		};
+		let mut coin_info = CoinInfo::default();
+		coin_info.price = result.price;
+		coin_info.last_update_timestamp = result.timestamp;
+
+		Ok(coin_info)
+	}
+
+	fn get_value(
+		_blockchain: Vec<u8>,
+		_symbol: Vec<u8>,
+	) -> Result<PriceInfo, sp_runtime::DispatchError> {
+		todo!()
+	}
+}
+
+pub struct DataCollector;
+impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(_key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> for DataCollector {
+	fn feed_value(
+		_who: AccountId,
+		key: Key,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		let key = MockOracleKeyConvertor::convert(key).unwrap();
+		let r = value.value.into_inner();
+
+		let data = Data { key, price: r, timestamp: value.timestamp };
+
+		COINS.with(|coins| {
+			let mut r = coins.borrow_mut();
+			r.push(data)
+		});
+		Ok(())
+	}
 }

--- a/pallets/replace/src/mock.rs
+++ b/pallets/replace/src/mock.rs
@@ -6,17 +6,18 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{
-		DataCollector, MockConvertMoment, MockConvertPrice, MockDiaOracle, MockOracleKeyConvertor,
-	},
+	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use orml_traits::parameter_type_with_key;
+use primitives::oracle::Key;
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, TestXt},
-	traits::{BlakeTwo256, IdentityLookup, One, Zero},
+	traits::{BlakeTwo256, Convert, IdentityLookup, One, Zero},
 };
+use std::cell::RefCell;
 
 pub use currency::{
 	testing_constants::{
@@ -379,4 +380,68 @@ where
 		Security::set_active_block_number(1);
 		test();
 	});
+}
+
+thread_local! {
+	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+}
+
+pub struct MockDiaOracle;
+impl DiaOracle for MockDiaOracle {
+	fn get_coin_info(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<CoinInfo, sp_runtime::DispatchError> {
+		let key = (blockchain, symbol);
+		let mut result: Option<Data> = None;
+		COINS.with(|c| {
+			let r = c.borrow();
+			for i in &*r {
+				if i.key == key.clone() {
+					result = Some(i.clone());
+					break
+				}
+			}
+		});
+		let Some(result) = result else {
+			return Err(sp_runtime::DispatchError::Other(""));
+		};
+		let mut coin_info = CoinInfo::default();
+		coin_info.price = result.price;
+		coin_info.last_update_timestamp = result.timestamp;
+
+		Ok(coin_info)
+	}
+
+	fn get_value(
+		_blockchain: Vec<u8>,
+		_symbol: Vec<u8>,
+	) -> Result<PriceInfo, sp_runtime::DispatchError> {
+		todo!()
+	}
+}
+
+pub struct DataCollector;
+impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(_key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> for DataCollector {
+	fn feed_value(
+		_who: AccountId,
+		key: Key,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		let key = MockOracleKeyConvertor::convert(key).unwrap();
+		let r = value.value.into_inner();
+
+		let data = Data { key, price: r, timestamp: value.timestamp };
+
+		COINS.with(|coins| {
+			let mut r = coins.borrow_mut();
+			r.push(data)
+		});
+		Ok(())
+	}
 }

--- a/pallets/vault-registry/src/mock.rs
+++ b/pallets/vault-registry/src/mock.rs
@@ -6,17 +6,18 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{
-		DataCollector, MockConvertMoment, MockConvertPrice, MockDiaOracle, MockOracleKeyConvertor,
-	},
+	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use orml_traits::parameter_type_with_key;
+use primitives::oracle::Key;
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, TestXt},
-	traits::{BlakeTwo256, IdentityLookup, One, Zero},
+	traits::{BlakeTwo256, Convert, IdentityLookup, One, Zero},
 };
+use std::cell::RefCell;
 
 pub use currency::testing_constants::{
 	DEFAULT_COLLATERAL_CURRENCY, DEFAULT_NATIVE_CURRENCY, DEFAULT_WRAPPED_CURRENCY,
@@ -363,4 +364,68 @@ where
 		.unwrap();
 		test()
 	})
+}
+
+thread_local! {
+	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+}
+
+pub struct MockDiaOracle;
+impl DiaOracle for MockDiaOracle {
+	fn get_coin_info(
+		blockchain: Vec<u8>,
+		symbol: Vec<u8>,
+	) -> Result<CoinInfo, sp_runtime::DispatchError> {
+		let key = (blockchain, symbol);
+		let mut result: Option<Data> = None;
+		COINS.with(|c| {
+			let r = c.borrow();
+			for i in &*r {
+				if i.key == key.clone() {
+					result = Some(i.clone());
+					break
+				}
+			}
+		});
+		let Some(result) = result else {
+			return Err(sp_runtime::DispatchError::Other(""));
+		};
+		let mut coin_info = CoinInfo::default();
+		coin_info.price = result.price;
+		coin_info.last_update_timestamp = result.timestamp;
+
+		Ok(coin_info)
+	}
+
+	fn get_value(
+		_blockchain: Vec<u8>,
+		_symbol: Vec<u8>,
+	) -> Result<PriceInfo, sp_runtime::DispatchError> {
+		todo!()
+	}
+}
+
+pub struct DataCollector;
+impl DataProvider<Key, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(_key: &Key) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> for DataCollector {
+	fn feed_value(
+		_who: AccountId,
+		key: Key,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		let key = MockOracleKeyConvertor::convert(key).unwrap();
+		let r = value.value.into_inner();
+
+		let data = Data { key, price: r, timestamp: value.timestamp };
+
+		COINS.with(|coins| {
+			let mut r = coins.borrow_mut();
+			r.push(data)
+		});
+		Ok(())
+	}
 }

--- a/testchain/runtime/Cargo.toml
+++ b/testchain/runtime/Cargo.toml
@@ -81,7 +81,6 @@ hex = "0.4.2"
 mocktopus = "0.8.0"
 pretty_assertions = "0.7.2"
 serde_json = "1.0"
-oracle = {path = "../../pallets/oracle", features = ['testing-utils']}
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36"}

--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -16,9 +16,8 @@ use frame_support::{
 use codec::Encode;
 pub use dia_oracle::dia::*;
 pub use frame_system::Call as SystemCall;
-#[cfg(feature = "test")]
-use oracle::oracle_mock::DataCollector;
-use oracle::{dia::DiaOracleAdapter, OracleKey};
+
+use oracle::{dia::DiaOracleAdapter, OracleKey, TimestampedValue};
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::{currency::MutationHooks, parameter_type_with_key};
 pub use pallet_balances::Call as BalancesCall;
@@ -475,6 +474,25 @@ impl Convert<u64, Option<Moment>> for ConvertMoment {
 	}
 }
 
+use oracle::DataProvider;
+pub struct DataCollector;
+impl DataProvider<OracleKey, TimestampedValue<UnsignedFixedPoint, Moment>> for DataCollector {
+	fn get(key: &OracleKey) -> Option<TimestampedValue<UnsignedFixedPoint, Moment>> {
+		todo!()
+	}
+}
+impl orml_oracle::DataFeeder<OracleKey, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId>
+	for DataCollector
+{
+	fn feed_value(
+		who: AccountId,
+		key: OracleKey,
+		value: TimestampedValue<UnsignedFixedPoint, Moment>,
+	) -> sp_runtime::DispatchResult {
+		todo!()
+	}
+}
+
 impl oracle::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
@@ -487,7 +505,7 @@ impl oracle::Config for Runtime {
 		ConvertMoment,
 	>;
 
-	#[cfg(feature = "test")]
+	//#[cfg(test)]
 	type DataFeedProvider = DataCollector;
 }
 


### PR DESCRIPTION
- solve issue with `thead_local` in tests. When mock `DataFeeder` and `DataProviderExtended`
- solve issue for `spacewalk-testchain-runtime` with additional config type `DataFeeder`
- cargo` test --all --all-features`  build and passed. only one tests failed : `test_subxt_processing_events_after_dispatch_error`