### PR TITLE
Remove integration tests related to oracle feed_values extrinsic

### DIFF
--- a/clients/runtime/src/tests.rs
+++ b/clients/runtime/src/tests.rs
@@ -80,34 +80,6 @@ async fn test_too_low_priority_matching() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_subxt_processing_events_after_dispatch_error() {
-	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
-	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
-
-	let oracle_provider = setup_provider(client.clone(), AccountKeyring::Bob).await;
-	let invalid_oracle = setup_provider(client, AccountKeyring::Dave).await;
-
-	let event_listener = crate::integration::assert_event::<FeedValuesEvent, _>(
-		Duration::from_secs(80),
-		parachain_rpc.clone(),
-		|_| true,
-	);
-
-	let key = OracleKey::ExchangeRate(DEFAULT_TESTING_CURRENCY);
-	let exchange_rate = FixedU128::saturating_from_rational(1u128, 100u128);
-
-	let result = tokio::join!(
-		event_listener,
-		invalid_oracle.feed_values(vec![(key.clone(), exchange_rate)]),
-		oracle_provider.feed_values(vec![(key, exchange_rate)])
-	);
-
-	// ensure first set_exchange_rate failed and second succeeded.
-	result.1.unwrap_err();
-	result.2.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_register_vault() {
 	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
 	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;


### PR DESCRIPTION
- `cargo test --all --all-features` passed successfully 