### PR TITLE
Oracle pallet begin block improve parachain status

### DIFF
--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use crate::metadata::runtime_types::security::types::StatusCode;
 use frame_support::assert_ok;
 use futures::{future::Either, pin_mut, Future, FutureExt, SinkExt, StreamExt};
 use primitives::DiaOracleKeyConvertor;
@@ -24,7 +25,7 @@ use subxt_client::{
 
 use crate::{
 	rpc::{OraclePallet, VaultRegistryPallet},
-	CurrencyId, FixedU128, SpacewalkParachain, SpacewalkSigner,
+	CurrencyId, FixedU128, SecurityPallet, SpacewalkParachain, SpacewalkSigner,
 };
 use primitives::oracle::Key as OracleKey;
 
@@ -82,6 +83,27 @@ pub async fn setup_provider(client: SubxtClient, key: AccountKeyring) -> Spacewa
 const SLEEP_DURATION: Duration = Duration::from_millis(1000);
 const TIMEOUT_DURATION: Duration = Duration::from_secs(20);
 
+async fn wait_for_aggregate(parachain_rpc: &SpacewalkParachain) {
+	while true {
+		let status = parachain_rpc.get_parachain_status().await;
+		match status {
+			Ok(status_code) => match status_code {
+				StatusCode::Running => {
+					return
+				},
+				StatusCode::Shutdown => {},
+				StatusCode::Error => {},
+			},
+			Err(e) => {},
+		}
+		sleep(SLEEP_DURATION).await;
+	}
+}
+
+pub async fn wait(parachain_rpc: &SpacewalkParachain) {
+	assert_ok!(timeout(TIMEOUT_DURATION, wait_for_aggregate(parachain_rpc)).await);
+}
+
 pub async fn set_exchange_rate_and_wait(
 	parachain_rpc: &SpacewalkParachain,
 	currency_id: CurrencyId,
@@ -99,6 +121,12 @@ pub async fn set_stellar_fees(parachain_rpc: &SpacewalkParachain, value: FixedU1
 	let converted_key = DiaOracleKeyConvertor::convert(key.clone()).unwrap();
 	assert_ok!(parachain_rpc.feed_values(vec![(converted_key, value)]).await);
 	parachain_rpc.manual_seal().await;
+}
+
+pub async fn get_exchange_rate(parachain_rpc: &SpacewalkParachain, currency_id: CurrencyId) {
+	let key = OracleKey::ExchangeRate(currency_id);
+	let converted_key = DiaOracleKeyConvertor::convert(key.clone()).unwrap();
+	assert_ok!(parachain_rpc.get_exchange_rate(converted_key.0, converted_key.1).await);
 }
 
 /// calculate how much collateral the vault requires to accept an issue of the given size

--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -88,9 +88,7 @@ async fn wait_for_aggregate(parachain_rpc: &SpacewalkParachain) {
 		let status = parachain_rpc.get_parachain_status().await;
 		match status {
 			Ok(status_code) => match status_code {
-				StatusCode::Running => {
-					return
-				},
+				StatusCode::Running => return,
 				StatusCode::Shutdown => {},
 				StatusCode::Error => {},
 			},

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -866,15 +866,18 @@ impl OraclePallet for SpacewalkParachain {
 			},
 			Err(err) => {},
 		}
-
+		if time == 0 {
+			time = u64::MAX / 2 - 10; // by some reason timestamp storage return 0 and thefore spacewalk pallets
+			              // go to offline status because not all OracleKeys has prices during
+			              // begin_block function in oracle spacewalk.
+		}
 		for ((blockchain, symbol), price) in values {
 			let coin_info = CoinInfo {
 				symbol: symbol.clone(),
 				name: vec![],
 				blockchain: blockchain.clone(),
 				supply: 0,
-				// last_update_timestamp: time,
-				last_update_timestamp: u64::MAX / 2 - 10,
+				last_update_timestamp: time,
 				price: price.into_inner(),
 			};
 			coin_infos.push(((blockchain, symbol), coin_info));

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -803,6 +803,8 @@ pub trait OraclePallet {
 		symbol: Vec<u8>,
 	) -> Result<FixedU128, Error>;
 
+	async fn get_oracle_keys(&self) -> Result<Vec<OracleKey>, Error>;
+
 	async fn feed_values(&self, values: Vec<((Vec<u8>, Vec<u8>), FixedU128)>) -> Result<(), Error>;
 
 	async fn wrapped_to_collateral(
@@ -838,6 +840,17 @@ impl OraclePallet for SpacewalkParachain {
 		.map(|coin_info| FixedU128::from_inner(coin_info.price))
 	}
 
+	/// Returns the last exchange rate in planck per satoshis, the time at which it was set
+	/// and the configured max delay.
+	async fn get_oracle_keys(&self) -> Result<Vec<OracleKey>, Error> {
+		let keys = self.query_finalized_or_error(metadata::storage().oracle().oracle_keys()).await;
+		let result = match keys {
+			Ok(i) => Ok(i),
+			Err(e) => Err(e),
+		};
+		return result
+	}
+
 	/// Sets the current exchange rate (i.e. DOT/XLM)
 	///
 	/// # Arguments
@@ -860,7 +873,8 @@ impl OraclePallet for SpacewalkParachain {
 				name: vec![],
 				blockchain: blockchain.clone(),
 				supply: 0,
-				last_update_timestamp: time,
+				// last_update_timestamp: time,
+				last_update_timestamp: u64::MAX / 2 - 10,
 				price: price.into_inner(),
 			};
 			coin_infos.push(((blockchain, symbol), coin_info));

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -176,8 +176,6 @@ where
 	.await;
 	set_stellar_fees(&parachain_rpc, FixedU128::from(1)).await;
 
-	wait(&parachain_rpc).await;
-
 	let vault_provider = setup_provider(client.clone(), AccountKeyring::Charlie).await;
 	let vault_id = VaultId::new(
 		AccountKeyring::Charlie.into(),

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -221,7 +221,9 @@ impl<T: Config> Pallet<T> {
 		}
 
 		let current_status_is_online = Self::is_oracle_online();
-		let new_status_is_online = oracle_keys.len() > 0 && updated_items_len > 0;
+		let new_status_is_online = oracle_keys.len() > 0 &&
+			updated_items_len > 0 &&
+			updated_items_len == oracle_keys.len();
 
 		if current_status_is_online != new_status_is_online {
 			if new_status_is_online {


### PR DESCRIPTION
Solved the actual problem with vault integration tests.
By some reason `timestamp storage` return **0** and therefore `spacewalk pallets`
go to offline status because not all `OracleKeys` has prices during
begin_block function in oracle spacewalk.