### PR TITLE
fix unit tests using hash map instead of vector

### DIFF
--- a/pallets/nomination/src/mock.rs
+++ b/pallets/nomination/src/mock.rs
@@ -6,7 +6,7 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	oracle_mock::{Data, DataKey, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
 	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use orml_traits::parameter_type_with_key;
@@ -369,7 +369,7 @@ where
 }
 
 thread_local! {
-	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+	static COINS: RefCell<std::collections::HashMap<DataKey, Data>> = RefCell::new(std::collections::HashMap::<DataKey, Data>::new());
 }
 
 pub struct MockDiaOracle;
@@ -379,15 +379,17 @@ impl DiaOracle for MockDiaOracle {
 		symbol: Vec<u8>,
 	) -> Result<CoinInfo, sp_runtime::DispatchError> {
 		let key = (blockchain, symbol);
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
 		let mut result: Option<Data> = None;
 		COINS.with(|c| {
 			let r = c.borrow();
-			for i in &*r {
-				if i.key == key.clone() {
-					result = Some(i.clone());
-					break
-				}
-			}
+
+			let hash_set = &*r;
+			let o = hash_set.get(&data_key);
+			match o {
+				Some(i) => result = Some(i.clone()),
+				None => {},
+			};
 		});
 		let Some(result) = result else {
 			return Err(sp_runtime::DispatchError::Other(""));
@@ -427,11 +429,12 @@ impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> fo
 		let key = MockOracleKeyConvertor::convert(key).unwrap();
 		let r = value.value.into_inner();
 
-		let data = Data { key, price: r, timestamp: value.timestamp };
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
+		let data = Data { key: data_key.clone(), price: r, timestamp: value.timestamp };
 
 		COINS.with(|coins| {
 			let mut r = coins.borrow_mut();
-			r.push(data)
+			r.insert(data_key, data);
 		});
 		Ok(())
 	}

--- a/pallets/oracle/src/mock.rs
+++ b/pallets/oracle/src/mock.rs
@@ -228,10 +228,8 @@ where
 	});
 }
 
-use std::collections::HashMap;
-
 thread_local! {
-	static COINS: RefCell<HashMap<DataKey, Data>> = RefCell::new(HashMap::<DataKey, Data>::new());
+	static COINS: RefCell<std::collections::HashMap<DataKey, Data>> = RefCell::new(std::collections::HashMap::<DataKey, Data>::new());
 }
 
 pub struct MockDiaOracle;
@@ -291,9 +289,9 @@ impl orml_oracle::DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, 
 		value: TimestampedValue<UnsignedFixedPoint, Moment>,
 	) -> sp_runtime::DispatchResult {
 		let key = MockOracleKeyConvertor::convert(key).unwrap();
-		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
 		let r = value.value.into_inner();
 
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
 		let data = Data { key: data_key.clone(), price: r, timestamp: value.timestamp };
 
 		COINS.with(|coins| {

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -10,9 +10,14 @@ use primitives::{oracle::Key, CurrencyId};
 type Moment = u64;
 use sp_std::{vec, vec::Vec};
 
-#[derive(Clone)]
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+pub struct DataKey {
+	pub blockchain: Vec<u8>,
+	pub symbol: Vec<u8>,
+}
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
 pub struct Data {
-	pub key: (Vec<u8>, Vec<u8>),
+	pub key: DataKey,
 	pub price: u128,
 	pub timestamp: u64,
 }

--- a/pallets/oracle/src/tests.rs
+++ b/pallets/oracle/src/tests.rs
@@ -68,88 +68,94 @@ mod oracle_offline_detection {
 		));
 		mine_block();
 	}
+	fn feed_value_with_value(currency_id: CurrencyId, oracle: SubmittingOracle, value: u128) {
+		assert_ok!(Oracle::_feed_values(
+			1,
+			vec![(OracleKey::ExchangeRate(currency_id), FixedU128::from(value))]
+		));
+		mine_block();
+	}
 
-	// //TODO
-	// #[test]
-	// fn basic_oracle_offline_logic() {
-	// 	run_test(|| {
-	// 		Oracle::get_max_delay.mock_safe(move || MockResult::Return(10));
+	#[test]
+	fn basic_oracle_offline_logic() {
+		run_test(|| {
+			Oracle::get_max_delay.mock_safe(move || MockResult::Return(10));
 
-	// 		set_time(0);
-	// 		feed_value(CurrencyId::XCM(DOT), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			set_time(0);
+			feed_value(CurrencyId::XCM(DOT), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
-	// 		set_time(5);
-	// 		feed_value(CurrencyId::XCM(KSM), OracleA);
+			set_time(5);
+			feed_value(CurrencyId::XCM(KSM), OracleA);
 
-	// 		// DOT expires after block 10
-	// 		set_time(10);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
-	// 		set_time(11);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			// DOT expires after block 10
+			set_time(10);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			set_time(11);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
-	// 		// feeding KSM makes no difference
-	// 		feed_value(CurrencyId::XCM(KSM), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			// feeding KSM makes no difference
+			feed_value(CurrencyId::XCM(KSM), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
-	// 		// feeding DOT makes it running again
-	// 		feed_value(CurrencyId::XCM(DOT), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			// feeding DOT makes it running again
+			feed_value_with_value(CurrencyId::XCM(DOT), OracleA, 7);
+			set_time(15);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
-	// 		// KSM expires after t=21 (it was set at t=11)
-	// 		set_time(21);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
-	// 		set_time(22);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			// KSM expires after t=21 (it was set at t=11)
+			set_time(21);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			set_time(22);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
-	// 		// check that status remains ERROR until BOTH currencies have been updated
-	// 		set_time(100);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
-	// 		feed_value(CurrencyId::XCM(DOT), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
-	// 		feed_value(CurrencyId::XCM(KSM), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
-	// 	});
-	// }
+			// check that status remains ERROR until BOTH currencies have been updated
+			set_time(100);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			feed_value(CurrencyId::XCM(DOT), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			feed_value(CurrencyId::XCM(KSM), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+		});
+	}
 
-	// //TODO
-	// #[test]
-	// fn oracle_offline_logic_with_multiple_oracles() {
-	// 	run_test(|| {
-	// 		Oracle::get_max_delay.mock_safe(move || MockResult::Return(10));
+	#[test]
+	fn oracle_offline_logic_with_multiple_oracles() {
+		run_test(|| {
+			Oracle::get_max_delay.mock_safe(move || MockResult::Return(10));
 
-	// 		set_time(0);
-	// 		feed_value(Token(DOT), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			set_time(0);
+			feed_value(CurrencyId::XCM(DOT), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
-	// 		set_time(5);
-	// 		feed_value(Token(KSM), OracleA);
+			set_time(5);
+			feed_value(CurrencyId::XCM(KSM), OracleA);
 
-	// 		set_time(7);
-	// 		feed_value(Token(DOT), OracleB);
+			set_time(7);
+			feed_value(CurrencyId::XCM(DOT), OracleB);
 
-	// 		// OracleA's DOT submission expires at 10, but OracleB's only at 17. However, KSM
-	// 		// expires at 15:
-	// 		set_time(15);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
-	// 		set_time(16);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			// OracleA's DOT submission expires at 10, but OracleB's only at 17. However, KSM
+			// expires at 15:
+			set_time(15);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			set_time(16);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
-	// 		// Feeding KSM brings it back online
-	// 		feed_value(Token(KSM), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			// Feeding KSM brings it back online
+			feed_value(CurrencyId::XCM(KSM), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
-	// 		// check that status is set of ERROR when both oracle's DOT submission expired
-	// 		set_time(17);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
-	// 		set_time(18);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
+			// check that status is set of ERROR when both oracle's DOT submission expired
+			set_time(17);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+			set_time(18);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
-	// 		// A DOT submission by any oracle brings it back online
-	// 		feed_value(Token(DOT), OracleA);
-	// 		assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
-	// 	});
-	// }
+			// A DOT submission by any oracle brings it back online
+			feed_value(CurrencyId::XCM(DOT), OracleA);
+			assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
+		});
+	}
 }
 
 #[test]

--- a/pallets/redeem/src/mock.rs
+++ b/pallets/redeem/src/mock.rs
@@ -6,7 +6,7 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	oracle_mock::{Data, DataKey, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
 	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use primitives::oracle::Key;
@@ -401,7 +401,7 @@ where
 }
 
 thread_local! {
-	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+	static COINS: RefCell<std::collections::HashMap<DataKey, Data>> = RefCell::new(std::collections::HashMap::<DataKey, Data>::new());
 }
 
 pub struct MockDiaOracle;
@@ -411,15 +411,17 @@ impl DiaOracle for MockDiaOracle {
 		symbol: Vec<u8>,
 	) -> Result<CoinInfo, sp_runtime::DispatchError> {
 		let key = (blockchain, symbol);
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
 		let mut result: Option<Data> = None;
 		COINS.with(|c| {
 			let r = c.borrow();
-			for i in &*r {
-				if i.key == key.clone() {
-					result = Some(i.clone());
-					break
-				}
-			}
+
+			let hash_set = &*r;
+			let o = hash_set.get(&data_key);
+			match o {
+				Some(i) => result = Some(i.clone()),
+				None => {},
+			};
 		});
 		let Some(result) = result else {
 			return Err(sp_runtime::DispatchError::Other(""));
@@ -459,11 +461,12 @@ impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> fo
 		let key = MockOracleKeyConvertor::convert(key).unwrap();
 		let r = value.value.into_inner();
 
-		let data = Data { key, price: r, timestamp: value.timestamp };
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
+		let data = Data { key: data_key.clone(), price: r, timestamp: value.timestamp };
 
 		COINS.with(|coins| {
 			let mut r = coins.borrow_mut();
-			r.push(data)
+			r.insert(data_key, data);
 		});
 		Ok(())
 	}

--- a/pallets/replace/src/mock.rs
+++ b/pallets/replace/src/mock.rs
@@ -6,7 +6,7 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	oracle_mock::{Data, DataKey, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
 	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use orml_traits::parameter_type_with_key;
@@ -383,7 +383,7 @@ where
 }
 
 thread_local! {
-	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+	static COINS: RefCell<std::collections::HashMap<DataKey, Data>> = RefCell::new(std::collections::HashMap::<DataKey, Data>::new());
 }
 
 pub struct MockDiaOracle;
@@ -393,15 +393,17 @@ impl DiaOracle for MockDiaOracle {
 		symbol: Vec<u8>,
 	) -> Result<CoinInfo, sp_runtime::DispatchError> {
 		let key = (blockchain, symbol);
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
 		let mut result: Option<Data> = None;
 		COINS.with(|c| {
 			let r = c.borrow();
-			for i in &*r {
-				if i.key == key.clone() {
-					result = Some(i.clone());
-					break
-				}
-			}
+
+			let hash_set = &*r;
+			let o = hash_set.get(&data_key);
+			match o {
+				Some(i) => result = Some(i.clone()),
+				None => {},
+			};
 		});
 		let Some(result) = result else {
 			return Err(sp_runtime::DispatchError::Other(""));
@@ -441,11 +443,12 @@ impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> fo
 		let key = MockOracleKeyConvertor::convert(key).unwrap();
 		let r = value.value.into_inner();
 
-		let data = Data { key, price: r, timestamp: value.timestamp };
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
+		let data = Data { key: data_key.clone(), price: r, timestamp: value.timestamp };
 
 		COINS.with(|coins| {
 			let mut r = coins.borrow_mut();
-			r.push(data)
+			r.insert(data_key, data);
 		});
 		Ok(())
 	}

--- a/pallets/vault-registry/src/mock.rs
+++ b/pallets/vault-registry/src/mock.rs
@@ -6,7 +6,7 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use oracle::{
 	dia::DiaOracleAdapter,
-	oracle_mock::{Data, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
+	oracle_mock::{Data, DataKey, MockConvertMoment, MockConvertPrice, MockOracleKeyConvertor},
 	CoinInfo, DataFeeder, DataProvider, DiaOracle, PriceInfo, TimestampedValue,
 };
 use orml_traits::parameter_type_with_key;
@@ -367,7 +367,7 @@ where
 }
 
 thread_local! {
-	static COINS: std::cell::RefCell<Vec<Data>>  = RefCell::new(vec![]);
+	static COINS: RefCell<std::collections::HashMap<DataKey, Data>> = RefCell::new(std::collections::HashMap::<DataKey, Data>::new());
 }
 
 pub struct MockDiaOracle;
@@ -377,15 +377,17 @@ impl DiaOracle for MockDiaOracle {
 		symbol: Vec<u8>,
 	) -> Result<CoinInfo, sp_runtime::DispatchError> {
 		let key = (blockchain, symbol);
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
 		let mut result: Option<Data> = None;
 		COINS.with(|c| {
 			let r = c.borrow();
-			for i in &*r {
-				if i.key == key.clone() {
-					result = Some(i.clone());
-					break
-				}
-			}
+
+			let hash_set = &*r;
+			let o = hash_set.get(&data_key);
+			match o {
+				Some(i) => result = Some(i.clone()),
+				None => {},
+			};
 		});
 		let Some(result) = result else {
 			return Err(sp_runtime::DispatchError::Other(""));
@@ -425,11 +427,12 @@ impl DataFeeder<Key, TimestampedValue<UnsignedFixedPoint, Moment>, AccountId> fo
 		let key = MockOracleKeyConvertor::convert(key).unwrap();
 		let r = value.value.into_inner();
 
-		let data = Data { key, price: r, timestamp: value.timestamp };
+		let data_key = DataKey { blockchain: key.0.clone(), symbol: key.1.clone() };
+		let data = Data { key: data_key.clone(), price: r, timestamp: value.timestamp };
 
 		COINS.with(|coins| {
 			let mut r = coins.borrow_mut();
-			r.push(data)
+			r.insert(data_key, data);
 		});
 		Ok(())
 	}


### PR DESCRIPTION
Some unit tests foes not work because mock `thead_local` variable contains `Vec` of prices instead of `HashMap`
and therefore after updates price get function take the first(old) element in vector instead of a new value(last value in vector).