### PR TITLE
242 - unsafe integer cast for `BalanceConversion`'s `StaticLookUp` implementation

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -489,7 +489,7 @@ create_currency_id! {
 		PHA("Phala", 10) = 14,
 		ZTG("Zeitgeist", 10) = 15,
 		USD("Statemine", 10) = 16,
-		
+
 		DOT("Polkadot", 10) = 20,
 	}
 }
@@ -696,7 +696,10 @@ impl StaticLookup for BalanceConversion {
 	}
 
 	fn unlookup(stellar_stroops: Self::Target) -> Self::Source {
-		(stellar_stroops * CONVERSION_RATE as i64) as u128
+		let conversion_rate = i64::try_from(CONVERSION_RATE).unwrap_or(i64::MAX);
+
+		let value = stellar_stroops * conversion_rate;
+		u128::try_from(value).unwrap_or(0)
 	}
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -698,7 +698,7 @@ impl StaticLookup for BalanceConversion {
 	fn unlookup(stellar_stroops: Self::Target) -> Self::Source {
 		let conversion_rate = i64::try_from(CONVERSION_RATE).unwrap_or(i64::MAX);
 
-		let value = stellar_stroops * conversion_rate;
+		let value = stellar_stroops.saturating_mul(conversion_rate);
 		u128::try_from(value).unwrap_or(0)
 	}
 }

--- a/primitives/src/tests.rs
+++ b/primitives/src/tests.rs
@@ -161,6 +161,9 @@ fn test_balance_convr() {
 
 	let lookup_orig = BalanceConversion::unlookup(balance_lookup);
 	assert_eq!(lookup_orig, balance);
+
+	let balance_unlookup = BalanceConversion::unlookup(i64::MIN);
+	assert_eq!(balance_unlookup, 0);
 }
 
 #[test]


### PR DESCRIPTION
This is item #5 of [#242](https://github.com/pendulum-chain/spacewalk/issues/242)
if conversion rate is too big for i64, set it to what its max is.
if the i64 value reaches negative, make it zero for u128.

^ Unless that's the wrong approach?

