### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -26,6 +26,10 @@ jobs:
       SCCACHE_DIR: ${{ matrix.sccache-path }}
 
     steps:
+      - name: Freeing up more disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - uses: actions/checkout@v2
 
       - name: Install sccache (ubuntu-latest)

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -836,20 +836,13 @@ impl OraclePallet for SpacewalkParachain {
 	/// * `value` - the current exchange rate
 	async fn feed_values(&self, values: Vec<((Vec<u8>, Vec<u8>), FixedU128)>) -> Result<(), Error> {
 		use crate::metadata::runtime_types::dia_oracle::dia::CoinInfo;
+
+		let now = std::time::SystemTime::now();
+		let since_the_epoch =
+			now.duration_since(std::time::UNIX_EPOCH).expect("Time went backwards");
+		let time = since_the_epoch.as_secs();
+
 		let mut coin_infos = vec![];
-		let timestamp = self.query_finalized_or_error(metadata::storage().timestamp().now()).await;
-		let mut time = 0;
-		match timestamp {
-			Ok(o) => {
-				time = o as u64;
-			},
-			Err(_) => {},
-		}
-		if time == 0 {
-			time = u64::MAX / 2 - 10; // by some reason timestamp storage return 0 and thefore spacewalk pallets
-			              // go to offline status because not all OracleKeys has prices during
-			              // begin_block function in oracle spacewalk.
-		}
 		for ((blockchain, symbol), price) in values {
 			let coin_info = CoinInfo {
 				symbol: symbol.clone(),

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -138,13 +138,15 @@ where
 	set_exchange_rate_and_wait(
 		&parachain_rpc,
 		DEFAULT_TESTING_CURRENCY,
-		FixedU128::from(100000000),
+		// Set exchange rate to 1:1 with USD
+		FixedU128::saturating_from_rational(1u128, 1u128),
 	)
 	.await;
 	set_exchange_rate_and_wait(
 		&parachain_rpc,
 		DEFAULT_WRAPPED_CURRENCY,
-		FixedU128::saturating_from_rational(1u128, 1u128),
+		// Set exchange rate to 10:1 with USD
+		FixedU128::saturating_from_rational(1u128, 10u128),
 	)
 	.await;
 
@@ -164,13 +166,15 @@ where
 	set_exchange_rate_and_wait(
 		&parachain_rpc,
 		DEFAULT_TESTING_CURRENCY,
-		FixedU128::from(100000000),
+		// Set exchange rate to 1:1 with USD
+		FixedU128::saturating_from_rational(1u128, 1u128),
 	)
 	.await;
 	set_exchange_rate_and_wait(
 		&parachain_rpc,
 		DEFAULT_WRAPPED_CURRENCY,
-		FixedU128::saturating_from_rational(1u128, 1u128),
+		// Set exchange rate to 10:1 with USD
+		FixedU128::saturating_from_rational(1u128, 10u128),
 	)
 	.await;
 

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -104,6 +104,7 @@ impl Convert<u128, Option<FixedU128>> for MockConvertPrice {
 pub struct MockConvertMoment;
 impl Convert<u64, Option<u64>> for MockConvertMoment {
 	fn convert(moment: u64) -> Option<u64> {
-		Some(moment)
+		// Convert milliseconds to seconds
+		Some(moment * 1000)
 	}
 }

--- a/pallets/oracle/src/oracle_mock.rs
+++ b/pallets/oracle/src/oracle_mock.rs
@@ -104,7 +104,6 @@ impl Convert<u128, Option<FixedU128>> for MockConvertPrice {
 pub struct MockConvertMoment;
 impl Convert<u64, Option<u64>> for MockConvertMoment {
 	fn convert(moment: u64) -> Option<u64> {
-		// Convert milliseconds to seconds
-		Some(moment * 1000)
+		Some(moment)
 	}
 }


### PR DESCRIPTION
This PR fixes the currently failing integration tests. They were broken because of the faulty timestamp that we passed in the `feed_values` function of the integration tests.

I also decided to change the exchange rates of the assets we set for the integration tests. This is not necessary but I decided to change them to make them more 'realistic'.