### PR TITLE
301 trim stellar secret key before using it in vault client

### DIFF
--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -344,8 +344,10 @@ impl VaultService {
 
 		let stellar_vault_secret_key =
 			fs::read_to_string(&config.stellar_vault_secret_key_filepath)?;
-		let stellar_wallet =
-			StellarWallet::from_secret_encoded(&stellar_vault_secret_key, is_public_network)?;
+		let stellar_wallet = StellarWallet::from_secret_encoded(
+			&stellar_vault_secret_key.trim().to_string(),
+			is_public_network,
+		)?;
 		tracing::debug!(
 			"Vault wallet public key: {}",
 			from_utf8(&stellar_wallet.get_public_key().to_encoding())?

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-	#[error("Server returned rpc error")]
+	#[error("Invalid secret key")]
 	InvalidSecretKey,
 	#[error("Error fetching horizon data: {0}")]
 	HttpFetchingError(#[from] FetchError),


### PR DESCRIPTION
This change is necessary to fix the vaults cloud deployment.

Closes #301.