### PR TITLE
317 add xlm to vault client auto register

### DIFF
--- a/clients/runtime/src/assets.rs
+++ b/clients/runtime/src/assets.rs
@@ -8,8 +8,17 @@ pub trait TryFromSymbol: Sized {
 }
 
 impl TryFromSymbol for CurrencyId {
+	/// This can build a currency from a string in the following formats:
+	/// - `XLM` which is simply the native Stellar currency
+	/// - `<issuer>:<code>` where `<issuer>` is the issuer of the asset and `<code>` is the code of
+	///   the asset
+	/// - `<xcm_id>` where `<xcm_id>` is the XCM currency id
 	fn try_from_symbol(symbol: String) -> Result<Self, Error> {
 		let uppercase_symbol = symbol.to_uppercase();
+
+		if uppercase_symbol == "XLM" {
+			return Ok(CurrencyId::StellarNative)
+		}
 
 		// Try to build stellar asset
 		let parts = uppercase_symbol.split(':').collect::<Vec<&str>>();
@@ -21,9 +30,43 @@ impl TryFromSymbol for CurrencyId {
 
 		// We assume that it is an XCM currency so we try to parse it as a number
 		if let Ok(id) = uppercase_symbol.parse::<u8>() {
-			return Ok(CurrencyId::XCM(id))
+			Ok(CurrencyId::XCM(id))
 		} else {
-			return Err(Error::InvalidCurrency)
+			Err(Error::InvalidCurrency)
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use primitives::Asset;
+
+	#[test]
+	fn test_try_from_symbol_works_for_native_currency() {
+		assert_eq!(CurrencyId::try_from_symbol("XLM".to_string()), Ok(CurrencyId::StellarNative));
+		assert_eq!(CurrencyId::try_from_symbol("xlm".to_string()), Ok(CurrencyId::StellarNative));
+		assert_eq!(CurrencyId::try_from_symbol("Xlm".to_string()), Ok(CurrencyId::StellarNative));
+	}
+
+	#[test]
+	fn test_try_from_symbol_works_for_stellar_asset() {
+		let issuer_bytes = [
+			20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46,
+			199, 108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
+		];
+
+		assert_eq!(
+			CurrencyId::try_from_symbol(
+				"GAKNDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC:USDC".to_string()
+			),
+			Ok(CurrencyId::Stellar(Asset::AlphaNum4 { code: *b"USDC", issuer: issuer_bytes }))
+		);
+		assert_eq!(
+			CurrencyId::try_from_symbol(
+				"gaknDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC:USDC".to_string()
+			),
+			Ok(CurrencyId::Stellar(Asset::AlphaNum4 { code: *b"USDC", issuer: issuer_bytes }))
+		);
 	}
 }

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -166,7 +166,7 @@ impl VaultIdManager {
 }
 
 /// Expecting an input of the form: `collateral_currency,wrapped_currency,collateral_amount` with
-/// `collateral_currency` being the currency of the collateral (e.g. DOT, KSM, ...),
+/// `collateral_currency` being the XCM index of the currency to be locked (e.g. 0, 1, 2...),
 /// `wrapped_currency` being the currency codes of the wrapped currency (e.g. USDC, EURT...)
 ///  including the issuer and code, ie 'GABC...:USDC'  and
 /// `collateral_amount` being the amount of collateral to be locked.


### PR DESCRIPTION
This changes the parsing of the `auto-register` config parameter such that `XLM` can also be used as a wrapped asset.

Closes #317.