### PR TITLE
Change naming of oracle pallet functions

### DIFF
--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -800,17 +800,9 @@ pub trait OraclePallet {
 
 	async fn feed_values(&self, values: Vec<((Vec<u8>, Vec<u8>), FixedU128)>) -> Result<(), Error>;
 
-	async fn wrapped_to_collateral(
-		&self,
-		amount: u128,
-		currency_id: CurrencyId,
-	) -> Result<u128, Error>;
+	async fn currency_to_usd(&self, amount: u128, currency_id: CurrencyId) -> Result<u128, Error>;
 
-	async fn collateral_to_wrapped(
-		&self,
-		amount: u128,
-		currency_id: CurrencyId,
-	) -> Result<u128, Error>;
+	async fn usd_to_currency(&self, amount: u128, currency_id: CurrencyId) -> Result<u128, Error>;
 
 	fn on_fee_rate_change(&self) -> FeeRateUpdateReceiver;
 }
@@ -871,17 +863,13 @@ impl OraclePallet for SpacewalkParachain {
 
 	/// Converts the amount of wrapped Stellar assets to the collateral currency, based on the
 	/// current set exchange rate.
-	async fn wrapped_to_collateral(
-		&self,
-		amount: u128,
-		currency_id: CurrencyId,
-	) -> Result<u128, Error> {
+	async fn currency_to_usd(&self, amount: u128, currency_id: CurrencyId) -> Result<u128, Error> {
 		let head = self.get_finalized_block_hash().await?;
 		let result: BalanceWrapper<_> = self
 			.api
 			.rpc()
 			.request(
-				"oracle_wrappedToCollateral",
+				"oracle_currencyToUsd",
 				rpc_params![BalanceWrapper { amount }, currency_id, head],
 			)
 			.await?;
@@ -891,17 +879,13 @@ impl OraclePallet for SpacewalkParachain {
 
 	/// Converts the amount of collateral currency to the specified wrapped asset, based on the
 	/// current set exchange rate.
-	async fn collateral_to_wrapped(
-		&self,
-		amount: u128,
-		currency_id: CurrencyId,
-	) -> Result<u128, Error> {
+	async fn usd_to_currency(&self, amount: u128, currency_id: CurrencyId) -> Result<u128, Error> {
 		let head = self.get_finalized_block_hash().await?;
 		let result: BalanceWrapper<_> = self
 			.api
 			.rpc()
 			.request(
-				"oracle_collateralToWrapped",
+				"oracle_usdToCurrency",
 				rpc_params![BalanceWrapper { amount }, currency_id, head],
 			)
 			.await?;

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -1197,10 +1197,11 @@ async fn test_off_chain_liquidation() {
 		assert_issue(&user_provider, WALLET.clone(), &vault_id, issue_amount, oracle_agent.clone())
 			.await;
 
+		// Reduce price of testing currency from 1:1 to 100:1 to trigger liquidation
 		set_exchange_rate_and_wait(
 			&authorized_oracle_provider,
 			DEFAULT_TESTING_CURRENCY,
-			FixedU128::from(1000000000),
+			FixedU128::saturating_from_rational(1, 100),
 		)
 		.await;
 

--- a/pallets/oracle/rpc/runtime-api/src/lib.rs
+++ b/pallets/oracle/rpc/runtime-api/src/lib.rs
@@ -41,12 +41,12 @@ sp_api::decl_runtime_apis! {
 		Balance: Codec,
 		CurrencyId: Codec,
 	{
-		fn wrapped_to_collateral(
+		fn currency_to_usd(
 			amount: BalanceWrapper<Balance>,
 			currency_id: CurrencyId,
 		) -> Result<BalanceWrapper<Balance>, DispatchError>;
 
-		fn collateral_to_wrapped(
+		fn usd_to_currency(
 			amount: BalanceWrapper<Balance>,
 			currency_id: CurrencyId,
 		) -> Result<BalanceWrapper<Balance>, DispatchError>;

--- a/pallets/oracle/rpc/src/lib.rs
+++ b/pallets/oracle/rpc/src/lib.rs
@@ -23,16 +23,16 @@ where
 	Balance: Codec + MaybeDisplay + MaybeFromStr,
 	CurrencyId: Codec,
 {
-	#[method(name = "oracle_wrappedToCollateral")]
-	fn wrapped_to_collateral(
+	#[method(name = "oracle_currencyToUsd")]
+	fn currency_to_usd(
 		&self,
 		amount: BalanceWrapper<Balance>,
 		currency_id: CurrencyId,
 		at: Option<BlockHash>,
 	) -> RpcResult<BalanceWrapper<Balance>>;
 
-	#[method(name = "oracle_collateralToWrapped")]
-	fn collateral_to_wrapped(
+	#[method(name = "oracle_usdToCurrency")]
+	fn usd_to_currency(
 		&self,
 		amount: BalanceWrapper<Balance>,
 		currency_id: CurrencyId,
@@ -79,7 +79,7 @@ where
 	Balance: Codec + MaybeDisplay + MaybeFromStr,
 	CurrencyId: Codec,
 {
-	fn wrapped_to_collateral(
+	fn currency_to_usd(
 		&self,
 		amount: BalanceWrapper<Balance>,
 		currency_id: CurrencyId,
@@ -88,10 +88,10 @@ where
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
-		handle_response(api.wrapped_to_collateral(&at, amount, currency_id))
+		handle_response(api.currency_to_usd(&at, amount, currency_id))
 	}
 
-	fn collateral_to_wrapped(
+	fn usd_to_currency(
 		&self,
 		amount: BalanceWrapper<Balance>,
 		currency_id: CurrencyId,
@@ -100,6 +100,6 @@ where
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
-		handle_response(api.collateral_to_wrapped(&at, amount, currency_id))
+		handle_response(api.usd_to_currency(&at, amount, currency_id))
 	}
 }

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -269,15 +269,15 @@ impl<T: Config> Pallet<T> {
 		let converted = match (amount.currency(), currency_id) {
 			(x, y) if x == y => amount.amount(),
 			(_, _) => {
-				// first convert to wrapped, then convert wrapped to the desired currency
-				let base = Self::collateral_to_wrapped(amount.amount(), amount.currency())?; // maybe this does not work?
-				Self::wrapped_to_collateral(base, currency_id)?
+				// first convert to usd, then convert usd to the desired currency
+				let base = Self::usd_to_currency(amount.amount(), amount.currency())?;
+				Self::currency_to_usd(base, currency_id)?
 			},
 		};
 		Ok(Amount::new(converted, currency_id))
 	}
 
-	pub fn wrapped_to_collateral(
+	pub fn currency_to_usd(
 		amount: BalanceOf<T>,
 		currency_id: CurrencyId,
 	) -> Result<BalanceOf<T>, DispatchError> {
@@ -286,7 +286,7 @@ impl<T: Config> Pallet<T> {
 		Ok(converted)
 	}
 
-	pub fn collateral_to_wrapped(
+	pub fn usd_to_currency(
 		amount: BalanceOf<T>,
 		currency_id: CurrencyId,
 	) -> Result<BalanceOf<T>, DispatchError> {

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -269,9 +269,8 @@ impl<T: Config> Pallet<T> {
 		let converted = match (amount.currency(), currency_id) {
 			(x, y) if x == y => amount.amount(),
 			(_, _) => {
-				// first convert to USD, then convert USD to the desired currency
-				let base = Self::currency_to_usd(amount.amount(), amount.currency())?;
-				Self::usd_to_currency(base, currency_id)?
+				let base = Self::usd_to_currency(amount.amount(), amount.currency())?;
+				Self::currency_to_usd(base, currency_id)?
 			},
 		};
 		Ok(Amount::new(converted, currency_id))

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -269,8 +269,9 @@ impl<T: Config> Pallet<T> {
 		let converted = match (amount.currency(), currency_id) {
 			(x, y) if x == y => amount.amount(),
 			(_, _) => {
-				let base = Self::usd_to_currency(amount.amount(), amount.currency())?;
-				Self::currency_to_usd(base, currency_id)?
+				// First convert to USD, then convert USD to the desired currency
+				let base = Self::currency_to_usd(amount.amount(), amount.currency())?;
+				Self::usd_to_currency(base, currency_id)?
 			},
 		};
 		Ok(Amount::new(converted, currency_id))

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -269,9 +269,9 @@ impl<T: Config> Pallet<T> {
 		let converted = match (amount.currency(), currency_id) {
 			(x, y) if x == y => amount.amount(),
 			(_, _) => {
-				// first convert to usd, then convert usd to the desired currency
-				let base = Self::usd_to_currency(amount.amount(), amount.currency())?;
-				Self::currency_to_usd(base, currency_id)?
+				// first convert to USD, then convert USD to the desired currency
+				let base = Self::currency_to_usd(amount.amount(), amount.currency())?;
+				Self::usd_to_currency(base, currency_id)?
 			},
 		};
 		Ok(Amount::new(converted, currency_id))

--- a/pallets/oracle/src/tests.rs
+++ b/pallets/oracle/src/tests.rs
@@ -143,38 +143,32 @@ fn getting_exchange_rate_fails_with_missing_exchange_rate() {
 	run_test(|| {
 		let key = OracleKey::ExchangeRate(CurrencyId::XCM(0));
 		assert_err!(Oracle::get_price(key), TestError::MissingExchangeRate);
-		assert_err!(
-			Oracle::wrapped_to_collateral(0, CurrencyId::XCM(0)),
-			TestError::MissingExchangeRate
-		);
-		assert_err!(
-			Oracle::collateral_to_wrapped(0, CurrencyId::XCM(0)),
-			TestError::MissingExchangeRate
-		);
+		assert_err!(Oracle::currency_to_usd(0, CurrencyId::XCM(0)), TestError::MissingExchangeRate);
+		assert_err!(Oracle::usd_to_currency(0, CurrencyId::XCM(0)), TestError::MissingExchangeRate);
 	});
 }
 
 #[test]
-fn wrapped_to_collateral() {
+fn currency_to_usd() {
 	run_test(|| {
 		Oracle::get_price
 			.mock_safe(|_| MockResult::Return(Ok(FixedU128::checked_from_rational(2, 1).unwrap())));
 		let test_cases = [(0, 0), (2, 4), (10, 20)];
 		for (input, expected) in test_cases.iter() {
-			let result = Oracle::wrapped_to_collateral(*input, CurrencyId::XCM(0));
+			let result = Oracle::currency_to_usd(*input, CurrencyId::XCM(0));
 			assert_ok!(result, *expected);
 		}
 	});
 }
 
 #[test]
-fn collateral_to_wrapped() {
+fn usd_to_currency() {
 	run_test(|| {
 		Oracle::get_price
 			.mock_safe(|_| MockResult::Return(Ok(FixedU128::checked_from_rational(2, 1).unwrap())));
 		let test_cases = [(0, 0), (4, 2), (20, 10), (21, 10)];
 		for (input, expected) in test_cases.iter() {
-			let result = Oracle::collateral_to_wrapped(*input, CurrencyId::XCM(0));
+			let result = Oracle::usd_to_currency(*input, CurrencyId::XCM(0));
 			assert_ok!(result, *expected);
 		}
 	});

--- a/pallets/vault-registry/src/benchmarking.rs
+++ b/pallets/vault-registry/src/benchmarking.rs
@@ -133,12 +133,12 @@ benchmarks! {
 
 		register_vault_with_collateral::<T>(vault_id.clone(), 10_000);
 		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::one()).unwrap();
-		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_wrapped_currency_id(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
+		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_wrapped_currency_id(), UnsignedFixedPoint::<T>::checked_from_rational(1, 10).unwrap()).unwrap();
 
 		VaultRegistry::<T>::try_increase_to_be_issued_tokens(&vault_id, &wrapped(5_000)).unwrap();
 		VaultRegistry::<T>::issue_tokens(&vault_id, &wrapped(5_000)).unwrap();
 
-		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
+		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(1, 10).unwrap()).unwrap();
 		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_wrapped_currency_id(), UnsignedFixedPoint::<T>::one()).unwrap();
 	}: _(RawOrigin::Signed(origin), vault_id)
 
@@ -147,8 +147,8 @@ benchmarks! {
 		let origin: T::AccountId = account("Origin", 0, 0);
 		mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
 		register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
-		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
-		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_wrapped_currency_id(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
+		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(1, 10).unwrap()).unwrap();
+		Oracle::<T>::_set_exchange_rate(vault_id.clone().account_id, get_wrapped_currency_id(), UnsignedFixedPoint::<T>::checked_from_rational(1, 10).unwrap()).unwrap();
 		VaultRegistry::<T>::liquidate_vault(&vault_id).unwrap();
 	}: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone())
 

--- a/pallets/vault-registry/src/tests.rs
+++ b/pallets/vault-registry/src/tests.rs
@@ -1256,7 +1256,7 @@ fn get_unsettled_collateralization_from_vault_succeeds() {
 #[test]
 fn get_settled_collateralization_from_vault_succeeds() {
 	run_test(|| {
-		// wrapped_to_collateral is / 10 and we issue 2 * amount
+		// currency_to_usd is / 10 and we issue 2 * amount
 		let issue_tokens: u128 = 100000 / 10 / 5; // 2000
 		let id = create_sample_vault_and_issue_tokens(issue_tokens);
 


### PR DESCRIPTION
PR related to issue #321 
renamed functions:
- wrapped_to_collateral -> currency_to_usd
- collateral_to_wrapped -> usd_to_currency

change the order of calls functions in oracle convert function:
new order is 

```
let base = Self::currency_to_usd(amount.amount(), amount.currency())?;
Self::usd_to_currency(base, currency_id)?
```
