### PR TITLE
Update signature of get_required_collateral_for_wrapped RPC function

### DIFF
--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -126,10 +126,11 @@ pub async fn get_exchange_rate(parachain_rpc: &SpacewalkParachain, currency_id: 
 pub async fn get_required_vault_collateral_for_issue(
 	parachain_rpc: &SpacewalkParachain,
 	amount: u128,
+	wrapped_currency: CurrencyId,
 	collateral_currency: CurrencyId,
 ) -> u128 {
 	parachain_rpc
-		.get_required_collateral_for_wrapped(amount, collateral_currency)
+		.get_required_collateral_for_wrapped(amount, wrapped_currency, collateral_currency)
 		.await
 		.unwrap()
 }

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -526,7 +526,7 @@ pub trait VaultRegistryPallet {
 		&self,
 		amount_wrapped_asset: u128,
 		wrapped_currency_id: CurrencyId,
-		collateral_currency: CurrencyId,
+		collateral_currency_id: CurrencyId,
 	) -> Result<u128, Error>;
 
 	async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, Error>;
@@ -670,7 +670,7 @@ impl VaultRegistryPallet for SpacewalkParachain {
 		&self,
 		amount_wrapped_asset: u128,
 		wrapped_currency_id: CurrencyId,
-		collateral_currency: CurrencyId,
+		collateral_currency_id: CurrencyId,
 	) -> Result<u128, Error> {
 		let head = self.get_finalized_block_hash().await?;
 		let result: BalanceWrapper<_> = self
@@ -681,7 +681,7 @@ impl VaultRegistryPallet for SpacewalkParachain {
 				rpc_params![
 					BalanceWrapper { amount: amount_wrapped_asset },
 					wrapped_currency_id,
-					collateral_currency,
+					collateral_currency_id,
 					head
 				],
 			)

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -525,6 +525,7 @@ pub trait VaultRegistryPallet {
 	async fn get_required_collateral_for_wrapped(
 		&self,
 		amount_wrapped_asset: u128,
+		wrapped_currency_id: CurrencyId,
 		collateral_currency: CurrencyId,
 	) -> Result<u128, Error>;
 
@@ -668,6 +669,7 @@ impl VaultRegistryPallet for SpacewalkParachain {
 	async fn get_required_collateral_for_wrapped(
 		&self,
 		amount_wrapped_asset: u128,
+		wrapped_currency_id: CurrencyId,
 		collateral_currency: CurrencyId,
 	) -> Result<u128, Error> {
 		let head = self.get_finalized_block_hash().await?;
@@ -678,6 +680,7 @@ impl VaultRegistryPallet for SpacewalkParachain {
 				"vaultRegistry_getRequiredCollateralForWrapped",
 				rpc_params![
 					BalanceWrapper { amount: amount_wrapped_asset },
+					wrapped_currency_id,
 					collateral_currency,
 					head
 				],

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -162,9 +162,14 @@ pub async fn handle_replace_request<
 	vault_id: &'a VaultId,
 ) -> Result<(), Error> {
 	let collateral_currency = vault_id.collateral_currency();
+	let wrapped_currency = vault_id.wrapped_currency();
 
 	let (required_replace_collateral, current_collateral, used_collateral) = try_join3(
-		parachain_rpc.get_required_collateral_for_wrapped(event.amount, collateral_currency),
+		parachain_rpc.get_required_collateral_for_wrapped(
+			event.amount,
+			wrapped_currency,
+			collateral_currency,
+		),
 		parachain_rpc.get_vault_total_collateral(vault_id.clone()),
 		parachain_rpc.get_required_collateral_for_vault(vault_id.clone()),
 	)
@@ -253,7 +258,7 @@ mod tests {
 		async fn withdraw_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
 		async fn get_public_key(&self) -> Result<Option<StellarPublicKeyRaw>, RuntimeError>;
 		async fn register_public_key(&self, public_key: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
-		async fn get_required_collateral_for_wrapped(&self, amount: u128, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
+		async fn get_required_collateral_for_wrapped(&self, amount: u128, wrapped_currency: CurrencyId, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
 		async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
 		async fn get_vault_total_collateral(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
 		async fn get_collateralization_from_vault(&self, vault_id: VaultId, only_issued: bool) -> Result<u128, RuntimeError>;
@@ -317,7 +322,7 @@ mod tests {
 		let mut parachain_rpc = MockProvider::default();
 		parachain_rpc
 			.expect_get_required_collateral_for_wrapped()
-			.returning(|_, _| Ok(51));
+			.returning(|_, _, _| Ok(51));
 		parachain_rpc.expect_get_required_collateral_for_vault().returning(|_| Ok(50));
 		parachain_rpc.expect_get_vault_total_collateral().returning(|_| Ok(100));
 
@@ -342,7 +347,7 @@ mod tests {
 		let mut parachain_rpc = MockProvider::default();
 		parachain_rpc
 			.expect_get_required_collateral_for_wrapped()
-			.returning(|_, _| Ok(50));
+			.returning(|_, _, _| Ok(50));
 		parachain_rpc.expect_get_required_collateral_for_vault().returning(|_| Ok(50));
 		parachain_rpc.expect_get_vault_total_collateral().returning(|_| Ok(100));
 		parachain_rpc.expect_accept_replace().returning(|_, _, _, _, _| Ok(()));

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -232,6 +232,7 @@ async fn test_redeem_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -301,6 +302,7 @@ async fn test_replace_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&old_vault_provider,
 			issue_amount,
+			old_vault_id.wrapped_currency(),
 			old_vault_id.collateral_currency(),
 		)
 		.await;
@@ -391,6 +393,7 @@ async fn test_withdraw_replace_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&old_vault_provider,
 			issue_amount,
+			old_vault_id.wrapped_currency(),
 			old_vault_id.collateral_currency(),
 		)
 		.await;
@@ -474,6 +477,7 @@ async fn test_cancel_scheduler_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&old_vault_provider,
 			issue_amount * 10,
+			old_vault_id.wrapped_currency(),
 			old_vault_id.collateral_currency(),
 		)
 		.await;
@@ -662,6 +666,7 @@ async fn test_issue_cancel_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -745,6 +750,7 @@ async fn test_issue_overpayment_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount * over_payment_factor,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -829,6 +835,7 @@ async fn test_automatic_issue_execution_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -937,6 +944,7 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault1_provider,
 			issue_amount,
+			vault1_id.wrapped_currency(),
 			vault1_id.collateral_currency(),
 		)
 		.await;
@@ -1072,6 +1080,7 @@ async fn test_execute_open_requests_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -1161,6 +1170,7 @@ async fn test_off_chain_liquidation() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -1210,6 +1220,7 @@ async fn test_shutdown() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&sudo_provider,
 			issue_amount,
+			sudo_vault_id.wrapped_currency(),
 			sudo_vault_id.collateral_currency(),
 		)
 		.await;
@@ -1261,6 +1272,7 @@ async fn test_requests_with_incompatible_amounts_fail() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			incompatible_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;

--- a/pallets/vault-registry/rpc/runtime-api/src/lib.rs
+++ b/pallets/vault-registry/rpc/runtime-api/src/lib.rs
@@ -44,7 +44,7 @@ sp_api::decl_runtime_apis! {
 
 		/// Get the minimum amount of collateral required for the given amount of token
 		/// with the current threshold and exchange rate
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId, collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
 
 		/// Get the amount of collateral required for the given vault to be at the
 		/// current SecureCollateralThreshold with the current exchange rate

--- a/pallets/vault-registry/rpc/runtime-api/src/lib.rs
+++ b/pallets/vault-registry/rpc/runtime-api/src/lib.rs
@@ -44,7 +44,7 @@ sp_api::decl_runtime_apis! {
 
 		/// Get the minimum amount of collateral required for the given amount of token
 		/// with the current threshold and exchange rate
-		fn get_required_collateral_for_wrapped(amount: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
 
 		/// Get the amount of collateral required for the given vault to be at the
 		/// current SecureCollateralThreshold with the current exchange rate

--- a/pallets/vault-registry/rpc/src/lib.rs
+++ b/pallets/vault-registry/rpc/src/lib.rs
@@ -92,8 +92,9 @@ where
 	#[method(name = "vaultRegistry_getRequiredCollateralForWrapped")]
 	fn get_required_collateral_for_wrapped(
 		&self,
-		amount: BalanceWrapper<Balance>,
-		currency_id: CurrencyId,
+		amount_wrapped: BalanceWrapper<Balance>,
+		wrapped_currency_id: CurrencyId,
+		collateral_currency_id: CurrencyId,
 		at: Option<BlockHash>,
 	) -> RpcResult<BalanceWrapper<Balance>>;
 
@@ -289,15 +290,21 @@ where
 
 	fn get_required_collateral_for_wrapped(
 		&self,
-		amount: BalanceWrapper<Balance>,
-		currency_id: CurrencyId,
+		amount_wrapped: BalanceWrapper<Balance>,
+		wrapped_currency_id: CurrencyId,
+		collateral_currency_id: CurrencyId,
 		at: Option<<Block as BlockT>::Hash>,
 	) -> RpcResult<BalanceWrapper<Balance>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
 		handle_response(
-			api.get_required_collateral_for_wrapped(&at, amount, currency_id),
+			api.get_required_collateral_for_wrapped(
+				&at,
+				amount_wrapped,
+				wrapped_currency_id,
+				collateral_currency_id,
+			),
 			"Unable to get required collateral for amount".into(),
 		)
 	}

--- a/testchain/node/src/chain_spec.rs
+++ b/testchain/node/src/chain_spec.rs
@@ -13,10 +13,10 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 use primitives::{oracle::Key, CurrencyId, VaultCurrencyPair};
 use serde_json::{map::Map, Value};
 use spacewalk_runtime::{
-	AccountId, AuraConfig, BalancesConfig, FeeConfig, FieldLength, GenesisConfig,
-	GetWrappedCurrencyId, GrandpaConfig, IssueConfig, NominationConfig, OracleConfig, Organization,
-	RedeemConfig, ReplaceConfig, SecurityConfig, Signature, StatusCode, StellarRelayConfig,
-	SudoConfig, SystemConfig, TokensConfig, Validator, VaultRegistryConfig, DAYS, WASM_BINARY,
+	AccountId, AuraConfig, BalancesConfig, FeeConfig, FieldLength, GenesisConfig, GrandpaConfig,
+	IssueConfig, NominationConfig, OracleConfig, Organization, RedeemConfig, ReplaceConfig,
+	SecurityConfig, Signature, StatusCode, StellarRelayConfig, SudoConfig, SystemConfig,
+	TokensConfig, Validator, VaultRegistryConfig, DAYS, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -30,6 +30,23 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 		.expect("static values are valid; qed")
 		.public()
 }
+
+// For mainnet USDC issued by centre.io
+// const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4 {
+// 	code: *b"USDC",
+// 	issuer: [
+// 		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
+// 		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
+// 	],
+// };
+// For Testnet USDC issued by
+const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(
+	*b"USDC",
+	[
+		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
+		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
+	],
+);
 
 /// Generate an Aura authority key.
 pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
@@ -190,7 +207,7 @@ pub fn development_config() -> ChainSpec {
 }
 
 fn default_pair(currency_id: CurrencyId) -> VaultCurrencyPair<CurrencyId> {
-	VaultCurrencyPair { collateral: currency_id, wrapped: GetWrappedCurrencyId::get() }
+	VaultCurrencyPair { collateral: currency_id, wrapped: WRAPPED_CURRENCY_ID }
 }
 
 // Used to create bounded vecs for genesis config

--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -202,27 +202,10 @@ impl pallet_timestamp::Config for Runtime {
 
 const NATIVE_CURRENCY_ID: CurrencyId = CurrencyId::Native;
 const PARENT_CURRENCY_ID: CurrencyId = CurrencyId::XCM(0);
-// For mainnet USDC issued by centre.io
-// const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4 {
-// 	code: *b"USDC",
-// 	issuer: [
-// 		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
-// 		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
-// 	],
-// };
-// For Testnet USDC issued by
-const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(
-	*b"USDC",
-	[
-		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
-		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
-	],
-);
 
 parameter_types! {
 	pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;
 	pub const GetRelayChainCurrencyId: CurrencyId = PARENT_CURRENCY_ID;
-	pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
 	pub const TransactionByteFee: Balance = MILLICENTS;
 }
 
@@ -907,8 +890,8 @@ impl_runtime_apis! {
 			VaultRegistry::get_collateralization_from_vault_and_collateral(vault, &amount, only_issued)
 		}
 
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, _wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-			let amount_wrapped = Amount::new(amount_wrapped.amount, GetWrappedCurrencyId::get());
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let amount_wrapped = Amount::new(amount_wrapped.amount, wrapped_currency_id);
 			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, collateral_currency_id)?;
 			Ok(BalanceWrapper{amount:result.amount()})
 		}

--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -907,9 +907,9 @@ impl_runtime_apis! {
 			VaultRegistry::get_collateralization_from_vault_and_collateral(vault, &amount, only_issued)
 		}
 
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, _wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
 			let amount_wrapped = Amount::new(amount_wrapped.amount, GetWrappedCurrencyId::get());
-			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, currency_id)?;
+			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, collateral_currency_id)?;
 			Ok(BalanceWrapper{amount:result.amount()})
 		}
 


### PR DESCRIPTION
- updated get_required_collateral_for_wrapped RPC function in vault-registry
- updated testchain runtime. `wrapped_currency_id` in testchain does not passed to the pallet function. use default value as  `GetWrappedCurrencyId::get()`

```
const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(
	*b"USDC",
	[
		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
	],
);
```