### PR TITLE
update vault integration tests

### DIFF
--- a/clients/runtime/src/integration/mod.rs
+++ b/clients/runtime/src/integration/mod.rs
@@ -126,10 +126,11 @@ pub async fn get_exchange_rate(parachain_rpc: &SpacewalkParachain, currency_id: 
 pub async fn get_required_vault_collateral_for_issue(
 	parachain_rpc: &SpacewalkParachain,
 	amount: u128,
+	wrapped_currency: CurrencyId,
 	collateral_currency: CurrencyId,
 ) -> u128 {
 	parachain_rpc
-		.get_required_collateral_for_wrapped(amount, collateral_currency)
+		.get_required_collateral_for_wrapped(amount, wrapped_currency, collateral_currency)
 		.await
 		.unwrap()
 }

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -162,9 +162,14 @@ pub async fn handle_replace_request<
 	vault_id: &'a VaultId,
 ) -> Result<(), Error> {
 	let collateral_currency = vault_id.collateral_currency();
+	let wrapped_currency = vault_id.wrapped_currency();
 
 	let (required_replace_collateral, current_collateral, used_collateral) = try_join3(
-		parachain_rpc.get_required_collateral_for_wrapped(event.amount, collateral_currency),
+		parachain_rpc.get_required_collateral_for_wrapped(
+			event.amount,
+			wrapped_currency,
+			collateral_currency,
+		),
 		parachain_rpc.get_vault_total_collateral(vault_id.clone()),
 		parachain_rpc.get_required_collateral_for_vault(vault_id.clone()),
 	)
@@ -253,7 +258,7 @@ mod tests {
 		async fn withdraw_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
 		async fn get_public_key(&self) -> Result<Option<StellarPublicKeyRaw>, RuntimeError>;
 		async fn register_public_key(&self, public_key: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
-		async fn get_required_collateral_for_wrapped(&self, amount: u128, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
+		async fn get_required_collateral_for_wrapped(&self, amount: u128, wrapped_currency: CurrencyId, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
 		async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
 		async fn get_vault_total_collateral(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
 		async fn get_collateralization_from_vault(&self, vault_id: VaultId, only_issued: bool) -> Result<u128, RuntimeError>;
@@ -317,7 +322,7 @@ mod tests {
 		let mut parachain_rpc = MockProvider::default();
 		parachain_rpc
 			.expect_get_required_collateral_for_wrapped()
-			.returning(|_, _| Ok(51));
+			.returning(|_, _, _| Ok(51));
 		parachain_rpc.expect_get_required_collateral_for_vault().returning(|_| Ok(50));
 		parachain_rpc.expect_get_vault_total_collateral().returning(|_| Ok(100));
 
@@ -342,7 +347,7 @@ mod tests {
 		let mut parachain_rpc = MockProvider::default();
 		parachain_rpc
 			.expect_get_required_collateral_for_wrapped()
-			.returning(|_, _| Ok(50));
+			.returning(|_, _, _| Ok(50));
 		parachain_rpc.expect_get_required_collateral_for_vault().returning(|_| Ok(50));
 		parachain_rpc.expect_get_vault_total_collateral().returning(|_| Ok(100));
 		parachain_rpc.expect_accept_replace().returning(|_, _, _, _, _| Ok(()));

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -232,6 +232,7 @@ async fn test_redeem_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -301,6 +302,7 @@ async fn test_replace_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&old_vault_provider,
 			issue_amount,
+			old_vault_id.wrapped_currency(),
 			old_vault_id.collateral_currency(),
 		)
 		.await;
@@ -391,6 +393,7 @@ async fn test_withdraw_replace_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&old_vault_provider,
 			issue_amount,
+			old_vault_id.wrapped_currency(),
 			old_vault_id.collateral_currency(),
 		)
 		.await;
@@ -474,6 +477,7 @@ async fn test_cancel_scheduler_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&old_vault_provider,
 			issue_amount * 10,
+			old_vault_id.wrapped_currency(),
 			old_vault_id.collateral_currency(),
 		)
 		.await;
@@ -662,6 +666,7 @@ async fn test_issue_cancel_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -745,6 +750,7 @@ async fn test_issue_overpayment_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount * over_payment_factor,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -829,6 +835,7 @@ async fn test_automatic_issue_execution_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -937,6 +944,7 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault1_provider,
 			issue_amount,
+			vault1_id.wrapped_currency(),
 			vault1_id.collateral_currency(),
 		)
 		.await;
@@ -1072,6 +1080,7 @@ async fn test_execute_open_requests_succeeds() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -1161,6 +1170,7 @@ async fn test_off_chain_liquidation() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			issue_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;
@@ -1210,6 +1220,7 @@ async fn test_shutdown() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&sudo_provider,
 			issue_amount,
+			sudo_vault_id.wrapped_currency(),
 			sudo_vault_id.collateral_currency(),
 		)
 		.await;
@@ -1261,6 +1272,7 @@ async fn test_requests_with_incompatible_amounts_fail() {
 		let vault_collateral = get_required_vault_collateral_for_issue(
 			&vault_provider,
 			incompatible_amount,
+			vault_id.wrapped_currency(),
 			vault_id.collateral_currency(),
 		)
 		.await;


### PR DESCRIPTION
- update integration tests for vault. pass `wrapped_currency_id` from vault data.
- updated `get_required_vault_collateral_for_issue` with one more parameter `wrapped_currency` to pass it into `get_required_collateral_for_wrapped`