### PR TITLE
160 amend metrics reporting

### DIFF
--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -20,6 +20,7 @@ use wallet::{StellarWallet, TransactionResponse};
 
 use crate::{
 	error::Error,
+	metrics::update_stellar_metrics,
 	oracle::{types::Slot, OracleAgent, Proof},
 	system::VaultData,
 	VaultIdManager, YIELD_RATE,
@@ -159,10 +160,11 @@ impl Request {
 			}
 		}
 
-		let (tx_env, slot) = self.transfer_stellar_asset(vault.stellar_wallet).await?;
+		let (tx_env, slot) = self.transfer_stellar_asset(vault.stellar_wallet.clone()).await?;
 
 		let proof = oracle_agent.get_proof(slot).await?;
 
+		let _ = update_stellar_metrics(&vault, &parachain_rpc).await;
 		self.execute(parachain_rpc, tx_env, proof).await
 	}
 

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -14,8 +14,8 @@ use runtime::{
 	},
 	types::currency_id::CurrencyIdExt,
 	AggregateUpdatedEvent, CollateralBalancesPallet, CurrencyId, Error as RuntimeError, FixedU128,
-	IssuePallet, IssueRequestStatus, OracleKey, PrettyPrint, RedeemPallet, RedeemRequestStatus,
-	SecurityPallet, SpacewalkParachain, UtilFuncs, VaultId, VaultRegistryPallet, H256,
+	IssuePallet, IssueRequestStatus, OracleKey, RedeemPallet, RedeemRequestStatus, SecurityPallet,
+	SpacewalkParachain, UtilFuncs, VaultId, VaultRegistryPallet, H256,
 };
 use service::{
 	warp::{Rejection, Reply},
@@ -273,14 +273,7 @@ pub async fn publish_collateralization<P: VaultRegistryPallet>(
 
 	let collateralization = match result {
 		Ok(collateralization) => collateralization,
-		Err(e) => {
-			tracing::error!(
-				"Failed to get collateralization for vault {:?}: {:?}",
-				vault.vault_id.pretty_print(),
-				e
-			);
-			0
-		},
+		Err(_) => 0, // We don't want to log an error here, because it would be too noisy
 	};
 
 	let float_collateralization_percentage = FixedU128::from_inner(collateralization).to_float();
@@ -488,7 +481,7 @@ pub async fn poll_metrics<
 		}
 
 		for vault in vault_id_manager.get_entries().await {
-			update_stellar_metrics(&vault, parachain_rpc.clone()).await;
+			update_stellar_metrics(&vault, parachain_rpc).await;
 		}
 
 		sleep(SLEEP_DURATION).await;

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -271,11 +271,7 @@ pub async fn publish_collateralization<P: VaultRegistryPallet>(
 		.get_collateralization_from_vault(vault.vault_id.clone(), false)
 		.await;
 
-	let collateralization = match result {
-		Ok(collateralization) => collateralization,
-		Err(_) => 0, // We don't want to log an error here, because it would be too noisy
-	};
-
+	let collateralization = result.unwrap_or(0);
 	let float_collateralization_percentage = FixedU128::from_inner(collateralization).to_float();
 	vault.metrics.collateralization.set(float_collateralization_percentage);
 }


### PR DESCRIPTION
Amends the changes for #160.

We forgot to add a function that keeps the Stellar balance metric up-to-date. This PR changes it such that the Stellar balance metrics are updated periodically or after executing a request.