### PR TITLE
Move WRAPPED_CURRENCY_ID from runtime to chain_spec and remove usage of GetWrappedCurrencyId::get()

### DIFF
--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -526,7 +526,7 @@ pub trait VaultRegistryPallet {
 		&self,
 		amount_wrapped_asset: u128,
 		wrapped_currency_id: CurrencyId,
-		collateral_currency: CurrencyId,
+		collateral_currency_id: CurrencyId,
 	) -> Result<u128, Error>;
 
 	async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, Error>;
@@ -670,7 +670,7 @@ impl VaultRegistryPallet for SpacewalkParachain {
 		&self,
 		amount_wrapped_asset: u128,
 		wrapped_currency_id: CurrencyId,
-		collateral_currency: CurrencyId,
+		collateral_currency_id: CurrencyId,
 	) -> Result<u128, Error> {
 		let head = self.get_finalized_block_hash().await?;
 		let result: BalanceWrapper<_> = self
@@ -681,7 +681,7 @@ impl VaultRegistryPallet for SpacewalkParachain {
 				rpc_params![
 					BalanceWrapper { amount: amount_wrapped_asset },
 					wrapped_currency_id,
-					collateral_currency,
+					collateral_currency_id,
 					head
 				],
 			)

--- a/pallets/vault-registry/rpc/runtime-api/src/lib.rs
+++ b/pallets/vault-registry/rpc/runtime-api/src/lib.rs
@@ -44,7 +44,7 @@ sp_api::decl_runtime_apis! {
 
 		/// Get the minimum amount of collateral required for the given amount of token
 		/// with the current threshold and exchange rate
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId, collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
 
 		/// Get the amount of collateral required for the given vault to be at the
 		/// current SecureCollateralThreshold with the current exchange rate

--- a/testchain/node/src/chain_spec.rs
+++ b/testchain/node/src/chain_spec.rs
@@ -13,10 +13,10 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 use primitives::{oracle::Key, CurrencyId, VaultCurrencyPair};
 use serde_json::{map::Map, Value};
 use spacewalk_runtime::{
-	AccountId, AuraConfig, BalancesConfig, FeeConfig, FieldLength, GenesisConfig,
-	GetWrappedCurrencyId, GrandpaConfig, IssueConfig, NominationConfig, OracleConfig, Organization,
-	RedeemConfig, ReplaceConfig, SecurityConfig, Signature, StatusCode, StellarRelayConfig,
-	SudoConfig, SystemConfig, TokensConfig, Validator, VaultRegistryConfig, DAYS, WASM_BINARY,
+	AccountId, AuraConfig, BalancesConfig, FeeConfig, FieldLength, GenesisConfig, GrandpaConfig,
+	IssueConfig, NominationConfig, OracleConfig, Organization, RedeemConfig, ReplaceConfig,
+	SecurityConfig, Signature, StatusCode, StellarRelayConfig, SudoConfig, SystemConfig,
+	TokensConfig, Validator, VaultRegistryConfig, DAYS, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -30,6 +30,23 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 		.expect("static values are valid; qed")
 		.public()
 }
+
+// For mainnet USDC issued by centre.io
+// const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4 {
+// 	code: *b"USDC",
+// 	issuer: [
+// 		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
+// 		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
+// 	],
+// };
+// For Testnet USDC issued by
+const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(
+	*b"USDC",
+	[
+		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
+		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
+	],
+);
 
 /// Generate an Aura authority key.
 pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
@@ -190,7 +207,7 @@ pub fn development_config() -> ChainSpec {
 }
 
 fn default_pair(currency_id: CurrencyId) -> VaultCurrencyPair<CurrencyId> {
-	VaultCurrencyPair { collateral: currency_id, wrapped: GetWrappedCurrencyId::get() }
+	VaultCurrencyPair { collateral: currency_id, wrapped: WRAPPED_CURRENCY_ID }
 }
 
 // Used to create bounded vecs for genesis config

--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -202,27 +202,10 @@ impl pallet_timestamp::Config for Runtime {
 
 const NATIVE_CURRENCY_ID: CurrencyId = CurrencyId::Native;
 const PARENT_CURRENCY_ID: CurrencyId = CurrencyId::XCM(0);
-// For mainnet USDC issued by centre.io
-// const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4 {
-// 	code: *b"USDC",
-// 	issuer: [
-// 		59, 153, 17, 56, 14, 254, 152, 139, 160, 168, 144, 14, 177, 207, 228, 79, 54, 111, 125,
-// 		190, 148, 107, 237, 7, 114, 64, 247, 246, 36, 223, 21, 197,
-// 	],
-// };
-// For Testnet USDC issued by
-const WRAPPED_CURRENCY_ID: CurrencyId = CurrencyId::AlphaNum4(
-	*b"USDC",
-	[
-		20, 209, 150, 49, 176, 55, 23, 217, 171, 154, 54, 110, 16, 50, 30, 226, 102, 231, 46, 199,
-		108, 171, 97, 144, 240, 161, 51, 109, 72, 34, 159, 139,
-	],
-);
 
 parameter_types! {
 	pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;
 	pub const GetRelayChainCurrencyId: CurrencyId = PARENT_CURRENCY_ID;
-	pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
 	pub const TransactionByteFee: Balance = MILLICENTS;
 }
 

--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -907,8 +907,8 @@ impl_runtime_apis! {
 			VaultRegistry::get_collateralization_from_vault_and_collateral(vault, &amount, only_issued)
 		}
 
-		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, _wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-			let amount_wrapped = Amount::new(amount_wrapped.amount, GetWrappedCurrencyId::get());
+		fn get_required_collateral_for_wrapped(amount_wrapped: BalanceWrapper<Balance>, wrapped_currency_id: CurrencyId,  collateral_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+			let amount_wrapped = Amount::new(amount_wrapped.amount, wrapped_currency_id);
 			let result = VaultRegistry::get_required_collateral_for_wrapped(&amount_wrapped, collateral_currency_id)?;
 			Ok(BalanceWrapper{amount:result.amount()})
 		}


### PR DESCRIPTION
- move definition of `WRAPPED_CURRENCY_ID` from runtime to `chain_spec`
- use `wrapped_currency_id` parameter instead of hardcoded value `GetWrappedCurrencyId::get()` in runtime.
- rename `collateral_currency` to `collateral_currency_id`