### PR TITLE
Add safer amount conversion from Stellar amounts to host chain amounts

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -676,11 +676,8 @@ impl StaticLookup for BalanceConversion {
 	}
 
 	fn unlookup(stellar_stroops: Self::Target) -> Self::Source {
-		let conversion_rate =
-			Self::Target::try_from(DECIMALS_CONVERSION_RATE).unwrap_or(Self::Target::MAX);
-
-		let value = stellar_stroops.saturating_mul(conversion_rate);
-		Self::Source::try_from(value).unwrap_or(0)
+		let valut = Self::Source::try_from(stellar_stroops).unwrap_or(0);
+		valut.saturating_mul(DECIMALS_CONVERSION_RATE)
 	}
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -676,8 +676,8 @@ impl StaticLookup for BalanceConversion {
 	}
 
 	fn unlookup(stellar_stroops: Self::Target) -> Self::Source {
-		let valut = Self::Source::try_from(stellar_stroops).unwrap_or(0);
-		valut.saturating_mul(DECIMALS_CONVERSION_RATE)
+		let value = Self::Source::try_from(stellar_stroops).unwrap_or(0);
+		value.saturating_mul(DECIMALS_CONVERSION_RATE)
 	}
 }
 


### PR DESCRIPTION
PR related to this issue https://github.com/pendulum-chain/spacewalk/issues/331

- first widen the Stellar amount to u128 
- multiply with 100_000.