### PR TITLE
Add flow for automatically building binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build binaries
+on:
+  push:
+    branches:
+      spacewalk-release
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger job
+        uses: appleboy/gitlab-ci-action@master
+        with:
+          url: "https://gitlab.com"
+          token: ${{ secrets.GITLABAPI }}
+          project_id: 43970950


### PR DESCRIPTION
Adds a workflow file that automatically triggers an action to build the binaries for spacewalk.

Related to [this](https://github.com/pendulum-chain/tasks/issues/28) task.