### PR TITLE
Use different XCMCurrencyConversion impl depends on features flag

### DIFF
--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -460,20 +460,47 @@ impl NativeCurrencyKey for SpacewalkNativeCurrencyKey {
 
 // It's important that this is implemented the same way as the MockOracleKeyConvertor
 // because this is used in the benchmark_utils::DataCollector when feeding prices
-impl XCMCurrencyConversion for SpacewalkNativeCurrencyKey {
-	fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
-		// We assume that the blockchain is always 0 and the symbol represents the token symbol
-		let blockchain = vec![0u8];
-		let symbol = vec![token_symbol];
-		Some((blockchain, symbol))
-	}
+cfg_if::cfg_if! {
+	if #[cfg(feature = "testing-utils")] {
+		impl XCMCurrencyConversion for SpacewalkNativeCurrencyKey {
+			fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
+				// We assume that the blockchain is always 0 and the symbol represents the token symbol
+				let blockchain = vec![0u8];
+				let symbol = vec![token_symbol];
+				Some((blockchain, symbol))
+			}
 
-	fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
-		// We assume that the blockchain is always 0 and the symbol represents the token symbol
-		if blockchain.len() != 1 && blockchain[0] != 0 || symbol.len() != 1 {
-			return None
+			fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
+				// We assume that the blockchain is always 0 and the symbol represents the token symbol
+				if blockchain.len() != 1 && blockchain[0] != 0 || symbol.len() != 1 {
+					return None
+				}
+				return Some(symbol[0])
+			}
 		}
-		return Some(symbol[0])
+	}
+	else{
+		impl XCMCurrencyConversion for SpacewalkNativeCurrencyKey {
+			fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
+				if token_symbol == 0 {
+					return Some((b"Kusama".to_vec(), b"KSM".to_vec()))
+				}
+
+				// We assume that the blockchain is always 0 and the symbol represents the token symbol
+				let blockchain = vec![0u8];
+				let symbol = vec![token_symbol];
+
+				Some((blockchain, symbol))
+			}
+
+			fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
+				// We assume that the blockchain is always 0 and the symbol represents the token symbol
+				if blockchain.len() != 1 && blockchain[0] != 0 || symbol.len() != 1 {
+					return None
+				}
+				return Some(symbol[0])
+			}
+		}
 	}
 }
 

--- a/testchain/runtime/src/lib.rs
+++ b/testchain/runtime/src/lib.rs
@@ -460,47 +460,28 @@ impl NativeCurrencyKey for SpacewalkNativeCurrencyKey {
 
 // It's important that this is implemented the same way as the MockOracleKeyConvertor
 // because this is used in the benchmark_utils::DataCollector when feeding prices
-cfg_if::cfg_if! {
-	if #[cfg(feature = "testing-utils")] {
-		impl XCMCurrencyConversion for SpacewalkNativeCurrencyKey {
-			fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
-				// We assume that the blockchain is always 0 and the symbol represents the token symbol
-				let blockchain = vec![0u8];
-				let symbol = vec![token_symbol];
-				Some((blockchain, symbol))
-			}
-
-			fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
-				// We assume that the blockchain is always 0 and the symbol represents the token symbol
-				if blockchain.len() != 1 && blockchain[0] != 0 || symbol.len() != 1 {
-					return None
-				}
-				return Some(symbol[0])
-			}
-		}
-	}
-	else{
-		impl XCMCurrencyConversion for SpacewalkNativeCurrencyKey {
-			fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
+impl XCMCurrencyConversion for SpacewalkNativeCurrencyKey {
+	fn convert_to_dia_currency_id(token_symbol: u8) -> Option<(Vec<u8>, Vec<u8>)> {
+		cfg_if::cfg_if! {
+			if #[cfg(not(feature = "testing-utils"))] {
 				if token_symbol == 0 {
 					return Some((b"Kusama".to_vec(), b"KSM".to_vec()))
 				}
-
-				// We assume that the blockchain is always 0 and the symbol represents the token symbol
-				let blockchain = vec![0u8];
-				let symbol = vec![token_symbol];
-
-				Some((blockchain, symbol))
-			}
-
-			fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
-				// We assume that the blockchain is always 0 and the symbol represents the token symbol
-				if blockchain.len() != 1 && blockchain[0] != 0 || symbol.len() != 1 {
-					return None
-				}
-				return Some(symbol[0])
 			}
 		}
+		// We assume that the blockchain is always 0 and the symbol represents the token symbol
+		let blockchain = vec![0u8];
+		let symbol = vec![token_symbol];
+
+		Some((blockchain, symbol))
+	}
+
+	fn convert_from_dia_currency_id(blockchain: Vec<u8>, symbol: Vec<u8>) -> Option<u8> {
+		// We assume that the blockchain is always 0 and the symbol represents the token symbol
+		if blockchain.len() != 1 && blockchain[0] != 0 || symbol.len() != 1 {
+			return None
+		}
+		return Some(symbol[0])
 	}
 }
 


### PR DESCRIPTION
PR related to issue https://github.com/pendulum-chain/spacewalk/issues/325
- updated testchain runtime
- use different implementation of `XCMCurrencyConversion` trait depends on enabled feature flag.
- add new implementation for non `testing-utils` feature in spacewalk testnet
- keep the prev implementation of `XCMCurrencyConversion` trait for `SpacewalkNativeCurrencyKey` to keep integration working as expected.