### PR TITLE
Pad CurrencyId slices with space characters instead of '0' bytes

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -529,11 +529,13 @@ impl TryFrom<(&str, AssetIssuer)> for CurrencyId {
 		let slice = value.0;
 		let issuer = value.1;
 		if slice.len() <= 4 {
-			let mut code: Bytes4 = [0; 4];
+			// We pad with space characters to make it more convenient in the UI
+			let mut code: Bytes4 = [b' '; 4];
 			code[..slice.len()].copy_from_slice(slice.as_bytes());
 			Ok(CurrencyId::AlphaNum4(code, issuer))
 		} else if slice.len() > 4 && slice.len() <= 12 {
-			let mut code: Bytes12 = [0; 12];
+			// We pad with space characters to make it more convenient in the UI
+			let mut code: Bytes12 = [b' '; 12];
 			code[..slice.len()].copy_from_slice(slice.as_bytes());
 			Ok(CurrencyId::AlphaNum12(code, issuer))
 		} else {


### PR DESCRIPTION
The code field of Stellar currency IDs needs to have exactly 4 or 12 bytes. So far, we were padding with the `0` byte, ie. 'null' which makes sense. However, it's not easy to put in this 0 byte when using the UI to enter codes in eg. polkadot.js that are less than 4 or 12 characters. That's why, now instead of prefilling the 4 or 12 bytes with `0` bytes, we now fill them with the space character.

Closes #344.