### PR TITLE
Waive fee for successful execution of `execute_issue()` extrinsic

### DIFF
--- a/pallets/issue/src/lib.rs
+++ b/pallets/issue/src/lib.rs
@@ -282,7 +282,10 @@ pub mod pallet {
 				transaction_set_encoded,
 			)?;
 
-			Ok(().into())
+			// Don't take tx fees on success. If the vault had to pay for this function, it would
+			// have been vulnerable to a griefing attack where users would issue amounts just
+			// above the minimum transfer value.
+			Ok(Pays::No.into())
 		}
 
 		/// Cancel the issuance of tokens if expired


### PR DESCRIPTION
This changes the `execute_issue()` extrinsic to not charge a fee upon successful execution. 
The `execute_redeem()` function was not changed because it actually already implements this fee waiving mechanism. 

Closes #348.