### PR TITLE
257 Fix informational issues part 3

### DIFF
--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -22,8 +22,8 @@ use prometheus::Error as PrometheusError;
 pub enum Error {
 	#[error("Could not get exchange rate info")]
 	ExchangeRateInfo,
-	#[error("Exchange Rate list is empty")]
-	FeedingEmptyExchangeRate,
+	#[error("The list is empty. At least one element is required.")]
+	FeedingEmptyList,
 	#[error("Could not get issue id")]
 	RequestIssueIDNotFound,
 	#[error("Could not get redeem id")]

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -22,6 +22,8 @@ use prometheus::Error as PrometheusError;
 pub enum Error {
 	#[error("Could not get exchange rate info")]
 	ExchangeRateInfo,
+	#[error("Exchange Rate list is empty")]
+	FeedingEmptyExchangeRate,
 	#[error("Could not get issue id")]
 	RequestIssueIDNotFound,
 	#[error("Could not get redeem id")]

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -871,7 +871,7 @@ impl OraclePallet for SpacewalkParachain {
 	/// * `value` - the current exchange rate
 	async fn feed_values(&self, values: Vec<((Vec<u8>, Vec<u8>), FixedU128)>) -> Result<(), Error> {
 		if values.is_empty() {
-			return Err(Error::FeedingEmptyExchangeRate);
+			return Err(Error::FeedingEmptyList);
 		}
 
 		use crate::metadata::runtime_types::dia_oracle::dia::CoinInfo;

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -870,6 +870,10 @@ impl OraclePallet for SpacewalkParachain {
 	/// # Arguments
 	/// * `value` - the current exchange rate
 	async fn feed_values(&self, values: Vec<((Vec<u8>, Vec<u8>), FixedU128)>) -> Result<(), Error> {
+		if values.is_empty() {
+			return Err(Error::FeedingEmptyExchangeRate);
+		}
+
 		use crate::metadata::runtime_types::dia_oracle::dia::CoinInfo;
 
 		let now = std::time::SystemTime::now();

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -871,7 +871,7 @@ impl OraclePallet for SpacewalkParachain {
 	/// * `value` - the current exchange rate
 	async fn feed_values(&self, values: Vec<((Vec<u8>, Vec<u8>), FixedU128)>) -> Result<(), Error> {
 		if values.is_empty() {
-			return Err(Error::FeedingEmptyList);
+			return Err(Error::FeedingEmptyList)
 		}
 
 		use crate::metadata::runtime_types::dia_oracle::dia::CoinInfo;

--- a/clients/vault/src/error.rs
+++ b/clients/vault/src/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
 	#[error("StellarWalletError: {0}")]
 	StellarWalletError(#[from] WalletError),
 
-	#[error("Error returned when fetching remote info")]
+	#[error("Error fetching remote info from a Stellar Horizon server")]
 	HorizonResponseError,
 	#[error("Lookup Error")]
 	LookupError,

--- a/clients/vault/src/error.rs
+++ b/clients/vault/src/error.rs
@@ -34,7 +34,7 @@ pub enum Error {
 	StellarWalletError(#[from] WalletError),
 
 	#[error("Error returned when fetching remote info")]
-	HttpFetchingError,
+	HorizonResponseError,
 	#[error("Lookup Error")]
 	LookupError,
 	#[error("Stellar SDK Error")]

--- a/clients/vault/src/issue.rs
+++ b/clients/vault/src/issue.rs
@@ -52,9 +52,10 @@ pub(crate) async fn initialize_issue_set(
 /// # Arguments
 ///
 /// * `parachain_rpc` - the parachain RPC handle
-/// * `vault_secret_key` - The secret key of this vault
+/// * `vault_public_key` - The public key of this vault
 /// * `event_channel` - the channel over which to signal events
 /// * `issues` - a map to save all the new issue requests
+/// * `memos_to_issue_ids` - map of issue memo to issue id
 pub async fn listen_for_issue_requests(
 	parachain_rpc: SpacewalkParachain,
 	vault_public_key: PublicKey,

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -128,7 +128,6 @@ pub async fn start_oracle_agent(
 impl OracleAgent {
 	/// This method returns the proof for a given slot or an error if the proof cannot be provided.
 	/// The agent will try every possible way to get the proof before returning an error.
-	/// Set timeout to 60 seconds; 10 seconds interval.
 	pub async fn get_proof(&self, slot: Slot) -> Result<Proof, Error> {
 		let sender = self
 			.message_sender
@@ -151,6 +150,7 @@ impl OracleAgent {
 					None => {
 						tracing::warn!("Failed to build proof for slot {slot}.");
 						drop(collector);
+						// give 10 seconds interval for every retry
 						sleep(Duration::from_secs(10)).await;
 						continue
 					},

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -84,7 +84,12 @@ impl ScpMessageCollector {
 	/// fetches envelopes from the stellar node
 	async fn ask_node_for_envelopes(&self, slot: Slot, sender: &StellarMessageSender) {
 		// for this slot to be processed, we must put this in our watch list.
-		let _ = sender.send(StellarMessage::GetScpState(slot.try_into().unwrap())).await;
+		if let Err(e) = sender.send(StellarMessage::GetScpState(slot.try_into().unwrap())).await {
+			tracing::error!(
+				"Proof Building for slot {slot}: failed to send `GetScpState` message: {e:?}"
+			);
+			return
+		}
 		tracing::debug!(
 			"Proof Building for slot {slot}: requesting to StellarNode for messages..."
 		);
@@ -196,18 +201,15 @@ impl ScpMessageCollector {
 	///
 	/// * `envelopes_map_lock` - the map to insert the envelopes to.
 	/// * `slot` - the slot where the envelopes belong to
-	fn get_envelopes_from_horizon_archive(
-		&self,
-		slot: Slot,
-	) -> impl Future<Output = Result<(), String>> {
+	fn get_envelopes_from_horizon_archive(&self, slot: Slot) -> impl Future<Output = ()> {
 		tracing::debug!("Fetching SCP envelopes from horizon archive for slot {slot}...");
 		let envelopes_map_arc = self.envelopes_map_clone();
 
 		let archive_urls = self.stellar_history_archive_urls();
 		async move {
 			if archive_urls.is_empty() {
-				tracing::debug!("Cannot get envelopes from horizon archive for slot {slot}: no archive URLs configured");
-				return Err("No archive URLs configured".to_string())
+				tracing::error!("Cannot get envelopes from horizon archive for slot {slot}: no archive URLs configured");
+				return
 			}
 
 			// We try to get the SCPArchive from each archive URL until we succeed or run out of
@@ -217,7 +219,7 @@ impl ScpMessageCollector {
 				let scp_archive_result = scp_archive_storage.get_archive(slot).await;
 				if let Err(e) = scp_archive_result {
 					tracing::error!(
-						"Could not get SCPArchive for slot {slot:?} from Horizon Archive: {e:?}"
+						"Could not get SCPArchive for slot {slot} from Horizon Archive: {e:?}"
 					);
 					continue
 				}
@@ -268,18 +270,18 @@ impl ScpMessageCollector {
 
 						if envelopes_map.get(&slot).is_none() {
 							tracing::debug!(
-							"Adding {} archived SCP envelopes for slot {slot} to envelopes map. {} are externalized",
-							relevant_envelopes.len(),
-							externalized_envelopes_count
-						);
+								"Adding {} archived SCP envelopes for slot {slot} to envelopes map. {} are externalized",
+								relevant_envelopes.len(),
+								externalized_envelopes_count
+							);
 							envelopes_map.insert(slot, relevant_envelopes);
 							break
 						}
 					}
+				} else {
+					tracing::warn!("Could not get ScpHistory entry from archive for slot {slot}");
 				}
 			}
-			// If we get here, we failed to get the envelopes from any archive
-			return Err("Could not get envelopes from any archive".to_string())
 		}
 	}
 
@@ -318,6 +320,10 @@ impl ScpMessageCollector {
 					let mut tx_set_map = txset_map_arc.write();
 					tx_set_map.insert(slot, target_history_entry.tx_set.clone());
 					break
+				} else {
+					tracing::warn!(
+						"Could not get TransactionHistory entry from archive for slot {slot}"
+					);
 				}
 			}
 		}

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -134,7 +134,7 @@ impl ScpMessageCollector {
 		empty
 	}
 
-	/// Returns either a TransactionSet or a ProofStatus saying it failed to retrieve the set.
+	/// Returns a TransactionSet if a txset is found; None if the slot does not have a txset
 	///
 	/// # Arguments
 	///

--- a/clients/vault/src/oracle/storage/impls.rs
+++ b/clients/vault/src/oracle/storage/impls.rs
@@ -55,11 +55,12 @@ impl FileHandlerExt<EnvelopesMap> for EnvelopesFileHandler {
 		let len = data.len();
 
 		for (idx, (key, value)) in data.iter().enumerate() {
+			// writes the first slot as the beginning of the filename
 			if idx == 0 {
 				let _ = write!(filename, "{}_", key);
 			}
-
-			if idx == (len - 1) {
+			// writes the last slot as the ending of the filename
+			else if idx == (len - 1) {
 				let _ = write!(filename, "{}", key);
 			}
 
@@ -106,11 +107,12 @@ impl FileHandlerExt<TxSetMap> for TxSetsFileHandler {
 		let len = data.len();
 
 		for (idx, (key, set)) in data.iter().enumerate() {
+			// writes the first slot as the beginning of the filename
 			if idx == 0 {
 				let _ = write!(filename, "{}_", key);
 			}
-
-			if idx == (len - 1) {
+			// writes the last slot as the ending of the filename
+			else if idx == (len - 1) {
 				let _ = write!(filename, "{}", key);
 			}
 
@@ -220,7 +222,6 @@ mod test {
 		{
 			let slot = 578490;
 			let expected_name = format!("{}_{}", slot - *M_SLOTS_FILE, slot);
-
 			let file_name =
 				EnvelopesFileHandler::find_file_by_slot(slot).expect("should return a file");
 			assert_eq!(&file_name, &expected_name);
@@ -360,6 +361,7 @@ mod test {
 			let mut path = PathBuf::new();
 			path.push("./resources/test/tx_sets_for_testing");
 			path.push(&format!("{}_{}", first_slot, last_slot));
+			println!("find file: {:?}", path);
 
 			let mut file = File::open(path).expect("file should exist");
 			let mut bytes: Vec<u8> = vec![];

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -745,18 +745,18 @@ impl VaultService {
 
 		self.maintain_connection()?;
 
-		self.maybe_register_public_key().await?;
+		self.register_public_key_if_not_present().await?;
 
 		join_all(parsed_auto_register.iter().map(
 			|(collateral_currency, wrapped_currency, amount)| {
-				self.maybe_register_vault(collateral_currency, wrapped_currency, amount)
+				self.register_vault_if_not_present(collateral_currency, wrapped_currency, amount)
 			},
 		))
 		.await
 		.into_iter()
 		.collect::<Result<_, Error>>()?;
 
-		// purposefully _after_ maybe_register_vault and _before_ other calls
+		// purposefully _after_ register_vault_if_not_present and _before_ other calls
 		self.vault_id_manager.fetch_vault_ids().await?;
 
 		let wallet = self.stellar_wallet.write().await;
@@ -801,7 +801,7 @@ impl VaultService {
 		run_and_monitor_tasks(self.shutdown.clone(), tasks).await
 	}
 
-	async fn maybe_register_public_key(&mut self) -> Result<(), Error> {
+	async fn register_public_key_if_not_present(&mut self) -> Result<(), Error> {
 		if let Some(_faucet_url) = &self.config.faucet_url {
 			// TODO fund account with faucet
 		}
@@ -821,7 +821,7 @@ impl VaultService {
 		Ok(())
 	}
 
-	async fn maybe_register_vault(
+	async fn register_vault_if_not_present(
 		&self,
 		collateral_currency: &CurrencyId,
 		wrapped_currency: &CurrencyId,

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -846,9 +846,7 @@ impl VaultService {
 				)
 				.await
 				.map_err(|e| Error::RuntimeError(e))
-		}
-
-		if let Some(_faucet_url) = &self.config.faucet_url {
+		} else if let Some(_faucet_url) = &self.config.faucet_url {
 			tracing::info!("[{}] Automatically registering...", vault_id.pretty_print());
 			// TODO
 			// faucet::fund_and_register(&self.spacewalk_parachain, faucet_url, &vault_id)

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -1,6 +1,6 @@
 use crate::types::StatusCode;
 use primitives::stellar::{types::SequenceNumber, TransactionEnvelope};
-use reqwest::Error as FetchError;
+use reqwest::Error as ReqwestError;
 use std::fmt::{Debug, Display, Formatter};
 use thiserror::Error;
 
@@ -9,7 +9,7 @@ pub enum Error {
 	#[error("Invalid secret key")]
 	InvalidSecretKey,
 	#[error("Error fetching horizon data: {0}")]
-	HttpFetchingError(#[from] FetchError),
+	HorizonResponseError(#[from] ReqwestError),
 	#[error("Could not build transaction: {0}")]
 	BuildTransactionError(String),
 	#[error("Transaction submission failed. Title: {title}, Status: {status}, Reason: {reason}, Envelope XDR: {envelope_xdr:?}")]
@@ -36,7 +36,7 @@ pub enum Error {
 impl Error {
 	pub fn is_recoverable(&self) -> bool {
 		match self {
-			Error::HttpFetchingError(e) if e.is_timeout() => true,
+			Error::HorizonResponseError(e) if e.is_timeout() => true,
 			Error::HorizonSubmissionError { title: _, status, reason: _, envelope_xdr: _ }
 				if *status == 504 =>
 				true,
@@ -56,7 +56,7 @@ impl Error {
 		let server_errors = 500u16..599;
 
 		match self {
-			Error::HttpFetchingError(e) =>
+			Error::HorizonResponseError(e) =>
 				e.status().map(|code| server_errors.contains(&code.as_u16())).unwrap_or(false),
 			Error::HorizonSubmissionError { title: _, status, reason: _, envelope_xdr: _ } =>
 				server_errors.contains(status),

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -298,7 +298,6 @@ where
 		HorizonFetcher::new(horizon_client, vault_account_public_key, is_public_network);
 
 	let mut last_cursor = 0;
-	tracing::info!("CARLA CARLA CARLA listen_for_new_transactions");
 
 	loop {
 		last_cursor = fetcher

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -56,7 +56,7 @@ impl HorizonClient for reqwest::Client {
 		interpret_response::<R>(response).await
 	}
 
-	async fn get_transactions<A: StellarTypeToString<PublicKey, Error> + Send>(
+	async fn get_account_transactions<A: StellarTypeToString<PublicKey, Error> + Send>(
 		&self,
 		account_id: A,
 		is_public_network: bool,
@@ -211,7 +211,7 @@ impl<C: HorizonClient + Clone> HorizonFetcher<C> {
 	) -> Result<TransactionsResponseIter<C>, Error> {
 		let transactions_response = self
 			.client
-			.get_transactions(
+			.get_account_transactions(
 				self.vault_account_public_key.to_encoding(),
 				self.is_public_network,
 				last_cursor,
@@ -298,6 +298,7 @@ where
 		HorizonFetcher::new(horizon_client, vault_account_public_key, is_public_network);
 
 	let mut last_cursor = 0;
+	tracing::info!("CARLA CARLA CARLA listen_for_new_transactions");
 
 	loop {
 		last_cursor = fetcher

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -143,12 +143,13 @@ impl HorizonClient for reqwest::Client {
 			let base_url = horizon_url(is_public_network, need_fallback);
 			let url = format!("{}/transactions", base_url);
 
-			let response =
-				ready(self.post(url).form(&params).send().await.map_err(Error::HorizonResponseError))
-					.and_then(|response| async move {
-						interpret_response::<TransactionResponse>(response).await
-					})
-					.await;
+			let response = ready(
+				self.post(url).form(&params).send().await.map_err(Error::HorizonResponseError),
+			)
+			.and_then(|response| async move {
+				interpret_response::<TransactionResponse>(response).await
+			})
+			.await;
 
 			match response {
 				Err(e) if e.is_recoverable() || e.is_server_error() => {

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -52,7 +52,7 @@ pub fn horizon_url(is_public_network: bool, is_need_fallback: bool) -> &'static 
 impl HorizonClient for reqwest::Client {
 	async fn get_from_url<R: DeserializeOwned>(&self, url: &str) -> Result<R, Error> {
 		tracing::debug!("accessing url: {url:?}");
-		let response = self.get(url).send().await.map_err(Error::HttpFetchingError)?;
+		let response = self.get(url).send().await.map_err(Error::HorizonResponseError)?;
 		interpret_response::<R>(response).await
 	}
 
@@ -144,7 +144,7 @@ impl HorizonClient for reqwest::Client {
 			let url = format!("{}/transactions", base_url);
 
 			let response =
-				ready(self.post(url).form(&params).send().await.map_err(Error::HttpFetchingError))
+				ready(self.post(url).form(&params).send().await.map_err(Error::HorizonResponseError))
 					.and_then(|response| async move {
 						interpret_response::<TransactionResponse>(response).await
 					})

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -49,7 +49,10 @@ pub(crate) async fn interpret_response<T: DeserializeOwned>(
 		return response.json::<T>().await.map_err(Error::HorizonResponseError)
 	}
 
-	let resp = response.json::<serde_json::Value>().await.map_err(Error::HorizonResponseError)?;
+	let resp = response
+		.json::<serde_json::Value>()
+		.await
+		.map_err(Error::HorizonResponseError)?;
 
 	let title = resp[RESPONSE_FIELD_TITLE].as_str().unwrap_or(VALUE_UNKNOWN);
 	let status =

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -46,10 +46,10 @@ pub(crate) async fn interpret_response<T: DeserializeOwned>(
 	response: reqwest::Response,
 ) -> Result<T, Error> {
 	if response.status().is_success() {
-		return response.json::<T>().await.map_err(Error::HttpFetchingError)
+		return response.json::<T>().await.map_err(Error::HorizonResponseError)
 	}
 
-	let resp = response.json::<serde_json::Value>().await.map_err(Error::HttpFetchingError)?;
+	let resp = response.json::<serde_json::Value>().await.map_err(Error::HorizonResponseError)?;
 
 	let title = resp[RESPONSE_FIELD_TITLE].as_str().unwrap_or(VALUE_UNKNOWN);
 	let status =

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -152,7 +152,7 @@ async fn horizon_get_transaction_success() {
 
 	let public_key_encoded = "GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA";
 	let limit = 2;
-	match horizon_client.get_transactions(public_key_encoded, true, 0, limit, false).await {
+	match horizon_client.get_acount_transactions(public_key_encoded, true, 0, limit, false).await {
 		Ok(res) => {
 			let txs = res._embedded.records;
 			assert_eq!(txs.len(), 2);

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -152,7 +152,7 @@ async fn horizon_get_transaction_success() {
 
 	let public_key_encoded = "GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA";
 	let limit = 2;
-	match horizon_client.get_acount_transactions(public_key_encoded, true, 0, limit, false).await {
+	match horizon_client.get_account_transactions(public_key_encoded, true, 0, limit, false).await {
 		Ok(res) => {
 			let txs = res._embedded.records;
 			assert_eq!(txs.len(), 2);

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -152,7 +152,10 @@ async fn horizon_get_transaction_success() {
 
 	let public_key_encoded = "GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA";
 	let limit = 2;
-	match horizon_client.get_account_transactions(public_key_encoded, true, 0, limit, false).await {
+	match horizon_client
+		.get_account_transactions(public_key_encoded, true, 0, limit, false)
+		.await
+	{
 		Ok(res) => {
 			let txs = res._embedded.records;
 			assert_eq!(txs.len(), 2);

--- a/clients/wallet/src/horizon/traits.rs
+++ b/clients/wallet/src/horizon/traits.rs
@@ -17,7 +17,7 @@ use serde::de::DeserializeOwned;
 pub trait HorizonClient {
 	async fn get_from_url<R: DeserializeOwned>(&self, url: &str) -> Result<R, Error>;
 
-	async fn get_transactions<A: StellarTypeToString<PublicKey, Error> + Send>(
+	async fn get_account_transactions<A: StellarTypeToString<PublicKey, Error> + Send>(
 		&self,
 		account_id: A,
 		is_public_network: bool,

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -182,7 +182,7 @@ impl StellarWallet {
 		let horizon_client = Client::new();
 
 		let transactions_response = horizon_client
-			.get_transactions(
+			.get_account_transactions(
 				self.get_public_key(),
 				self.is_public_network,
 				0,

--- a/pallets/issue/src/lib.rs
+++ b/pallets/issue/src/lib.rs
@@ -411,7 +411,7 @@ impl<T: Config> Pallet<T> {
 		);
 		griefing_collateral.lock_on(&requester)?;
 
-		// only continue if the payment is above the minimum transfer amount
+		// only continue if the payment is above or equal to the minimum transfer amount
 		ensure!(
 			amount_requested
 				.ge(&Self::issue_minimum_transfer_amount(vault_id.wrapped_currency()))?,
@@ -425,7 +425,7 @@ impl<T: Config> Pallet<T> {
 		// compatible without loss of precision.
 		let fee = fee.round_to_target_chain()?;
 
-		// calculate the amount of tokens that will be transferred to the user upon execution
+		// calculate the amount of tokens that will be transferred to the user
 		let amount_user = amount_requested.checked_sub(&fee)?;
 
 		let issue_id = ext::security::get_secure_id::<T>();

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -235,7 +235,7 @@ impl<T: Config> Pallet<T> {
 		oracle: T::AccountId,
 		values: Vec<(OracleKey, T::UnsignedFixedPoint)>,
 	) -> DispatchResult {
-		frame_support::ensure!(!values.is_empty(), "the values fed is empty.");
+		frame_support::ensure!(!values.is_empty(), "The provided vector of fed values cannot be empty.");
 
 		let mut oracle_keys: Vec<_> = <OracleKeys<T>>::get();
 

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -235,7 +235,10 @@ impl<T: Config> Pallet<T> {
 		oracle: T::AccountId,
 		values: Vec<(OracleKey, T::UnsignedFixedPoint)>,
 	) -> DispatchResult {
-		frame_support::ensure!(!values.is_empty(), "The provided vector of fed values cannot be empty.");
+		frame_support::ensure!(
+			!values.is_empty(),
+			"The provided vector of fed values cannot be empty."
+		);
 
 		let mut oracle_keys: Vec<_> = <OracleKeys<T>>::get();
 

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -235,6 +235,8 @@ impl<T: Config> Pallet<T> {
 		oracle: T::AccountId,
 		values: Vec<(OracleKey, T::UnsignedFixedPoint)>,
 	) -> DispatchResult {
+		frame_support::ensure!(!values.is_empty(), "the values fed is empty.");
+
 		let mut oracle_keys: Vec<_> = <OracleKeys<T>>::get();
 
 		for (k, v) in values {

--- a/pallets/redeem/src/lib.rs
+++ b/pallets/redeem/src/lib.rs
@@ -158,8 +158,8 @@ pub mod pallet {
 		TryIntoIntError,
 		/// Redeem amount is too small.
 		AmountBelowMinimumTransferAmount,
-		/// Exceeds the volume limit for an issue request.
-		ExceedLimitVolumeForIssueRequest,
+		/// Exceeds the volume limit for a redeem request.
+		ExceedLimitVolumeForRedeemRequest,
 		/// Invalid payment amount
 		InvalidPaymentAmount,
 	}
@@ -1094,23 +1094,23 @@ impl<T: Config> Pallet<T> {
 		Ok(request)
 	}
 
-	fn increase_interval_volume(issue_amount: Amount<T>) -> Result<(), DispatchError> {
+	fn increase_interval_volume(burn_amount: Amount<T>) -> Result<(), DispatchError> {
 		if let Some(_limit_volume) = LimitVolumeAmount::<T>::get() {
-			let issue_volume = Self::convert_into_limit_currency_id_amount(issue_amount)?;
+			let burn_volume = Self::convert_into_limit_currency_id_amount(burn_amount)?;
 			let current_volume = CurrentVolumeAmount::<T>::get();
-			let new_volume = current_volume.saturating_add(issue_volume.amount());
+			let new_volume = current_volume.saturating_add(burn_volume.amount());
 			CurrentVolumeAmount::<T>::put(new_volume);
 		}
 		Ok(())
 	}
 
 	fn convert_into_limit_currency_id_amount(
-		issue_amount: Amount<T>,
+		burn_amount: Amount<T>,
 	) -> Result<Amount<T>, DispatchError> {
-		let issue_volume =
-			oracle::Pallet::<T>::convert(&issue_amount, LimitVolumeCurrencyId::<T>::get())
+		let burn_volume =
+			oracle::Pallet::<T>::convert(&burn_amount, LimitVolumeCurrencyId::<T>::get())
 				.map_err(|_| DispatchError::Other("Missing Exchange Rate"))?;
-		Ok(issue_volume)
+		Ok(burn_volume)
 	}
 
 	fn check_volume(amount_requested: Amount<T>) -> Result<(), DispatchError> {
@@ -1127,11 +1127,11 @@ impl<T: Config> Pallet<T> {
 			} else {
 				current_volume = CurrentVolumeAmount::<T>::get();
 			}
-			let new_issue_request_amount =
+			let new_redeem_request_amount =
 				Self::convert_into_limit_currency_id_amount(amount_requested)?;
 			ensure!(
-				new_issue_request_amount.amount().saturating_add(current_volume) <= limit_volume,
-				Error::<T>::ExceedLimitVolumeForIssueRequest
+				new_redeem_request_amount.amount().saturating_add(current_volume) <= limit_volume,
+				Error::<T>::ExceedLimitVolumeForRedeemRequest
 			);
 		}
 		Ok(())

--- a/pallets/redeem/src/lib.rs
+++ b/pallets/redeem/src/lib.rs
@@ -486,7 +486,6 @@ mod self_redeem {
 		// ensure that vault is not liquidated and not banned
 		ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
-		// for self-redeem, dustAmount is effectively 1 satoshi
 		ensure!(!amount_wrapped.is_zero(), Error::<T>::AmountBelowMinimumTransferAmount);
 
 		let (fees, consumed_issued_tokens) =

--- a/pallets/redeem/src/tests.rs
+++ b/pallets/redeem/src/tests.rs
@@ -1169,7 +1169,7 @@ fn test_request_redeem_fails_limits() {
 
 		assert_err!(
 			Redeem::request_redeem(RuntimeOrigin::signed(redeemer), amount, stellar_address, VAULT),
-			TestError::ExceedLimitVolumeForIssueRequest
+			TestError::ExceedLimitVolumeForRedeemRequest
 		);
 	})
 }
@@ -1432,7 +1432,7 @@ fn test_execute_redeem_fails_when_exceeds_rate_limit() {
 		let stellar_address = RANDOM_STELLAR_PUBLIC_KEY;
 		assert_err!(
 			Redeem::request_redeem(RuntimeOrigin::signed(redeemer), amount, stellar_address, VAULT),
-			TestError::ExceedLimitVolumeForIssueRequest
+			TestError::ExceedLimitVolumeForRedeemRequest
 		);
 	})
 }
@@ -1535,7 +1535,7 @@ fn test_execute_redeem_after_rate_limit_interval_reset_succeeds() {
 		let stellar_address = RANDOM_STELLAR_PUBLIC_KEY;
 		assert_err!(
 			Redeem::request_redeem(RuntimeOrigin::signed(redeemer), amount, stellar_address, VAULT),
-			TestError::ExceedLimitVolumeForIssueRequest
+			TestError::ExceedLimitVolumeForRedeemRequest
 		);
 
 		System::set_block_number(7200 + 20);


### PR DESCRIPTION
continues from #385.

~~This should be merged to branch [257-fix-informational-issues](https://github.com/pendulum-chain/spacewalk/tree/257-fix-informational-issues) AFTER  https://github.com/pendulum-chain/spacewalk/pull/388 , since system.rs contains a lot of changes.~~

* ## IMP-01 Same Behavior Defined for different conditions
  * ### **from audit:**
    * The function create_filename_and_data() from clients/vault/src/oracle/storage/impls.rs has two different if statements inside the for loop that iterates through the Envelopes Map.
    * The if statements handle different cases but their bodies are equal. This means that either one of the statements is missing some change or that in reality, there shouldn't be two different scenarios.
  * ### **files covered:**
    * clients/vault/src/oracle/storage/impls.rs 
      * the if statements are not the same at all. The first `IF` statement is for the beginning of the filename, hence the additional `_` underscore. The 2nd `IF` statement is the last portion of the filename. See test case `write_to_file_success` of the same file.

* ## LIE-04 Mismatch in variable name and pallet
   *  ### **from audit:**
       * The linked variables refer to issue_amount, issue_volume, and new_issue_request_amount, but they are defined in the Redeem pallet. It appears to be a leftover copy from the Issue pallet.
   *  ### **files covered:**
       * pallets/redeem/src
          * lib.rs
          * tests.rs
  
* ## 9B2-02 | Inconsistent Comments
   *  ### **from audit:**
       * The comments at clients/vault/src/oracle/agent.rs states the following: "Set timeout to 60 seconds; 10 seconds interval." While the code indicates that the loop is repeated every 5 seconds.
       * The comments at pallets/redeem/src/lib.rs says: "// for self-redeem, dustAmount is effectively 1 satoshi" refers to satoshi", but the vault collateral is not in Bitcoin.
       * The comment at pallets/issue/src/lib.rs/ "calculate the amount of tokens that will be transferred to the user upon execution" states that the fee, set in the _request_issue, is an amount that will be transferred to the user upon execution." However, the fee is the amount that the user will be paying to the Vault, upon execution.
       * The comment at pallets/issue/src/lib.rs/ states "only continue if the payment is above the minimum transfer amount". Although the expression used in the check is .gewhich in rust representsgreater or equal` expression.
       * The comment at clients/vault/src/issue.rs states that the second argument of the function listen_for_issue_requests() is the vault's secret key, but it is the public one.
       * The comment at clients/vault/src/oracle/collector/proof_builder.rs reports a wrong return type in case of a missing transaction set. The method returns Option::None instead of a ProofStatus type.
   *  ### **files covered:**
       * clients/vault/src/
          * issue.rs
          * oracle/
             * agent.rs
             * collector/proof_builder.rs 
       * pallets/redeem/src/lib.rs
       * pallets/issue/src/lib.rs      

* ## PRF-01 | Unhandled Error
   *  ### **from audit:**
       * We advise the team to manage the potential error. If the method is supposed to work in a best effort manner, at least a tracing log line should be printed for debug purposes.
   *  ### **files covered:**
       * clients/vault/src/oracle/collector/proof_buider.rs

* ## LIH-03 | Values Length Not Validated in `feed_values` Function
   *  ### **from audit:**
       * The function feed_values receive a list of values to be added to the oracle feed. However, the list's length is not validated and it could be empty. This opens the opportunity for a malicious or misconfigured oracle to spam with empty calls and emit useless FeedValues events.
       * We recommend validating the size of the input values of the feed_values function.
   *  ### **files covered:**
       * clients/runtime/src
          * error.rs
          * rpc.rs
       * pallets/oracle/src/lib.rs   

* ## CLI-01 | Confusing Function Naming
   *  ### **from audit:**
       * The function get_transactions() from the HorizonClient trait refers that the function will return the transactions based on their id or other values, calling the /transactions/* endpoints. However, the function's implementation gets all the transactions from a specific account_id. Thus, accessing a different endpoint which is /accounts/:account_id/transactions. A suggested name could be get_account_transactions.
       * Meanwhile, the function maybe_register_public_key() from vault/src/system.rs could improve its naming to "register_public_key_if_not_present". This latter approach directly states what the function will do. Similarly, the function maybe_register_vault() could be renamed to "register_vault_if_not_present".
   *  ### **files covered:**
       * clients/
          * vault/src/system.rs
          * wallet/src/
             * stellar_wallet.rs 
             * horizon/
                * horizon.rs
                * tests.rs
                * traits.rs 
       

* ## CLI-03 | Incorrect Error Type Thrown
   *  ### **from audit:**
       * The function submit_transaction() from wallet/src/horizon.rs creates a request of type POST but the error it throws in case there is one is Error::HttpFetchingError. The most appropriate error to throw should be HttpPostError, which is not defined in wallet/src/error.rs.
       * The same error happens in the function maybe_register_vault() from vault/src/system.rs where the error RuntimeError::VaultLiquidated is thrown whenever the vault is not registered. The correct error should be RuntimeError::VaultNotFound which is thrown by is_vault_registered()
   *  ### **files covered:**
       * clients/
          * vault/src/error.rs
          * wallet/src/error.rs
          * horizon/horizon.rs
          * horizon/responses.rs
             * instead of `HttpPostError`, I went for `HorizonResponseError` because this error only happens in the horizon space; be it post or get.
         * vault/src/system.rs
             * I removed `is_vault_registered()` because I think all functions starting with "is" should return a bool. Seeing that this function is used only twice AND checks for `VaultLiquidated` error anyway, I opted to call SpacewalkParachain's `fn get_vault()` directly.
             * Also moved the logic for registering vault with `maybe_collateral_amount` in another function.
            