### PR TITLE
[WIP] 340 add handling for non recoverable stellar submission errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11225,6 +11225,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.28",
  "mockall 0.8.3",
+ "mocktopus",
  "parity-scale-codec",
  "rand 0.8.5",
  "reqwest",

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -189,7 +189,7 @@ pub async fn handle_replace_request<
 				&event.old_vault_id,
 				event.amount,
 				0, // do not lock any additional collateral
-				wallet.get_public_key_raw(),
+				wallet.public_key_raw(),
 			)
 			.await?)
 	}

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -328,17 +328,17 @@ enum ServiceTask {
 }
 
 fn maybe_run<F, E>(should_run: bool, task: F) -> ServiceTask
-where
-	F: Future<Output = Result<(), E>> + Send + 'static,
-	E: Into<ServiceError<Error>>,
+	where
+		F: Future<Output = Result<(), E>> + Send + 'static,
+		E: Into<ServiceError<Error>>,
 {
 	ServiceTask::Optional(should_run, Box::pin(task.map_err(|x| x.into())))
 }
 
 fn run<F, E>(task: F) -> ServiceTask
-where
-	F: Future<Output = Result<(), E>> + Send + 'static,
-	E: Into<ServiceError<Error>>,
+	where
+		F: Future<Output = Result<(), E>> + Send + 'static,
+		E: Into<ServiceError<Error>>,
 {
 	ServiceTask::Essential(Box::pin(task.map_err(|x| x.into())))
 }
@@ -487,7 +487,7 @@ impl VaultService {
 					startup_height,
 					account_id,
 				)
-				.handle_cancellation::<IssueCanceller>(issue_event_rx)),
+					.handle_cancellation::<IssueCanceller>(issue_event_rx)),
 			),
 		]
 	}
@@ -531,7 +531,7 @@ impl VaultService {
 					startup_height,
 					account_id,
 				)
-				.handle_cancellation::<ReplaceCanceller>(replace_event_rx)),
+					.handle_cancellation::<ReplaceCanceller>(replace_event_rx)),
 			),
 		]
 	}
@@ -751,9 +751,9 @@ impl VaultService {
 				self.register_vault_if_not_present(collateral_currency, wrapped_currency, amount)
 			},
 		))
-		.await
-		.into_iter()
-		.collect::<Result<_, Error>>()?;
+			.await
+			.into_iter()
+			.collect::<Result<_, Error>>()?;
 
 		// purposefully _after_ register_vault_if_not_present and _before_ other calls
 		self.vault_id_manager.fetch_vault_ids().await?;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -328,17 +328,17 @@ enum ServiceTask {
 }
 
 fn maybe_run<F, E>(should_run: bool, task: F) -> ServiceTask
-	where
-		F: Future<Output = Result<(), E>> + Send + 'static,
-		E: Into<ServiceError<Error>>,
+where
+	F: Future<Output = Result<(), E>> + Send + 'static,
+	E: Into<ServiceError<Error>>,
 {
 	ServiceTask::Optional(should_run, Box::pin(task.map_err(|x| x.into())))
 }
 
 fn run<F, E>(task: F) -> ServiceTask
-	where
-		F: Future<Output = Result<(), E>> + Send + 'static,
-		E: Into<ServiceError<Error>>,
+where
+	F: Future<Output = Result<(), E>> + Send + 'static,
+	E: Into<ServiceError<Error>>,
 {
 	ServiceTask::Essential(Box::pin(task.map_err(|x| x.into())))
 }
@@ -487,7 +487,7 @@ impl VaultService {
 					startup_height,
 					account_id,
 				)
-					.handle_cancellation::<IssueCanceller>(issue_event_rx)),
+				.handle_cancellation::<IssueCanceller>(issue_event_rx)),
 			),
 		]
 	}
@@ -531,7 +531,7 @@ impl VaultService {
 					startup_height,
 					account_id,
 				)
-					.handle_cancellation::<ReplaceCanceller>(replace_event_rx)),
+				.handle_cancellation::<ReplaceCanceller>(replace_event_rx)),
 			),
 		]
 	}
@@ -751,9 +751,9 @@ impl VaultService {
 				self.register_vault_if_not_present(collateral_currency, wrapped_currency, amount)
 			},
 		))
-			.await
-			.into_iter()
-			.collect::<Result<_, Error>>()?;
+		.await
+		.into_iter()
+		.collect::<Result<_, Error>>()?;
 
 		// purposefully _after_ register_vault_if_not_present and _before_ other calls
 		self.vault_id_manager.fetch_vault_ids().await?;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -763,7 +763,7 @@ impl VaultService {
 		let is_public_network = wallet.is_public_network();
 
 		// re-submit transactions in the cache
-		wallet.resubmit_transactions_from_cache(true).await;
+		wallet.resubmit_transactions_from_cache().await;
 		drop(wallet);
 
 		let oracle_agent = self.create_oracle_agent(is_public_network).await?;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -763,7 +763,7 @@ impl VaultService {
 		let is_public_network = wallet.is_public_network();
 
 		// re-submit transactions in the cache
-		wallet.resubmit_transactions_from_cache().await;
+		wallet.resubmit_transactions_from_cache(true).await;
 		drop(wallet);
 
 		let oracle_agent = self.create_oracle_agent(is_public_network).await?;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -24,7 +24,7 @@ use runtime::{
 };
 use service::{wait_or_shutdown, Error as ServiceError, MonitoringConfig, Service};
 use stellar_relay_lib::{sdk::PublicKey, StellarOverlayConfig};
-use wallet::{LedgerTxEnvMap, RESUBMISSION_INTERVAL_IN_SECS, StellarWallet};
+use wallet::{LedgerTxEnvMap, StellarWallet, RESUBMISSION_INTERVAL_IN_SECS};
 
 use crate::{
 	cancellation::ReplaceCanceller,
@@ -763,7 +763,9 @@ impl VaultService {
 		let is_public_network = wallet.is_public_network();
 
 		// re-submit transactions in the cache
-		wallet.start_periodic_resubmission_of_transactions_from_cache(RESUBMISSION_INTERVAL_IN_SECS).await;
+		wallet
+			.start_periodic_resubmission_of_transactions_from_cache(RESUBMISSION_INTERVAL_IN_SECS)
+			.await;
 		drop(wallet);
 
 		let oracle_agent = self.create_oracle_agent(is_public_network).await?;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -24,7 +24,7 @@ use runtime::{
 };
 use service::{wait_or_shutdown, Error as ServiceError, MonitoringConfig, Service};
 use stellar_relay_lib::{sdk::PublicKey, StellarOverlayConfig};
-use wallet::{LedgerTxEnvMap, StellarWallet};
+use wallet::{LedgerTxEnvMap, RESUBMISSION_INTERVAL_IN_SECS, StellarWallet};
 
 use crate::{
 	cancellation::ReplaceCanceller,
@@ -763,7 +763,7 @@ impl VaultService {
 		let is_public_network = wallet.is_public_network();
 
 		// re-submit transactions in the cache
-		wallet.resubmit_transactions_from_cache().await;
+		wallet.start_periodic_resubmission_of_transactions_from_cache(RESUBMISSION_INTERVAL_IN_SECS).await;
 		drop(wallet);
 
 		let oracle_agent = self.create_oracle_agent(is_public_network).await?;

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -764,7 +764,12 @@ impl VaultService {
 
 		// re-submit transactions in the cache
 		let _receivers = wallet.resubmit_transactions_from_cache().await;
-		//todo: handle errors from the receivers
+		for result in _receivers {
+			if let Ok(Err(error)) = result.await {
+				let error = error;
+				let _ = wallet.handle_error(error).await;
+			}
+		}
 
 		drop(wallet);
 

--- a/clients/vault/tests/helper/helper.rs
+++ b/clients/vault/tests/helper/helper.rs
@@ -93,7 +93,7 @@ pub async fn register_vault_with_wallet(
 	items: Vec<(&SpacewalkParachain, &VaultId, u128)>,
 ) -> u128 {
 	let wallet_read = wallet.read().await;
-	let public_key = wallet_read.get_public_key();
+	let public_key = wallet_read.public_key();
 
 	let vault_collateral = register_vault(public_key, items).await;
 

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -94,7 +94,7 @@ async fn test_redeem_succeeds() {
 				),
 				async {
 					let wallet_read = user_wallet.read().await;
-					let address = wallet_read.get_public_key_raw();
+					let address = wallet_read.public_key_raw();
 					drop(wallet_read);
 					// We redeem half of what we issued
 					let redeem_id = user_provider
@@ -340,7 +340,7 @@ async fn test_cancel_scheduler_succeeds() {
 			let wallet_read = vault_wallet.read().await;
 			let issue_request_listener = vault::service::listen_for_issue_requests(
 				new_vault_provider.clone(),
-				wallet_read.get_public_key(),
+				wallet_read.public_key(),
 				issue_cancellation_event_tx.clone(),
 				issue_set.clone(),
 				memos_to_issue_ids.clone(),
@@ -473,7 +473,7 @@ async fn test_issue_cancel_succeeds() {
 		let memos_to_issue_ids = Arc::new(RwLock::new(IssueIdLookup::new()));
 
 		let issue_filter =
-			IssueFilter::new(&vault_wallet.read().await.get_public_key()).expect("Invalid filter");
+			IssueFilter::new(&vault_wallet.read().await.public_key()).expect("Invalid filter");
 
 		let issue_amount = upscaled_compatible_amount(100);
 		let vault_collateral = get_required_vault_collateral_for_issue(
@@ -489,7 +489,7 @@ async fn test_issue_cancel_succeeds() {
 				.register_vault_with_public_key(
 					&vault_id,
 					vault_collateral,
-					vault_wallet.read().await.get_public_key_raw(),
+					vault_wallet.read().await.public_key_raw(),
 				)
 				.await
 		);
@@ -524,7 +524,7 @@ async fn test_issue_cancel_succeeds() {
 		let wallet_read = vault_wallet.read().await;
 		let service = join3(
 			vault::service::listen_for_new_transactions(
-				wallet_read.get_public_key(),
+				wallet_read.public_key(),
 				wallet_read.is_public_network(),
 				slot_tx_env_map.clone(),
 				issue_set.clone(),
@@ -533,7 +533,7 @@ async fn test_issue_cancel_succeeds() {
 			),
 			vault::service::listen_for_issue_requests(
 				vault_provider.clone(),
-				wallet_read.get_public_key(),
+				wallet_read.public_key(),
 				issue_event_tx,
 				issue_set.clone(),
 				memos_to_issue_ids.clone(),
@@ -664,7 +664,7 @@ async fn test_automatic_issue_execution_succeeds() {
 					.register_vault_with_public_key(
 						&vault_id,
 						vault_collateral,
-						wallet_read.get_public_key_raw(),
+						wallet_read.public_key_raw(),
 					)
 					.await
 			);
@@ -711,7 +711,7 @@ async fn test_automatic_issue_execution_succeeds() {
 
 			let wallet_read = vault_wallet.read().await;
 			let issue_filter =
-				IssueFilter::new(&wallet_read.get_public_key()).expect("Invalid filter");
+				IssueFilter::new(&wallet_read.public_key()).expect("Invalid filter");
 			let slot_tx_env_map = Arc::new(RwLock::new(HashMap::new()));
 
 			let issue_set = Arc::new(RwLock::new(IssueRequestsMap::new()));
@@ -719,7 +719,7 @@ async fn test_automatic_issue_execution_succeeds() {
 			let (issue_event_tx, _issue_event_rx) = mpsc::channel::<CancellationEvent>(16);
 			let service = join3(
 				vault::service::listen_for_new_transactions(
-					wallet_read.get_public_key(),
+					wallet_read.public_key(),
 					wallet_read.is_public_network(),
 					slot_tx_env_map.clone(),
 					issue_set.clone(),
@@ -728,7 +728,7 @@ async fn test_automatic_issue_execution_succeeds() {
 				),
 				vault::service::listen_for_issue_requests(
 					vault_provider.clone(),
-					wallet_read.get_public_key(),
+					wallet_read.public_key(),
 					issue_event_tx,
 					issue_set.clone(),
 					memos_to_issue_ids.clone(),
@@ -782,7 +782,7 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 					.register_vault_with_public_key(
 						&vault1_id,
 						vault_collateral,
-						wallet_read.get_public_key_raw(),
+						wallet_read.public_key_raw(),
 					)
 					.await
 			);
@@ -791,7 +791,7 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 					.register_vault_with_public_key(
 						&vault2_id,
 						vault_collateral,
-						wallet_read.get_public_key_raw(),
+						wallet_read.public_key_raw(),
 					)
 					.await
 			);
@@ -859,7 +859,7 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 			};
 
 			let wallet_read = vault_wallet.read().await;
-			let vault_account_public_key = wallet_read.get_public_key();
+			let vault_account_public_key = wallet_read.public_key();
 			drop(wallet_read);
 			let issue_filter = IssueFilter::new(&vault_account_public_key).expect("Invalid filter");
 
@@ -927,7 +927,7 @@ async fn test_execute_open_requests_succeeds() {
 					.register_vault_with_public_key(
 						&vault_id,
 						vault_collateral,
-						wallet_read.get_public_key_raw(),
+						wallet_read.public_key_raw(),
 					)
 					.await
 			);
@@ -943,8 +943,8 @@ async fn test_execute_open_requests_succeeds() {
 			.await;
 
 			let wallet_read = user_wallet.read().await;
-			let address = wallet_read.get_public_key();
-			let address_raw = wallet_read.get_public_key_raw();
+			let address = wallet_read.public_key();
+			let address_raw = wallet_read.public_key_raw();
 			drop(wallet_read);
 			// Place redeem requests. 100_00000 is our minimum redeem amount with the current fee
 			// settings defined in the chain spec
@@ -1098,7 +1098,7 @@ async fn test_shutdown() {
 				.register_vault_with_public_key(
 					&sudo_vault_id,
 					vault_collateral,
-					vault_wallet.read().await.get_public_key_raw(),
+					vault_wallet.read().await.public_key_raw(),
 				)
 				.await
 		);
@@ -1146,13 +1146,13 @@ async fn test_requests_with_incompatible_amounts_fail() {
 		.await;
 
 		let wallet_read = vault_wallet.read().await;
-		let address = wallet_read.get_public_key_raw();
+		let address = wallet_read.public_key_raw();
 		assert_ok!(
 			vault_provider
 				.register_vault_with_public_key(
 					&vault_id,
 					vault_collateral,
-					wallet_read.get_public_key_raw()
+					wallet_read.public_key_raw()
 				)
 				.await
 		);

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -710,8 +710,8 @@ async fn test_automatic_issue_execution_succeeds() {
 			};
 
 			let wallet_read = vault_wallet.read().await;
-			let issue_filter =
-				IssueFilter::new(&wallet_read.public_key()).expect("Invalid filter");
+			let issue_filter = IssueFilter::new(&wallet_read.public_key()).expect("Invalid filter");
+
 			let slot_tx_env_map = Arc::new(RwLock::new(HashMap::new()));
 
 			let issue_set = Arc::new(RwLock::new(IssueRequestsMap::new()));

--- a/clients/wallet/Cargo.toml
+++ b/clients/wallet/Cargo.toml
@@ -28,3 +28,4 @@ primitives = { package = "spacewalk-primitives", path = "../../primitives"}
 [dev-dependencies]
 mockall = "0.8.1"
 serial_test = "0.9.0"
+mocktopus = "0.8.0"

--- a/clients/wallet/src/cache.rs
+++ b/clients/wallet/src/cache.rs
@@ -330,7 +330,7 @@ mod test {
 			extract_tx_envelope_from_path, parse_xdr_string_to_vec_u8, Error, WalletStateStorage,
 		},
 		error::CacheErrorKind,
-		test_helper::public_key_from_encoding,
+		mock::public_key_from_encoding,
 	};
 	use primitives::{
 		stellar::{

--- a/clients/wallet/src/cache.rs
+++ b/clients/wallet/src/cache.rs
@@ -153,9 +153,8 @@ impl WalletStateStorage {
 			Ok(_) => tracing::debug!("remove_tx_envelope(): Deleted file with sequence {sequence}"),
 			Err(e) => tracing::error!(
 				"remove_tx_envelope(): Failed to delete file with sequence {sequence}: {e:?}"
-			)
+			),
 		}
-
 	}
 
 	#[allow(dead_code)]

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -99,9 +99,9 @@ impl Error {
 #[derive(Error, PartialEq, Eq)]
 pub struct CacheError {
 	pub(crate) kind: CacheErrorKind,
-	path: Option<String>,
-	envelope: Option<TransactionEnvelope>,
-	sequence_number: Option<SequenceNumber>,
+	pub(crate) path: Option<String>,
+	pub(crate) envelope: Option<TransactionEnvelope>,
+	pub(crate) sequence_number: Option<SequenceNumber>,
 }
 impl Display for CacheError {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
 	#[error(transparent)]
 	CacheError(CacheError),
 
+	#[error("Transaction resubmission failed: {0}")]
+	ResubmissionError(String),
+
 	#[error("Cannot send payment to self")]
 	SelfPaymentError,
 }

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
 		title: String,
 		status: StatusCode,
 		reason: String,
+		result_code_op:Vec<String>,
 		envelope_xdr: Option<String>,
 	},
 	#[error("Could not parse string: {0}")]
@@ -40,7 +41,7 @@ impl Error {
 	pub fn is_recoverable(&self) -> bool {
 		match self {
 			Error::HorizonResponseError(e) if e.is_timeout() => true,
-			Error::HorizonSubmissionError { title: _, status, reason: _, envelope_xdr: _ }
+			Error::HorizonSubmissionError { status, .. }
 				if *status == 504 =>
 				true,
 			Error::CacheError(e) => match e.kind {
@@ -61,7 +62,7 @@ impl Error {
 		match self {
 			Error::HorizonResponseError(e) =>
 				e.status().map(|code| server_errors.contains(&code.as_u16())).unwrap_or(false),
-			Error::HorizonSubmissionError { title: _, status, reason: _, envelope_xdr: _ } =>
+			Error::HorizonSubmissionError { status, .. } =>
 				server_errors.contains(status),
 			_ => false,
 		}

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
 		title: String,
 		status: StatusCode,
 		reason: String,
-		result_code_op:Vec<String>,
+		result_code_op: Vec<String>,
 		envelope_xdr: Option<String>,
 	},
 	#[error("Could not parse string: {0}")]
@@ -41,9 +41,7 @@ impl Error {
 	pub fn is_recoverable(&self) -> bool {
 		match self {
 			Error::HorizonResponseError(e) if e.is_timeout() => true,
-			Error::HorizonSubmissionError { status, .. }
-				if *status == 504 =>
-				true,
+			Error::HorizonSubmissionError { status, .. } if *status == 504 => true,
 			Error::CacheError(e) => match e.kind {
 				CacheErrorKind::CreateDirectoryFailed |
 				CacheErrorKind::FileCreationFailed |
@@ -62,8 +60,7 @@ impl Error {
 		match self {
 			Error::HorizonResponseError(e) =>
 				e.status().map(|code| server_errors.contains(&code.as_u16())).unwrap_or(false),
-			Error::HorizonSubmissionError { status, .. } =>
-				server_errors.contains(status),
+			Error::HorizonSubmissionError { status, .. } => server_errors.contains(status),
 			_ => false,
 		}
 	}

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -14,18 +14,13 @@ use rand::seq::SliceRandom;
 use serde::de::DeserializeOwned;
 use tokio::{sync::RwLock, time::sleep};
 
-use crate::{
-	error::Error,
-	horizon::{
-		responses::{
-			interpret_response, HorizonAccountResponse, HorizonClaimableBalanceResponse,
-			HorizonTransactionsResponse, TransactionResponse, TransactionsResponseIter,
-		},
-		traits::HorizonClient,
+use crate::{error::Error, horizon::{
+	responses::{
+		interpret_response, HorizonAccountResponse, HorizonClaimableBalanceResponse,
+		HorizonTransactionsResponse, TransactionResponse, TransactionsResponseIter,
 	},
-	types::{FilterWith, PagingToken},
-	LedgerTxEnvMap,
-};
+	traits::HorizonClient,
+}, LedgerTxEnvMap, types::{FilterWith, PagingToken}};
 
 const POLL_INTERVAL: u64 = 5000;
 /// See [Stellar doc](https://developers.stellar.org/api/introduction/pagination/page-arguments)
@@ -172,7 +167,7 @@ impl HorizonClient for reqwest::Client {
 					continue
 				},
 
-				Err(Error::HorizonSubmissionError { title, status, reason, envelope_xdr }) => {
+				Err(Error::HorizonSubmissionError { title, status, reason, result_code_op, envelope_xdr }) => {
 					tracing::error!("submitting transaction with seq no: {seq_no:?}: failed with {title}, {reason}");
 					tracing::debug!("submitting transaction with seq no: {seq_no:?}: the envelope: {envelope_xdr:?}");
 					let envelope_xdr = envelope_xdr.or(Some(transaction_xdr.to_string()));
@@ -181,6 +176,7 @@ impl HorizonClient for reqwest::Client {
 						title,
 						status,
 						reason,
+						result_code_op,
 						envelope_xdr,
 					})
 				},

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -14,13 +14,18 @@ use rand::seq::SliceRandom;
 use serde::de::DeserializeOwned;
 use tokio::{sync::RwLock, time::sleep};
 
-use crate::{error::Error, horizon::{
-	responses::{
-		interpret_response, HorizonAccountResponse, HorizonClaimableBalanceResponse,
-		HorizonTransactionsResponse, TransactionResponse, TransactionsResponseIter,
+use crate::{
+	error::Error,
+	horizon::{
+		responses::{
+			interpret_response, HorizonAccountResponse, HorizonClaimableBalanceResponse,
+			HorizonTransactionsResponse, TransactionResponse, TransactionsResponseIter,
+		},
+		traits::HorizonClient,
 	},
-	traits::HorizonClient,
-}, LedgerTxEnvMap, types::{FilterWith, PagingToken}};
+	types::{FilterWith, PagingToken},
+	LedgerTxEnvMap,
+};
 
 const POLL_INTERVAL: u64 = 5000;
 /// See [Stellar doc](https://developers.stellar.org/api/introduction/pagination/page-arguments)
@@ -167,7 +172,13 @@ impl HorizonClient for reqwest::Client {
 					continue
 				},
 
-				Err(Error::HorizonSubmissionError { title, status, reason, result_code_op, envelope_xdr }) => {
+				Err(Error::HorizonSubmissionError {
+					title,
+					status,
+					reason,
+					result_code_op,
+					envelope_xdr,
+				}) => {
 					tracing::error!("submitting transaction with seq no: {seq_no:?}: failed with {title}, {reason}");
 					tracing::debug!("submitting transaction with seq no: {seq_no:?}: the envelope: {envelope_xdr:?}");
 					let envelope_xdr = envelope_xdr.or(Some(transaction_xdr.to_string()));

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -73,6 +73,7 @@ pub(crate) async fn interpret_response<T: DeserializeOwned>(
 						title: title.to_string(),
 						status,
 						reason: detail.to_string(),
+						result_code_op: vec![],
 						envelope_xdr: Some(envelope_xdr.to_string()),
 					}
 				},
@@ -93,7 +94,8 @@ pub(crate) async fn interpret_response<T: DeserializeOwned>(
 					Error::HorizonSubmissionError {
 						title: title.to_string(),
 						status,
-						reason: format!("{result_code_tx}: {result_code_op:?}"),
+						reason: format!("{result_code_tx}"),
+						result_code_op,
 						envelope_xdr: Some(envelope_xdr.to_string()),
 					}
 				},
@@ -106,6 +108,7 @@ pub(crate) async fn interpret_response<T: DeserializeOwned>(
 				title: title.to_string(),
 				status,
 				reason: detail.to_string(),
+				result_code_op: vec![],
 				envelope_xdr: None,
 			}
 		},

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -94,7 +94,7 @@ pub(crate) async fn interpret_response<T: DeserializeOwned>(
 					Error::HorizonSubmissionError {
 						title: title.to_string(),
 						status,
-						reason: format!("{result_code_tx}"),
+						reason: result_code_tx.to_string(),
 						result_code_op,
 						envelope_xdr: Some(envelope_xdr.to_string()),
 					}

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -9,7 +9,7 @@ use primitives::{
 		types::{
 			Memo, OperationResult, SequenceNumber, TransactionResult, TransactionResultResult,
 		},
-		Asset, TransactionEnvelope, XdrCodec,
+		Asset, PublicKey, TransactionEnvelope, XdrCodec,
 	},
 	MemoTypeExt, TextMemo,
 };
@@ -249,6 +249,10 @@ impl TransactionResponse {
 			.map_err(|_| Error::DecodeError)?;
 
 		res.parse::<SequenceNumber>().map_err(|_| Error::DecodeError)
+	}
+
+	pub fn source_account(&self) -> Result<PublicKey, Error> {
+		PublicKey::from_encoding(&self.source_account).map_err(|_| Error::DecodeError)
 	}
 
 	pub fn get_successful_operations_result(&self) -> Result<Vec<OperationResult>, Error> {

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -275,7 +275,7 @@ impl TransactionResponse {
 	}
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 pub struct HorizonAccountResponse {
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub id: Vec<u8>,
@@ -285,6 +285,17 @@ pub struct HorizonAccountResponse {
 	pub sequence: i64,
 	pub balances: Vec<HorizonBalance>,
 	// ...
+}
+
+impl Debug for HorizonAccountResponse {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("HorizonAccountResponse")
+			.field("id", &debug_str_or_vec_u8!(&self.id))
+			.field("account_id", &debug_str_or_vec_u8!(&self.account_id))
+			.field("sequence", &self.sequence)
+			.field("balances", &self.balances)
+			.finish()
+	}
 }
 
 impl HorizonAccountResponse {

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 		responses::{HorizonClaimableBalanceResponse, TransactionResponse},
 		traits::HorizonClient,
 	},
-	test_helper::secret_key_from_encoding,
+	mock::secret_key_from_encoding,
 };
 use mockall::predicate::*;
 use primitives::stellar::{

--- a/clients/wallet/src/lib.rs
+++ b/clients/wallet/src/lib.rs
@@ -18,10 +18,7 @@ pub (crate) mod mock;
 
 mod resubmissions;
 
-
-pub use types::{LedgerTxEnvMap, Slot};
 pub use resubmissions::*;
-
+pub use types::{LedgerTxEnvMap, Slot};
 
 pub type TransactionsResponseIter = horizon::responses::TransactionsResponseIter<reqwest::Client>;
-

--- a/clients/wallet/src/lib.rs
+++ b/clients/wallet/src/lib.rs
@@ -14,7 +14,7 @@ mod task;
 pub mod types;
 
 #[cfg(test)]
-pub (crate) mod mock;
+pub(crate) mod mock;
 
 mod resubmissions;
 

--- a/clients/wallet/src/lib.rs
+++ b/clients/wallet/src/lib.rs
@@ -13,28 +13,15 @@ mod stellar_wallet;
 mod task;
 pub mod types;
 
+#[cfg(test)]
+pub (crate) mod mock;
+
+mod resubmissions;
+
+
 pub use types::{LedgerTxEnvMap, Slot};
+pub use resubmissions::*;
+
 
 pub type TransactionsResponseIter = horizon::responses::TransactionsResponseIter<reqwest::Client>;
 
-#[cfg(test)]
-pub mod test_helper {
-	use primitives::{
-		stellar::{Asset, PublicKey, SecretKey},
-		CurrencyId,
-	};
-
-	pub const USDC_ISSUER: &str = "GAKNDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC";
-	pub fn default_usdc_asset() -> Asset {
-		let asset = CurrencyId::try_from(("USDC", USDC_ISSUER)).expect("should convert ok");
-		asset.try_into().expect("should convert to Asset")
-	}
-
-	pub fn public_key_from_encoding<T: AsRef<[u8]>>(encoded_key: T) -> PublicKey {
-		PublicKey::from_encoding(encoded_key).expect("should return a public key")
-	}
-
-	pub fn secret_key_from_encoding<T: AsRef<[u8]>>(encoded_key: T) -> SecretKey {
-		SecretKey::from_encoding(encoded_key).expect("should return a secret key")
-	}
-}

--- a/clients/wallet/src/mock.rs
+++ b/clients/wallet/src/mock.rs
@@ -1,107 +1,104 @@
+use crate::{
+	error::Error,
+	horizon::HorizonClient,
+	operations::{create_payment_operation, redeem_request_tests::create_account_merge_operation},
+	StellarWallet, TransactionResponse,
+};
+use primitives::{
+	stellar::{
+		types::SequenceNumber, Asset as StellarAsset, PublicKey, SecretKey, TransactionEnvelope,
+	},
+	CurrencyId, StellarStroops,
+};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use primitives::{stellar::{Asset as StellarAsset, PublicKey, SecretKey}, CurrencyId, StellarStroops};
-use primitives::stellar::TransactionEnvelope;
-use primitives::stellar::types::SequenceNumber;
-use crate::horizon::HorizonClient;
-use crate::{StellarWallet, TransactionResponse};
-use crate::error::Error;
-use crate::operations::create_payment_operation;
-use crate::operations::redeem_request_tests::create_account_merge_operation;
 
 pub const DEFAULT_DEST_PUBLIC_KEY: &str =
-    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+	"GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 pub const STELLAR_VAULT_SECRET_KEY: &str =
-    "SCV7RZN5XYYMMVSWYCR4XUMB76FFMKKKNHP63UTZQKVM4STWSCIRLWFJ";
+	"SCV7RZN5XYYMMVSWYCR4XUMB76FFMKKKNHP63UTZQKVM4STWSCIRLWFJ";
 pub const IS_PUBLIC_NETWORK: bool = false;
 
 pub const DEFAULT_STROOP_FEE_PER_OPERATION: u32 = 100;
 
 impl StellarWallet {
-    pub async fn is_account_exist(&self) -> bool {
-        self.client
-            .get_account(self.public_key(), self.is_public_network())
-            .await
-            .is_ok()
-    }
+	pub async fn is_account_exist(&self) -> bool {
+		self.client
+			.get_account(self.public_key(), self.is_public_network())
+			.await
+			.is_ok()
+	}
 
-    /// merges the wallet's account with the specified destination.
-    /// Exercise prudence when using this method, as it automatically removes the source account
-    /// once operation is successful.
-    pub async fn merge_account(
-        &mut self,
-        destination_address: PublicKey,
-    ) -> Result<TransactionResponse, Error> {
-        let account_merge_op = create_account_merge_operation(
-            destination_address,
-            self.public_key(),
-        )?;
+	/// merges the wallet's account with the specified destination.
+	/// Exercise prudence when using this method, as it automatically removes the source account
+	/// once operation is successful.
+	pub async fn merge_account(
+		&mut self,
+		destination_address: PublicKey,
+	) -> Result<TransactionResponse, Error> {
+		let account_merge_op =
+			create_account_merge_operation(destination_address, self.public_key())?;
 
-        self.send_to_address(
-            [9u8; 32],
-            DEFAULT_STROOP_FEE_PER_OPERATION,
-            vec![account_merge_op],
-        )
-            .await
-    }
+		self.send_to_address([9u8; 32], DEFAULT_STROOP_FEE_PER_OPERATION, vec![account_merge_op])
+			.await
+	}
 
-    pub fn create_payment_envelope(
-        &self,
-        destination_address: PublicKey,
-        asset: StellarAsset,
-        stroop_amount: StellarStroops,
-        request_id: [u8; 32],
-        stroop_fee_per_operation: u32,
-        next_sequence_number: SequenceNumber,
-    ) -> Result<TransactionEnvelope, Error> {
-        let public_key = self.public_key();
-        // create payment operation
-        let payment_op = create_payment_operation(
-            destination_address,
-            asset,
-            stroop_amount,
-            public_key.clone(),
-        )?;
+	pub fn create_payment_envelope(
+		&self,
+		destination_address: PublicKey,
+		asset: StellarAsset,
+		stroop_amount: StellarStroops,
+		request_id: [u8; 32],
+		stroop_fee_per_operation: u32,
+		next_sequence_number: SequenceNumber,
+	) -> Result<TransactionEnvelope, Error> {
+		let public_key = self.public_key();
+		// create payment operation
+		let payment_op = create_payment_operation(
+			destination_address,
+			asset,
+			stroop_amount,
+			public_key.clone(),
+		)?;
 
-        self.create_envelope(
-            request_id,
-            stroop_fee_per_operation,
-            next_sequence_number,
-            vec![payment_op],
-        )
-    }
+		self.create_envelope(
+			request_id,
+			stroop_fee_per_operation,
+			next_sequence_number,
+			vec![payment_op],
+		)
+	}
 }
 
 pub fn wallet_with_storage(storage: &str) -> Result<Arc<RwLock<StellarWallet>>, Error> {
-    wallet_with_secret_key_for_storage(storage, STELLAR_VAULT_SECRET_KEY)
+	wallet_with_secret_key_for_storage(storage, STELLAR_VAULT_SECRET_KEY)
 }
 
 pub fn wallet_with_secret_key_for_storage(
-    storage: &str,
-    secret_key: &str,
+	storage: &str,
+	secret_key: &str,
 ) -> Result<Arc<RwLock<StellarWallet>>, Error> {
-    Ok(Arc::new(RwLock::new(StellarWallet::from_secret_encoded_with_cache(
-        secret_key,
-        IS_PUBLIC_NETWORK,
-        storage.to_string(),
-    )?)))
+	Ok(Arc::new(RwLock::new(StellarWallet::from_secret_encoded_with_cache(
+		secret_key,
+		IS_PUBLIC_NETWORK,
+		storage.to_string(),
+	)?)))
 }
 
 pub fn default_destination() -> PublicKey {
-    public_key_from_encoding(DEFAULT_DEST_PUBLIC_KEY)
+	public_key_from_encoding(DEFAULT_DEST_PUBLIC_KEY)
 }
-
 
 pub const USDC_ISSUER: &str = "GAKNDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC";
 pub fn default_usdc_asset() -> StellarAsset {
-    let asset = CurrencyId::try_from(("USDC", USDC_ISSUER)).expect("should convert ok");
-    asset.try_into().expect("should convert to Asset")
+	let asset = CurrencyId::try_from(("USDC", USDC_ISSUER)).expect("should convert ok");
+	asset.try_into().expect("should convert to Asset")
 }
 
 pub fn public_key_from_encoding<T: AsRef<[u8]>>(encoded_key: T) -> PublicKey {
-    PublicKey::from_encoding(encoded_key).expect("should return a public key")
+	PublicKey::from_encoding(encoded_key).expect("should return a public key")
 }
 
 pub fn secret_key_from_encoding<T: AsRef<[u8]>>(encoded_key: T) -> SecretKey {
-    SecretKey::from_encoding(encoded_key).expect("should return a secret key")
+	SecretKey::from_encoding(encoded_key).expect("should return a secret key")
 }

--- a/clients/wallet/src/mock.rs
+++ b/clients/wallet/src/mock.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use primitives::{stellar::{Asset as StellarAsset, PublicKey, SecretKey}, CurrencyId, StellarStroops};
+use primitives::stellar::TransactionEnvelope;
+use primitives::stellar::types::SequenceNumber;
+use crate::horizon::HorizonClient;
+use crate::{StellarWallet, TransactionResponse};
+use crate::error::Error;
+use crate::operations::create_payment_operation;
+use crate::operations::redeem_request_tests::create_account_merge_operation;
+
+pub const DEFAULT_DEST_PUBLIC_KEY: &str =
+    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+pub const STELLAR_VAULT_SECRET_KEY: &str =
+    "SCV7RZN5XYYMMVSWYCR4XUMB76FFMKKKNHP63UTZQKVM4STWSCIRLWFJ";
+pub const IS_PUBLIC_NETWORK: bool = false;
+
+pub const DEFAULT_STROOP_FEE_PER_OPERATION: u32 = 100;
+
+impl StellarWallet {
+    pub async fn is_account_exist(&self) -> bool {
+        self.client
+            .get_account(self.public_key(), self.is_public_network())
+            .await
+            .is_ok()
+    }
+
+    /// merges the wallet's account with the specified destination.
+    /// Exercise prudence when using this method, as it automatically removes the source account
+    /// once operation is successful.
+    pub async fn merge_account(
+        &mut self,
+        destination_address: PublicKey,
+    ) -> Result<TransactionResponse, Error> {
+        let account_merge_op = create_account_merge_operation(
+            destination_address,
+            self.public_key(),
+        )?;
+
+        self.send_to_address(
+            [9u8; 32],
+            DEFAULT_STROOP_FEE_PER_OPERATION,
+            vec![account_merge_op],
+        )
+            .await
+    }
+
+    pub fn create_payment_envelope(
+        &self,
+        destination_address: PublicKey,
+        asset: StellarAsset,
+        stroop_amount: StellarStroops,
+        request_id: [u8; 32],
+        stroop_fee_per_operation: u32,
+        next_sequence_number: SequenceNumber,
+    ) -> Result<TransactionEnvelope, Error> {
+        let public_key = self.public_key();
+        // create payment operation
+        let payment_op = create_payment_operation(
+            destination_address,
+            asset,
+            stroop_amount,
+            public_key.clone(),
+        )?;
+
+        self.create_envelope(
+            request_id,
+            stroop_fee_per_operation,
+            next_sequence_number,
+            vec![payment_op],
+        )
+    }
+}
+
+pub fn wallet_with_storage(storage: &str) -> Result<Arc<RwLock<StellarWallet>>, Error> {
+    wallet_with_secret_key_for_storage(storage, STELLAR_VAULT_SECRET_KEY)
+}
+
+pub fn wallet_with_secret_key_for_storage(
+    storage: &str,
+    secret_key: &str,
+) -> Result<Arc<RwLock<StellarWallet>>, Error> {
+    Ok(Arc::new(RwLock::new(StellarWallet::from_secret_encoded_with_cache(
+        secret_key,
+        IS_PUBLIC_NETWORK,
+        storage.to_string(),
+    )?)))
+}
+
+pub fn default_destination() -> PublicKey {
+    public_key_from_encoding(DEFAULT_DEST_PUBLIC_KEY)
+}
+
+
+pub const USDC_ISSUER: &str = "GAKNDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC";
+pub fn default_usdc_asset() -> StellarAsset {
+    let asset = CurrencyId::try_from(("USDC", USDC_ISSUER)).expect("should convert ok");
+    asset.try_into().expect("should convert to Asset")
+}
+
+pub fn public_key_from_encoding<T: AsRef<[u8]>>(encoded_key: T) -> PublicKey {
+    PublicKey::from_encoding(encoded_key).expect("should return a public key")
+}
+
+pub fn secret_key_from_encoding<T: AsRef<[u8]>>(encoded_key: T) -> SecretKey {
+    SecretKey::from_encoding(encoded_key).expect("should return a secret key")
+}

--- a/clients/wallet/src/mock.rs
+++ b/clients/wallet/src/mock.rs
@@ -102,6 +102,21 @@ impl StellarWallet {
 
 		Ok(transaction.into_transaction_envelope())
 	}
+
+	pub async fn create_dummy_envelope_no_signature(
+		&self,
+		stroop_amount: StellarStroops,
+	) -> Result<TransactionEnvelope, Error> {
+		let sequence = self.get_sequence().await?;
+		self.create_payment_envelope_no_signature(
+			default_destination(),
+			StellarAsset::native(),
+			stroop_amount,
+			rand::random(),
+			DEFAULT_STROOP_FEE_PER_OPERATION,
+			sequence + 1,
+		)
+	}
 }
 
 pub fn wallet_with_storage(storage: &str) -> Result<Arc<RwLock<StellarWallet>>, Error> {

--- a/clients/wallet/src/operations.rs
+++ b/clients/wallet/src/operations.rs
@@ -93,7 +93,7 @@ pub trait RedeemOperationsExt: HorizonClient {
 			// if account exists and NO trustline, use claimable balance operation
 			Ok(_) => claimable_balance_operation(),
 			// if INactive account...
-			Err(Error::HorizonSubmissionError { title: _, status, reason: _, envelope_xdr: _ })
+			Err(Error::HorizonSubmissionError { status, .. })
 				if status == 404 =>
 			{
 				let to_be_redeemed_amount_u128 = stellar_stroops_to_u128(to_be_redeemed_amount);
@@ -184,7 +184,7 @@ pub fn create_basic_spacewalk_stellar_transaction(
 #[cfg(test)]
 pub mod redeem_request_tests {
 	use super::*;
-	use crate::test_helper::{
+	use crate::mock::{
 		default_usdc_asset, public_key_from_encoding, secret_key_from_encoding,
 	};
 	use primitives::{stellar::SecretKey, CurrencyId};

--- a/clients/wallet/src/operations.rs
+++ b/clients/wallet/src/operations.rs
@@ -93,9 +93,7 @@ pub trait RedeemOperationsExt: HorizonClient {
 			// if account exists and NO trustline, use claimable balance operation
 			Ok(_) => claimable_balance_operation(),
 			// if INactive account...
-			Err(Error::HorizonSubmissionError { status, .. })
-				if status == 404 =>
-			{
+			Err(Error::HorizonSubmissionError { status, .. }) if status == 404 => {
 				let to_be_redeemed_amount_u128 = stellar_stroops_to_u128(to_be_redeemed_amount);
 
 				// ... and redeeming amount >= 1 XLM, use create account operation
@@ -184,9 +182,7 @@ pub fn create_basic_spacewalk_stellar_transaction(
 #[cfg(test)]
 pub mod redeem_request_tests {
 	use super::*;
-	use crate::mock::{
-		default_usdc_asset, public_key_from_encoding, secret_key_from_encoding,
-	};
+	use crate::mock::{default_usdc_asset, public_key_from_encoding, secret_key_from_encoding};
 	use primitives::{stellar::SecretKey, CurrencyId};
 
 	const INACTIVE_STELLAR_SECRET_KEY: &str =

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -23,7 +23,10 @@ const MAX_LOOK_BACK_PAGES: u8 = 10;
 
 #[cfg_attr(test, mockable)]
 impl StellarWallet {
-	pub async fn start_periodic_resubmission_of_transactions_from_cache(&self, interval_in_seconds: u64) {
+	pub async fn start_periodic_resubmission_of_transactions_from_cache(
+		&self,
+		interval_in_seconds: u64,
+	) {
 		// Perform the resubmission
 		self._resubmit_transactions_from_cache().await;
 
@@ -110,7 +113,6 @@ impl StellarWallet {
 		#[allow(unused_mut)] mut errors: Vec<(Error, TransactionEnvelope)>,
 	) {
 		while let Some((error, env)) = errors.pop() {
-
 			// handle the error
 			match self.handle_error(error).await {
 				// a new kind of error occurred. Process it on the next loop.
@@ -121,8 +123,8 @@ impl StellarWallet {
 					errors.push((e, env));
 				},
 
-				// Resubmission failed for this Transaction Envelope and it's a non-recoverable error
-				// Remove from cache
+				// Resubmission failed for this Transaction Envelope and it's a non-recoverable
+				// error Remove from cache
 				Ok(None) => self.remove_tx_envelope_from_cache(&env),
 
 				// Resubmission was successful
@@ -706,7 +708,8 @@ mod test {
 		// let's resubmit these 3 transactions
 		let _ = wallet.start_periodic_resubmission_of_transactions_from_cache(60).await;
 
-		// We wait until the whole cache is empty because eventually all transactions should be handled
+		// We wait until the whole cache is empty because eventually all transactions should be
+		// handled
 		pause_process_in_secs(10).await;
 
 		loop {

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -35,7 +35,6 @@ impl StellarWallet {
 			let me_clone = Arc::clone(&me);
 			loop {
 				// Loops every 30 minutes or 1800 seconds
-				#[cfg(not(test))]
 				pause_process_in_secs(interval_in_seconds).await;
 
 				me_clone._resubmit_transactions_from_cache().await;
@@ -706,7 +705,7 @@ mod test {
 			.mock_safe(move |_, _| MockResult::Return(Box::pin(async move { false })));
 
 		// let's resubmit these 3 transactions
-		let _ = wallet.start_periodic_resubmission_of_transactions_from_cache(RESUBMISSION_INTERVAL_IN_SECS).await;
+		let _ = wallet.start_periodic_resubmission_of_transactions_from_cache(60).await;
 
 		// We wait until the whole cache is empty because eventually all transactions should be handled
 		pause_process_in_secs(10).await;

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -358,7 +358,7 @@ async fn auto_check_running_tasks(running_tasks: FailedTasks, wallet: Arc<Stella
 	tokio::spawn(async move {
 		loop {
 			#[cfg(not(test))]
-			pause_process_in_secs(30).await;
+			pause_process_in_secs(1800).await;
 
 			#[cfg(test)]
 			pause_process_in_secs(5).await;

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -70,9 +70,11 @@ impl StellarWallet {
 		//  Log those with errors.
 		let envelopes = match self.get_tx_envelopes_from_cache() {
 			Ok((envs, errors)) => {
-				tracing::warn!(
-					"_resubmit_transactions_from_cache(): errors from cache: {errors:?}"
-				);
+				if !errors.is_empty(){
+					tracing::warn!(
+						"_resubmit_transactions_from_cache(): errors from cache: {errors:?}"
+					);
+				}
 				envs
 			},
 			Err(errors) => {
@@ -92,7 +94,7 @@ impl StellarWallet {
 		if envelopes.is_empty() {
 			return
 		}
-		tracing::info!("resubmitting {:?} envelopes in cache...", envelopes.len());
+		tracing::info!("_resubmit_transactions_from_cache(): resubmitting {:?} envelopes in cache...", envelopes.len());
 
 		let mut error_collector = vec![];
 		// loop through the envelopes and resubmit each one

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -44,7 +44,8 @@ impl StellarWallet {
 		tokio::spawn(async move {
 		    let me_clone = Arc::clone(&me);
 		    loop {
-		        pause_process_in_secs(300).await;
+				// loops every 30 minutes or 1800 seconds
+		        pause_process_in_secs(1800).await;
 
 		        me_clone._resubmit_transactions_from_cache(running_tasks_clone.clone(),auto_check).await;
 		    }

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -140,7 +140,7 @@ impl StellarWallet {
 	/// Returns:
 	/// * `TransactionResponse` for successful resubmission;
 	/// * None for errors that cannot be resubmitted;
-	/// * An error that can be resubmitted again
+	/// * An error that can potentially be resubmitted again
 	///
 	/// This function determines whether an error is up for resubmission or not:
 	/// `tx_bad_seq` or `SequenceNumberAlreadyUsed` can be resubmitted by updating the sequence
@@ -709,7 +709,7 @@ mod test {
 		// let's resubmit these 3 transactions
 		let _ = wallet.resubmit_transactions_from_cache().await;
 
-		// let's pause for awhile, to catch up with the
+		// let's pause for awhile, to catch up with the transactions that need resubmission
 		pause_process_in_secs(10).await;
 
 		loop {

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -266,11 +266,11 @@ impl StellarWallet {
 				// assume that we already submitted this transaction.
 				match response.source_account() {
 					// no source account was found; move on to the next response
-					Err(_)  => continue,
+					Err(_) => continue,
 					// the wallet's public key is not this response's source account;
 					// move on to the next response
 					Ok(source_account) if !source_account.eq(&own_public_key) => continue,
-					_ => {}
+					_ => {},
 				}
 
 				// Check that the transaction contains the memo that we want to send.

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -131,6 +131,7 @@ impl StellarWallet {
 	/// * `failed_tasks` - a list of receivers that will receive a `TransactionEnvelope`
 	async fn handle_errors(
 		&self,
+		#[allow(unused_mut)]
 		mut errors: Vec<(Error, TransactionEnvelope)>,
 		failed_tasks: FailedTasks,
 	) {

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -322,7 +322,6 @@ mod test {
 		TransactionEnvelopeExt,
 	};
 	use serial_test::serial;
-	use crate::resubmissions::RESUBMISSION_INTERVAL_IN_SECS;
 
 	#[tokio::test]
 	#[serial]

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -1,0 +1,414 @@
+use std::sync::Arc;
+
+use std::time::Duration;
+use tokio::time::sleep;
+use primitives::stellar::{Memo, Transaction, TransactionEnvelope, XdrCodec};
+use primitives::TransactionEnvelopeExt;
+use crate::{StellarWallet, TransactionResponse};
+use crate::error::{CacheError, CacheErrorKind, Error};
+use crate::error::Error::{DecodeError, ResubmissionError};
+
+#[cfg(test)]
+use mocktopus::macros::mockable;
+
+#[cfg_attr(test, mockable)]
+impl StellarWallet {
+
+    /// Submits transactions found in the wallet's cache to Stellar.
+    pub async fn resubmit_transactions_from_cache(&self) {
+        let _ = self.transaction_submission_lock.lock().await;
+
+        // Collect all envelopes from cache. Log those with errors.
+        let envelopes =  match self.get_tx_envelopes_from_cache() {
+            Ok((envs, errors)) => {
+                tracing::warn!("resubmit_transactions_from_cache(): errors from cache: {errors:?}");
+                println!("resubmit_transactions_from_cache(): errors from cache: {errors:?}");
+                envs
+            }
+            Err(errors) => {
+                tracing::warn!("resubmit_transactions_from_cache(): errors from cache: {errors:?}");
+                println!("resubmit_transactions_from_cache(): errors from cache: {errors:?}");
+                return
+            }
+        };
+
+        let submit = |envelope:TransactionEnvelope| async {
+            self.submit_transaction(envelope).await
+        };
+
+        // there's nothing to resubmit
+        if envelopes.is_empty() { return }
+
+        let mut error_collector = vec![];
+        for envelope in envelopes {
+            if let Err(e) = submit(envelope).await {
+                println!("encountered error: {e:?}");
+                error_collector.push(e);
+            }
+        }
+
+        // handle errors found after submission
+        if !error_collector.is_empty() {
+            self.handle_errors(error_collector).await;
+        }
+    }
+
+    /// Handle all errors
+    async fn handle_errors(&self, errors:Vec<Error>) {
+        let me = Arc::new(self.clone());
+
+        for e in errors.into_iter() {
+            let mut error = e;
+            let x = error.to_string();
+            let me_clone = Arc::clone(&me);
+            tokio::spawn(async move {
+                loop {
+                    println!("handle_errors(): handle error: {error:?}");
+                    match me_clone.handle_error(error).await {
+                        Ok(res) => {
+                            println!("handle_errors(): handled: {x:?} ");
+                            return;
+                        },
+                        Err(e) => error = e
+                    }
+                    sleep(Duration::from_secs(1800)).await;
+                }
+            });
+        }
+    }
+
+    /// Determines whether an error is up for resubmission or not:
+    /// `tx_bad_seq` or `SequenceNumberAlreadyUsed` can be resubmitted by updating the sequence number
+    /// `tx_internal_error` should be resubmitted again
+    /// other errors must be logged and removed from cache.
+    async fn handle_error(&self, error: Error) -> Result<(), Error> {
+        match &error {
+            Error::HorizonSubmissionError { reason, envelope_xdr, .. } => {
+                match &reason[..] {
+                    "tx_bad_seq" =>
+                        return self.handle_tx_bad_seq_error_with_xdr(envelope_xdr).await
+                            .map(|_| ()),
+                    "tx_internal_error" =>
+                        return self.handle_tx_internal_error(envelope_xdr).await
+                            .map(|_| ()),
+                    _ => {
+                        if let Ok(env) = decode_to_envelope(envelope_xdr) {
+                            if let Some(sequence) = env.sequence_number() {
+                                if let Err(e) = self.remove_tx_envelope_from_cache(sequence) {
+                                    tracing::warn!("handle_error():: failed to remove transaction with sequence {sequence}: {e:?}");
+                                }
+                            }
+                        };
+                        tracing::error!(
+							"handle_error(): Unrecoverable HorizonSubmissionError: {error:?}"
+						);
+                    },
+                }
+            }
+            Error::CacheError(CacheError {
+                                  kind: CacheErrorKind::SequenceNumberAlreadyUsed,
+                                  envelope,
+                                  ..
+                              }) =>
+                if let Some(transaction_envelope) = envelope {
+                    return self.handle_tx_bad_seq_error_with_envelope(transaction_envelope.clone()).await
+                        .map(|_| ());
+                } else {
+                    tracing::warn!(
+						"handle_error(): SequenceNumberAlreadyUsed error but no envelope"
+					);
+                    println!(
+						"handle_error(): SequenceNumberAlreadyUsed error but no envelope"
+					);
+                },
+            _ => {
+                tracing::warn!("handle_error(): Unrecoverable error in Stellar wallet: {error:?}");
+            },
+        }
+
+        Ok(())
+    }
+
+    async fn handle_tx_internal_error(&self, envelope_xdr_as_str_opt:&Option<String>) -> Result<TransactionResponse,Error> {
+       let mut envelope =  decode_to_envelope(envelope_xdr_as_str_opt)?;
+        self.sign_envelope(&mut envelope)?;
+
+        self.submit_transaction(envelope).await
+    }
+}
+
+// handle tx_bad_seq
+#[cfg_attr(test, mockable)]
+impl StellarWallet {
+    async fn handle_tx_bad_seq_error_with_xdr(&self, envelope_xdr_as_str_opt:&Option<String>) -> Result<TransactionResponse,Error> {
+        let Some( envelope_xdr) = envelope_xdr_as_str_opt else {
+            tracing::warn!("handle_tx_bad_seq_error_with_xdr(): tx_bad_seq error but no envelope_xdr");
+
+            println!("handle_tx_bad_seq_error_with_xdr(): tx_bad_seq error but no envelope_xdr");
+            return Err(ResubmissionError(
+                "tx_bad_seq error but no envelope_xdr".to_string(),
+            ))
+        };
+
+        let tx_envelope =
+            TransactionEnvelope::from_base64_xdr(envelope_xdr)
+                .map_err(|_| DecodeError)?;
+
+        tracing::info!(
+			"handle_tx_bad_seq_error_with_xdr(): tx_bad_seq error. Resubmitting {envelope_xdr}");
+
+        println!(
+			"handle_tx_bad_seq_error_with_xdr(): tx_bad_seq error. Resubmitting {envelope_xdr}");
+        self.handle_tx_bad_seq_error_with_envelope(tx_envelope).await
+    }
+
+    async fn handle_tx_bad_seq_error_with_envelope(
+        &self,
+        tx_envelope: TransactionEnvelope,
+    ) -> Result<TransactionResponse, Error> {
+        let tx = tx_envelope.get_transaction().ok_or(DecodeError)?;
+        println!("handle_tx_bad_seq_error_with_envelope(): time to process transaction: {}",tx.seq_num);
+
+        // Check if we already submitted this transaction
+        if !self.is_transaction_already_submitted(&tx).await {
+            return self.bump_sequence_number_and_submit(tx).await
+        } else {
+            tracing::error!("handle_tx_bad_seq_error_with_envelope(): Similar transaction already submitted. Skipping {:?}", tx);
+            println!("handle_tx_bad_seq_error_with_envelope(): Similar transaction already submitted. Skipping {:?}", tx);
+            Err(ResubmissionError("Transaction already submitted".to_string()))
+        }
+    }
+
+    async fn bump_sequence_number_and_submit(
+        &self,
+        tx: Transaction,
+    ) -> Result<TransactionResponse, Error> {
+        let sequence_number = self.get_sequence().await?;
+
+        println!("Old sequence number: {}", tx.seq_num);
+        let mut updated_tx = tx.clone();
+        updated_tx.seq_num = sequence_number + 1 ;
+
+        println!("New sequence number: {}", updated_tx.seq_num);
+
+        let envelope = self.sign_and_create_envelope(updated_tx)?;
+
+        self.submit_transaction(envelope).await
+    }
+
+    /// This function iterates over all transactions of an account to see if a similar transaction
+    /// i.e. a transaction containing the same memo was already submitted previously.
+    /// TODO: This operation is very costly and we should try to optimize it in the future.
+    async fn is_transaction_already_submitted(&self, tx: &Transaction) -> bool {
+
+        println!("is_transaction_already_submitted(): start finding...");
+
+        let mut remaining_page = 10;
+        let own_public_key = self.public_key();
+
+        while let Ok(transaction) = self.get_all_transactions_iter().await {
+
+            println!("is_transaction_already_submitted(): analyze:");
+
+            if remaining_page == 0 {
+                break
+            }
+
+            for response in transaction.records {
+                // Make sure that we are the sender and not the receiver because otherwise an
+                // attacker could send a transaction to us with the target memo and we'd wrongly
+                // assume that we already submitted this transaction.
+                let Ok(source_account) = response.source_account() else {
+                    continue
+                };
+                if !source_account.eq(&own_public_key) {
+                    continue
+                }
+
+                // Check that the transaction contains the memo that we want to send.
+                let Some(response_memo) = response.memo_text() else { continue };
+                let Memo::MemoText(tx_memo) = &tx.memo else { continue };
+
+                if are_memos_eq(response_memo, tx_memo.get_vec()) {
+                    println!("is_transaction_already_submitted(): found a match!");
+                    return true
+                }
+            }
+            remaining_page -= 1;
+        }
+
+        println!("is_transaction_already_submitted(): found NO match!");
+        // We did not find a transaction that matched our criteria
+        false
+    }
+}
+
+#[cfg_attr(test, mockable)]
+fn are_memos_eq(memo1: &Vec<u8>, memo2: &Vec<u8>) -> bool {
+    memo1 == memo2
+}
+
+fn decode_to_envelope(envelope_xdr_as_str_opt:&Option<String>) -> Result<TransactionEnvelope, Error> {
+    let Some( envelope_xdr) = envelope_xdr_as_str_opt else {
+        tracing::warn!("handle_error(): tx_bad_seq error but no envelope_xdr");
+        return Err(ResubmissionError(
+            "tx_bad_seq error but no envelope_xdr".to_string(),
+        ))
+    };
+
+    TransactionEnvelope::from_base64_xdr(envelope_xdr).map_err(|_| DecodeError)
+}
+
+#[cfg(test)]
+mod test {
+    use mocktopus::mocking::{Mockable, MockResult};
+    use primitives::stellar::{Asset as StellarAsset, TransactionEnvelope, XdrCodec};
+    use primitives::TransactionEnvelopeExt;
+    use crate::mock::*;
+    use crate::StellarWallet;
+    use serial_test::serial;
+    #[tokio::test]
+    #[serial]
+    async fn resubmit_transactions_works() {
+        let wallet = wallet_with_storage("resources/resubmit_transactions_works")
+            .expect("should return an arc rwlock wallet")
+            .clone();
+        let wallet = wallet.write().await;
+
+        // let's send a successful transaction first
+
+        let asset = StellarAsset::native();
+        let amount = 1001;
+
+        let seq_number = wallet.get_sequence().await.expect("should return a sequence");
+
+        // creating a `tx_bad_seq` envelope.
+        let bad_request_id: [u8;32] = rand::random();
+        let bad_envelope = wallet
+            .create_payment_envelope(
+                default_destination(),
+                asset.clone(),
+                amount,
+                bad_request_id,
+                DEFAULT_STROOP_FEE_PER_OPERATION,
+                seq_number+5,
+            )
+            .expect("should return an envelope");
+
+        // let's save this in storage
+        let _ = wallet.save_tx_envelope_to_cache(bad_envelope.clone()).expect("should save.");
+
+        // create a successful transaction
+        let good_request_id: [u8;32] = rand::random();
+        let good_envelope = wallet
+            .create_payment_envelope(
+                default_destination(),
+                asset,
+                amount,
+                good_request_id,
+                DEFAULT_STROOP_FEE_PER_OPERATION,
+                seq_number + 1,
+            )
+            .expect("should return an envelope");
+
+        StellarWallet::is_transaction_already_submitted
+            .mock_safe(move |_, _| MockResult::Return(Box::pin(async move { false })));
+
+        // let's save this in storage
+        let _ = wallet.save_tx_envelope_to_cache(good_envelope.clone()).expect("should save");
+
+        // let's resubmit these 2 transactions
+        wallet.resubmit_transactions_from_cache().await;
+
+        let actual_sequence = wallet.get_sequence().await
+            .expect("should return a sequence number");
+
+
+        // 1 should pass, and 1 should fail.
+        assert_eq!(actual_sequence, seq_number+1);
+
+        wallet.remove_cache_dir();
+    }
+
+
+    #[tokio::test]
+    async fn handle_error_for_tx_bad_seq() {
+        let wallet = wallet_with_storage("resources/handle_error_works")
+            .expect("should return an arc rwlock wallet")
+            .clone();
+        let mut wallet = wallet.write().await;
+
+        // let's send a successful transaction first
+        let asset = StellarAsset::native();
+        let amount = 1001;
+        let request_id = [0u8; 32];
+
+        let response = wallet
+            .send_payment_to_address(
+                default_destination(),
+                asset.clone(),
+                amount,
+                request_id,
+                DEFAULT_STROOP_FEE_PER_OPERATION,
+                false,
+            )
+            .await
+            .expect("should be ok");
+
+        // get the sequence number of the previous one.
+        let env =
+            TransactionEnvelope::from_base64_xdr(response.envelope_xdr).expect("should convert ok");
+        let seq_number = env.sequence_number().expect("should return sequence number");
+
+        // creating a `tx_bad_seq` envelope.
+        let bad_request_id: [u8; 32] = rand::random();
+        let bad_envelope = wallet
+            .create_payment_envelope(
+                default_destination(),
+                asset.clone(),
+                amount,
+                bad_request_id,
+                DEFAULT_STROOP_FEE_PER_OPERATION,
+                seq_number,
+            )
+            .expect("should return an envelope");
+
+        let Err(error) = wallet.submit_transaction(bad_envelope).await else {
+            println!("oh my, it passed");
+            panic!("failed!!");
+
+        };
+
+        println!("The wallet error: {error:?}");
+
+        // Set this to false so that the wallet will try to resubmit the transaction.
+        StellarWallet::is_transaction_already_submitted
+            .mock_safe(move |_, _| MockResult::Return(Box::pin(async move { false })));
+
+        let result = wallet.handle_error(error).await;
+
+        // We assume that the transaction was re-created and submitted successfully.
+        println!("AND THE RESULT IS: {result:?}");
+        assert!(result.is_ok());
+
+
+        // let response = result.unwrap();
+        // assert_eq!(response.successful, true);
+        //
+        // // Try to handle the same error but this time the transaction was already submitted.
+        // let submission_error = Error::HorizonSubmissionError {
+        //     title: "title".to_string(),
+        //     status: 400,
+        //     reason: "tx_bad_seq".to_string(),
+        //     envelope_xdr: envelope_xdr,
+        // };
+        //
+        // StellarWallet::is_transaction_already_submitted
+        //     .mock_safe(move |_, _| MockResult::Return(Box::pin(async move { true })));
+        //
+        // let result = wallet.handle_error(submission_error).await;
+        // assert!(result.is_err());
+
+        wallet.remove_cache_dir();
+    }
+}

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -365,10 +365,6 @@ async fn auto_check_running_tasks(running_tasks: FailedTasks, wallet: Arc<Stella
 
 			let mut res = running_tasks.write().await;
 
-			if res.is_empty() {
-				break
-			}
-
 			let mut receiver = res.pop().expect("should return something");
 
 			// cannot resubmit

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -217,7 +217,7 @@ impl StellarWallet {
 		self.cache.get_tx_envelopes()
 	}
 
-	pub fn remove_tx_envelope_from_cache(&self, sequence: SequenceNumber) -> Result<(), Error> {
+	pub fn remove_tx_envelope_from_cache(&self, sequence: SequenceNumber) {
 		self.cache.remove_tx_envelope(sequence)
 	}
 

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -61,7 +61,7 @@ impl StellarWallet {
 
 	/// Returns a TransactionResponse after submitting transaction envelope to Stellar,
 	/// Else an Error.
-	pub async fn submit_transaction(
+	async fn submit_transaction(
 		&self,
 		envelope: TransactionEnvelope,
 	) -> Result<TransactionResponse, Error> {

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -61,7 +61,7 @@ impl StellarWallet {
 
 	/// Returns a TransactionResponse after submitting transaction envelope to Stellar,
 	/// Else an Error.
-	async fn submit_transaction(
+	pub async fn submit_transaction(
 		&self,
 		envelope: TransactionEnvelope,
 	) -> Result<TransactionResponse, Error> {

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -29,6 +29,8 @@ use crate::{
 };
 use primitives::{StellarPublicKeyRaw, StellarStroops, TransactionEnvelopeExt};
 
+#[cfg(test)]
+use mocktopus::macros::mockable;
 
 #[derive(Clone)]
 pub struct StellarWallet {
@@ -225,6 +227,7 @@ impl StellarWallet {
 }
 
 // send/submit functions of StellarWallet
+#[cfg_attr(test, mockable)]
 impl StellarWallet {
 	/// Returns a TransactionResponse after submitting transaction envelope to Stellar,
 	/// Else an Error.

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -70,6 +70,8 @@ impl StellarWallet {
 			envelope.clone(),
 		))?;
 
+		let _ = self.cache.save_tx_envelope(envelope.clone())?;
+
 		let submission_result = self
 			.client
 			.submit_transaction(
@@ -363,8 +365,6 @@ impl StellarWallet {
 			next_sequence_number,
 			operations,
 		)?;
-
-		let _ = self.cache.save_tx_envelope(envelope.clone())?;
 
 		self.submit_transaction(envelope).await
 	}

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -70,7 +70,7 @@ impl StellarWallet {
 			envelope.clone(),
 		))?;
 
-		let _ = self.cache.save_tx_envelope(envelope.clone())?;
+		let _ = self.cache.save_tx_envelope(envelope.clone());
 
 		let submission_result = self
 			.client

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -30,7 +30,7 @@ use stellar::{
 pub use substrate_stellar_sdk as stellar;
 use substrate_stellar_sdk::{
 	types::{OperationBody, SequenceNumber},
-	ClaimPredicate, Claimant, Memo, MuxedAccount, Operation, TransactionEnvelope,
+	ClaimPredicate, Claimant, Memo, MuxedAccount, Operation, Transaction, TransactionEnvelope,
 };
 
 #[cfg(test)]
@@ -801,6 +801,8 @@ pub trait TransactionEnvelopeExt {
 		-> u128;
 
 	fn sequence_number(&self) -> Option<SequenceNumber>;
+
+	fn get_transaction(&self) -> Option<Transaction>;
 }
 
 impl TransactionEnvelopeExt for TransactionEnvelope {
@@ -867,6 +869,15 @@ impl TransactionEnvelopeExt for TransactionEnvelope {
 			TransactionEnvelope::EnvelopeTypeTxV0(env) => Some(env.tx.seq_num),
 			TransactionEnvelope::EnvelopeTypeTx(env) => Some(env.tx.seq_num),
 			TransactionEnvelope::EnvelopeTypeTxFeeBump(_) | TransactionEnvelope::Default(_) => None,
+		}
+	}
+
+	fn get_transaction(&self) -> Option<Transaction> {
+		match self {
+			TransactionEnvelope::EnvelopeTypeTxV0(transaction) =>
+				Some(transaction.tx.clone().into()),
+			TransactionEnvelope::EnvelopeTypeTx(transaction) => Some(transaction.tx.clone()),
+			_ => None,
 		}
 	}
 }


### PR DESCRIPTION
The aim of this PR is to add error handling logic for failed submissions.

Closes #340

## General overview of the changes:
1. A few method renames;
1. Introduce new file: `resubmissions.rs`, dedicated for resubmission and handling of errors. Bulk of the code is here
2. Introduced new file: `mock.rs`, contains the function helpers for the tests cases
3. ~Also updated the `resubmit_transactions_from_cache()`, with a parameter that helps handle failed tasks~

## How to begin the review:
* clients/wallet/src/resubmissions.rs
  * ~type `FailedTasks` = essential for removing transaction envelopes in cache for failed resubmissions~
    * :star: instead of complicating things with channels, I just immediately call the `remove_tx_envelope_from_cache()` if the error is not viable for resubmission
  * fn `resubmit_transactions_from_cache()` = the only public method. Every 30 minutes it will read from cache and resubmit existing ones
  * fn `_resubmit_transactions_from_cache()`
     1.  Collect all envelopes from cache.
     2. Loops through all envelopes and resubmit them
     3.  ^ collects errors from the loop and tries to handle them
     4. ~if auto check is set to true, check `fn auto_check_running_tasks()`~
  * fn `handle_errors()`
    * loops through all the errors and handle them one by one
    * :star: for errors that cannot be resubmitted again, its corresponding envelope is removed from cache
  * fn `handle_error()` = resubmits transactions with the ff errors: 
    * `tx_bad_seq`
    * `tx_internal_error`
    * `CacheErrorKind::SequenceNumberAlreadyUsed`
 * fn `handle_tx_internal_error()` = resubmits a transaction with the error `tx_internal_error`
 * fn `handle_tx_bad_seq_error_with_xdr()` = resubmits a transaction with the error `tx_bad_seq`
 * fn `bump_sequence_number_and_submit()` = bump the sequence number of a transaction and resubmits it
 * fn `is_transaction_already_submitted()` = a costly checking if a transaction already exists. This is currently limited to just 10 pages
 * ~fn `auto_check_running_tasks()` = auto checks for failed resubmissions and forcefully remove transactions from the cache~
