### PR TITLE
263 add optimizations audit recommendations

### DIFF
--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -1202,6 +1202,8 @@ impl RedeemPallet for SpacewalkParachain {
 	}
 }
 
+type CustomFilter = Box<dyn Fn((H256, SpacewalkReplaceRequest)) -> bool + Send>;
+
 #[async_trait]
 pub trait ReplacePallet {
 	/// Request the replacement of a new vault ownership
@@ -1270,7 +1272,7 @@ pub trait ReplacePallet {
 	async fn get_old_vault_replace_requests(
 		&self,
 		account_id: AccountId,
-		filter: impl Fn((H256, SpacewalkReplaceRequest)) -> bool + Send,
+		filter: CustomFilter,
 	) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, Error>;
 
 	/// Get the time difference in number of blocks between when a replace
@@ -1367,7 +1369,7 @@ impl ReplacePallet for SpacewalkParachain {
 	async fn get_old_vault_replace_requests(
 		&self,
 		account_id: AccountId,
-		filter: impl Fn((H256, SpacewalkReplaceRequest)) -> bool + Send,
+		filter: CustomFilter,
 	) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, Error> {
 		let head = self.get_finalized_block_hash().await?;
 		let result: Vec<H256> = self

--- a/clients/vault/src/cancellation.rs
+++ b/clients/vault/src/cancellation.rs
@@ -169,7 +169,18 @@ impl<P: IssuePallet + ReplacePallet + Send + Sync> Canceller<P> for ReplaceCance
 // verbose drain_filter
 fn drain_expired(requests: &mut Vec<ActiveRequest>, current_height: u32) -> Vec<ActiveRequest> {
 
-	requests.drain(..).filter(|active_req| current_height > active_req.parachain_deadline_height).collect()
+	let mut expired = Vec::new();
+	
+    requests.retain(|req| {
+        if current_height > req.parachain_deadline_height {
+            expired.push(req.clone());
+            false
+        } else {
+            true
+        }
+    });
+
+    expired
 	
 }
 

--- a/clients/vault/src/cancellation.rs
+++ b/clients/vault/src/cancellation.rs
@@ -168,18 +168,9 @@ impl<P: IssuePallet + ReplacePallet + Send + Sync> Canceller<P> for ReplaceCance
 
 // verbose drain_filter
 fn drain_expired(requests: &mut Vec<ActiveRequest>, current_height: u32) -> Vec<ActiveRequest> {
-	let mut expired = Vec::new();
-	let has_expired = |request: &ActiveRequest| current_height > request.parachain_deadline_height;
-	let mut i = 0;
-	while i != requests.len() {
-		if has_expired(&requests[i]) {
-			let req = requests.remove(i);
-			expired.push(req);
-		} else {
-			i += 1;
-		}
-	}
-	expired
+
+	requests.drain(..).filter(|active_req| current_height > active_req.parachain_deadline_height).collect()
+	
 }
 
 /// The actual cancellation scheduling and handling

--- a/clients/vault/src/cancellation.rs
+++ b/clients/vault/src/cancellation.rs
@@ -168,20 +168,18 @@ impl<P: IssuePallet + ReplacePallet + Send + Sync> Canceller<P> for ReplaceCance
 
 // verbose drain_filter
 fn drain_expired(requests: &mut Vec<ActiveRequest>, current_height: u32) -> Vec<ActiveRequest> {
-
 	let mut expired = Vec::new();
-	
-    requests.retain(|req| {
-        if current_height > req.parachain_deadline_height {
-            expired.push(req.clone());
-            false
-        } else {
-            true
-        }
-    });
 
-    expired
-	
+	requests.retain(|req| {
+		if current_height > req.parachain_deadline_height {
+			expired.push(req.clone());
+			false
+		} else {
+			true
+		}
+	});
+
+	expired
 }
 
 /// The actual cancellation scheduling and handling

--- a/clients/vault/src/cancellation.rs
+++ b/clients/vault/src/cancellation.rs
@@ -172,7 +172,7 @@ fn drain_expired(requests: &mut Vec<ActiveRequest>, current_height: u32) -> Vec<
 
 	requests.retain(|req| {
 		if current_height > req.parachain_deadline_height {
-			expired.push(req.clone());
+			expired.push(*req);
 			false
 		} else {
 			true

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -377,9 +377,9 @@ pub async fn execute_open_requests(
 	//closure to filter redeem_requests
 	let filter_redeem_reqs = |(hash, request): (H256, SpacewalkRedeemRequest)| {
 		if request.status == RedeemRequestStatus::Pending {
-			Request::from_redeem_request(hash, request, payment_margin).ok()
+			true
 		} else {
-			None
+			false
 		}
 	};
 
@@ -394,7 +394,7 @@ pub async fn execute_open_requests(
 
 	// get all redeem and replace requests
 	let (open_redeems, open_replaces) = try_join!(
-		parachain_rpc.get_vault_redeem_requests::<Request>(vault_id.clone(), filter_redeem_reqs),
+		parachain_rpc.get_vault_redeem_requests(vault_id.clone(), Box::new(filter_redeem_reqs)),
 		parachain_rpc
 			.get_old_vault_replace_requests(vault_id.clone(), Box::new(filter_replace_reqs)),
 	)?;

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -382,7 +382,7 @@ pub async fn execute_open_requests(
 			None
 		}
 	};
-	
+
 	//closure to filter and transform replace_requests
 	let filter_replace_reqs = move |(hash, request): (H256, SpacewalkReplaceRequest)| {
 		if request.status == ReplaceRequestStatus::Pending {
@@ -394,11 +394,14 @@ pub async fn execute_open_requests(
 
 	// get all redeem and replace requests
 	let (open_redeems, open_replaces) = try_join!(
-		parachain_rpc.get_vault_redeem_requests::<Request>(vault_id.clone(), Box::new(filter_redeem_reqs)),
 		parachain_rpc
-			.get_old_vault_replace_requests::<Request>(vault_id.clone(), Box::new(filter_replace_reqs)),
+			.get_vault_redeem_requests::<Request>(vault_id.clone(), Box::new(filter_redeem_reqs)),
+		parachain_rpc.get_old_vault_replace_requests::<Request>(
+			vault_id.clone(),
+			Box::new(filter_replace_reqs)
+		),
 	)?;
-	
+
 	// collect all requests into a hashmap, indexed by their id
 	let mut open_requests = open_redeems
 		.into_iter()

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -395,7 +395,8 @@ pub async fn execute_open_requests(
 	// get all redeem and replace requests
 	let (open_redeems, open_replaces) = try_join!(
 		parachain_rpc.get_vault_redeem_requests::<Request>(vault_id.clone(), filter_redeem_reqs),
-		parachain_rpc.get_old_vault_replace_requests(vault_id.clone(), filter_replace_reqs),
+		parachain_rpc
+			.get_old_vault_replace_requests(vault_id.clone(), Box::new(filter_replace_reqs)),
 	)?;
 
 	// collect all requests into a hashmap, indexed by their id

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -386,16 +386,16 @@ pub async fn execute_open_requests(
 	//closure to filter replace_requests
 	let filter_replace_reqs = |(hash, request): (H256, SpacewalkReplaceRequest)| {
 		if request.status == ReplaceRequestStatus::Pending {
-			Request::from_replace_request(hash, request, payment_margin).ok()
+			true
 		} else {
-			None
+			false
 		}
 	};
 
 	// get all redeem and replace requests
 	let (open_redeems, open_replaces) = try_join!(
 		parachain_rpc.get_vault_redeem_requests::<Request>(vault_id.clone(), filter_redeem_reqs),
-		parachain_rpc.get_old_vault_replace_requests_filter::<Request>(vault_id.clone(), filter_replace_reqs),
+		parachain_rpc.get_old_vault_replace_requests(vault_id.clone(), filter_replace_reqs),
 	)?;
 
 	// collect all requests into a hashmap, indexed by their id

--- a/clients/vault/src/execution.rs
+++ b/clients/vault/src/execution.rs
@@ -374,29 +374,34 @@ pub async fn execute_open_requests(
 	let parachain_rpc = &parachain_rpc;
 	let vault_id = parachain_rpc.get_account_id().clone();
 
-	// get all redeem and replace requests
-	let (redeem_requests, replace_requests) = try_join!(
-		parachain_rpc.get_vault_redeem_requests(vault_id.clone()),
-		parachain_rpc.get_old_vault_replace_requests(vault_id.clone()),
-	)?;
-
-	let open_redeems = redeem_requests
-		.into_iter()
-		.filter(|(_, request)| request.status == RedeemRequestStatus::Pending)
-		.filter_map(|(hash, request)| {
+	//closure to filter redeem_requests
+	let filter_redeem_reqs = |(hash, request): (H256, SpacewalkRedeemRequest)| {
+		if request.status == RedeemRequestStatus::Pending {
 			Request::from_redeem_request(hash, request, payment_margin).ok()
-		});
+		} else {
+			None
+		}
+	};
 
-	let open_replaces = replace_requests
-		.into_iter()
-		.filter(|(_, request)| request.status == ReplaceRequestStatus::Pending)
-		.filter_map(|(hash, request)| {
+	//closure to filter replace_requests
+	let filter_replace_reqs = |(hash, request): (H256, SpacewalkReplaceRequest)| {
+		if request.status == ReplaceRequestStatus::Pending {
 			Request::from_replace_request(hash, request, payment_margin).ok()
-		});
+		} else {
+			None
+		}
+	};
+
+	// get all redeem and replace requests
+	let (open_redeems, open_replaces) = try_join!(
+		parachain_rpc.get_vault_redeem_requests::<Request>(vault_id.clone(), filter_redeem_reqs),
+		parachain_rpc.get_old_vault_replace_requests_filter::<Request>(vault_id.clone(), filter_replace_reqs),
+	)?;
 
 	// collect all requests into a hashmap, indexed by their id
 	let mut open_requests = open_redeems
-		.chain(open_replaces)
+		.into_iter()
+		.chain(open_replaces.into_iter())
 		.map(|x| (derive_shortened_request_id(&x.hash.0), x))
 		.collect::<HashMap<_, _>>();
 
@@ -461,7 +466,7 @@ pub async fn execute_open_requests(
 
 	// All requests remaining in the hashmap did not have a Stellar payment yet, so pay
 	// and execute all of these
-	for (_, request) in open_requests {
+	for (_, request) in open_requests.into_iter() {
 		// there are potentially a large number of open requests - pay and execute each
 		// in a separate task to ensure that awaiting confirmations does not significantly
 		// delay other requests

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -469,7 +469,7 @@ pub async fn poll_metrics<
 	loop {
 		publish_native_currency_balance(parachain_rpc).await?;
 		publish_issue_count(parachain_rpc, vault_id_manager).await;
-		
+
 		let pass_all_filter = |item: (H256, SpacewalkRedeemRequest)| Some(item);
 
 		if let Ok(redeems) = parachain_rpc

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -15,8 +15,7 @@ use runtime::{
 	types::currency_id::CurrencyIdExt,
 	AggregateUpdatedEvent, CollateralBalancesPallet, CurrencyId, Error as RuntimeError, FixedU128,
 	IssuePallet, IssueRequestStatus, OracleKey, RedeemPallet, RedeemRequestStatus, SecurityPallet,
-	SpacewalkParachain, UtilFuncs, VaultId, VaultRegistryPallet, H256,
-	SpacewalkRedeemRequest
+	SpacewalkParachain, SpacewalkRedeemRequest, UtilFuncs, VaultId, VaultRegistryPallet, H256,
 };
 use service::{
 	warp::{Rejection, Reply},
@@ -471,10 +470,13 @@ pub async fn poll_metrics<
 		publish_native_currency_balance(parachain_rpc).await?;
 		publish_issue_count(parachain_rpc, vault_id_manager).await;
 
-		let pass_all_filter = |item: (H256, SpacewalkRedeemRequest)| Some(item);
+		let pass_all_filter = |(_, _)| true;
 
 		if let Ok(redeems) = parachain_rpc
-			.get_vault_redeem_requests::<(H256, SpacewalkRedeemRequest)>(parachain_rpc.get_account_id().clone(), pass_all_filter)
+			.get_vault_redeem_requests(
+				parachain_rpc.get_account_id().clone(),
+				Box::new(pass_all_filter),
+			)
 			.await
 		{
 			publish_redeem_count(vault_id_manager, &redeems).await;

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -469,11 +469,11 @@ pub async fn poll_metrics<
 	loop {
 		publish_native_currency_balance(parachain_rpc).await?;
 		publish_issue_count(parachain_rpc, vault_id_manager).await;
-
-		let pass_all_filter = |(_, _)| true;
+		
+		let pass_all_filter = |item: (H256, SpacewalkRedeemRequest)| Some(item);
 
 		if let Ok(redeems) = parachain_rpc
-			.get_vault_redeem_requests(
+			.get_vault_redeem_requests::<(H256, SpacewalkRedeemRequest)>(
 				parachain_rpc.get_account_id().clone(),
 				Box::new(pass_all_filter),
 			)

--- a/clients/vault/src/metrics.rs
+++ b/clients/vault/src/metrics.rs
@@ -16,6 +16,7 @@ use runtime::{
 	AggregateUpdatedEvent, CollateralBalancesPallet, CurrencyId, Error as RuntimeError, FixedU128,
 	IssuePallet, IssueRequestStatus, OracleKey, RedeemPallet, RedeemRequestStatus, SecurityPallet,
 	SpacewalkParachain, UtilFuncs, VaultId, VaultRegistryPallet, H256,
+	SpacewalkRedeemRequest
 };
 use service::{
 	warp::{Rejection, Reply},
@@ -469,8 +470,11 @@ pub async fn poll_metrics<
 	loop {
 		publish_native_currency_balance(parachain_rpc).await?;
 		publish_issue_count(parachain_rpc, vault_id_manager).await;
+
+		let pass_all_filter = |item: (H256, SpacewalkRedeemRequest)| Some(item);
+
 		if let Ok(redeems) = parachain_rpc
-			.get_vault_redeem_requests(parachain_rpc.get_account_id().clone())
+			.get_vault_redeem_requests::<(H256, SpacewalkRedeemRequest)>(parachain_rpc.get_account_id().clone(), pass_all_filter)
 			.await
 		{
 			publish_redeem_count(vault_id_manager, &redeems).await;

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -115,7 +115,6 @@ impl ScpMessageCollector {
 		slot: Slot,
 		sender: &StellarMessageSender,
 	) -> Option<UnlimitedVarArray<ScpEnvelope>> {
-		let empty = UnlimitedVarArray::new_empty();
 
 		if let Some(envelopes) = self.envelopes_map().get(&slot) {
 			// lacking envelopes
@@ -124,7 +123,7 @@ impl ScpMessageCollector {
 					"Proof Building for slot {slot}: not enough envelopes to build proof "
 				);
 			} else {
-				return Some(UnlimitedVarArray::new(envelopes.clone()).unwrap_or(empty))
+				return UnlimitedVarArray::new(envelopes.clone()).ok()
 			}
 		}
 

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -115,7 +115,6 @@ impl ScpMessageCollector {
 		slot: Slot,
 		sender: &StellarMessageSender,
 	) -> Option<UnlimitedVarArray<ScpEnvelope>> {
-
 		if let Some(envelopes) = self.envelopes_map().get(&slot) {
 			// lacking envelopes
 			if envelopes.len() < get_min_externalized_messages(self.is_public()) {
@@ -185,7 +184,7 @@ impl ScpMessageCollector {
 			return Some(Proof { slot, envelopes, tx_set })
 		} else {
 			tracing::debug!("Couldn't build proof for slot {slot} due to missing envelopes");
-			return None;
+			return None
 		}
 	}
 

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -274,7 +274,7 @@ mod tests {
 			async fn execute_replace(&self, replace_id: H256, tx_env: &[u8], scp_envs: &[u8], tx_set: &[u8]) -> Result<(), RuntimeError>;
 			async fn cancel_replace(&self, replace_id: H256) -> Result<(), RuntimeError>;
 			async fn get_new_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
-			async fn get_old_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+			async fn get_old_vault_replace_requests(&self, account_id: AccountId, filter: impl Fn((H256, SpacewalkReplaceRequest)) -> bool + std::marker::Send) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
 			async fn get_replace_period(&self) -> Result<u32, RuntimeError>;
 			async fn get_replace_request(&self, replace_id: H256) -> Result<SpacewalkReplaceRequest, RuntimeError>;
 			async fn get_replace_dust_amount(&self) -> Result<u128, RuntimeError>;

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -248,47 +248,48 @@ mod tests {
 	}
 
 	mockall::mock! {
-	Provider {}
+		Provider {}
 
-	#[async_trait]
-	pub trait VaultRegistryPallet {
-		async fn get_vault(&self, vault_id: &VaultId) -> Result<SpacewalkVault, RuntimeError>;
-		async fn get_vaults_by_account_id(&self, account_id: &AccountId) -> Result<Vec<VaultId>, RuntimeError>;
-		async fn get_all_vaults(&self) -> Result<Vec<SpacewalkVault>, RuntimeError>;
-		async fn register_vault(&self, vault_id: &VaultId, collateral: u128) -> Result<(), RuntimeError>;
-		async fn deposit_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
-		async fn withdraw_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
-		async fn get_public_key(&self) -> Result<Option<StellarPublicKeyRaw>, RuntimeError>;
-		async fn register_public_key(&self, public_key: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
-		async fn get_required_collateral_for_wrapped(&self, amount: u128, wrapped_currency: CurrencyId, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
-		async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
-		async fn get_vault_total_collateral(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
-		async fn get_collateralization_from_vault(&self, vault_id: VaultId, only_issued: bool) -> Result<u128, RuntimeError>;
-	}
+		#[async_trait]
+		pub trait VaultRegistryPallet {
+			async fn get_vault(&self, vault_id: &VaultId) -> Result<SpacewalkVault, RuntimeError>;
+			async fn get_vaults_by_account_id(&self, account_id: &AccountId) -> Result<Vec<VaultId>, RuntimeError>;
+			async fn get_all_vaults(&self) -> Result<Vec<SpacewalkVault>, RuntimeError>;
+			async fn register_vault(&self, vault_id: &VaultId, collateral: u128) -> Result<(), RuntimeError>;
+			async fn deposit_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+			async fn withdraw_collateral(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+			async fn get_public_key(&self) -> Result<Option<StellarPublicKeyRaw>, RuntimeError>;
+			async fn register_public_key(&self, public_key: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
+			async fn get_required_collateral_for_wrapped(&self, amount: u128, wrapped_currency: CurrencyId, collateral_currency: CurrencyId) -> Result<u128, RuntimeError>;
+			async fn get_required_collateral_for_vault(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
+			async fn get_vault_total_collateral(&self, vault_id: VaultId) -> Result<u128, RuntimeError>;
+			async fn get_collateralization_from_vault(&self, vault_id: VaultId, only_issued: bool) -> Result<u128, RuntimeError>;
+		}
 
-	#[async_trait]
-	pub trait ReplacePallet {
-		async fn request_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
-		async fn withdraw_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
-		async fn accept_replace(&self, new_vault: &VaultId, old_vault: &VaultId, amount: u128, collateral: u128, stellar_address: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
-		async fn execute_replace(&self, replace_id: H256, tx_env: &[u8], scp_envs: &[u8], tx_set: &[u8]) -> Result<(), RuntimeError>;
-		async fn cancel_replace(&self, replace_id: H256) -> Result<(), RuntimeError>;
-		async fn get_new_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
-		async fn get_old_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
-		async fn get_replace_period(&self) -> Result<u32, RuntimeError>;
-		async fn get_replace_request(&self, replace_id: H256) -> Result<SpacewalkReplaceRequest, RuntimeError>;
-		async fn get_replace_dust_amount(&self) -> Result<u128, RuntimeError>;
-	}
+		#[async_trait]
+		pub trait ReplacePallet {
+			async fn request_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+			async fn withdraw_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
+			async fn accept_replace(&self, new_vault: &VaultId, old_vault: &VaultId, amount: u128, collateral: u128, stellar_address: StellarPublicKeyRaw) -> Result<(), RuntimeError>;
+			async fn execute_replace(&self, replace_id: H256, tx_env: &[u8], scp_envs: &[u8], tx_set: &[u8]) -> Result<(), RuntimeError>;
+			async fn cancel_replace(&self, replace_id: H256) -> Result<(), RuntimeError>;
+			async fn get_new_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+			async fn get_old_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+			async fn get_replace_period(&self) -> Result<u32, RuntimeError>;
+			async fn get_replace_request(&self, replace_id: H256) -> Result<SpacewalkReplaceRequest, RuntimeError>;
+			async fn get_replace_dust_amount(&self) -> Result<u128, RuntimeError>;
+		}
 
 
-	#[async_trait]
-	pub trait CollateralBalancesPallet {
-		async fn get_free_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
-		async fn get_native_balance_for_id(&self, id: &AccountId) -> Result<Balance, RuntimeError>;
-		async fn get_free_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
-		async fn get_reserved_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
-		async fn get_reserved_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
-		async fn transfer_to(&self, recipient: &AccountId, amount: u128, currency_id: CurrencyId) -> Result<(), RuntimeError>;         }
+		#[async_trait]
+		pub trait CollateralBalancesPallet {
+			async fn get_free_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+			async fn get_native_balance_for_id(&self, id: &AccountId) -> Result<Balance, RuntimeError>;
+			async fn get_free_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+			async fn get_reserved_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+			async fn get_reserved_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
+			async fn transfer_to(&self, recipient: &AccountId, amount: u128, currency_id: CurrencyId) -> Result<(), RuntimeError>;
+		}
 	}
 
 	impl Clone for MockProvider {

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -247,7 +247,6 @@ mod tests {
 		}};
 	}
 
-	type CustomFilter = Box<dyn Fn((H256, SpacewalkReplaceRequest)) -> bool + Send>;
 
 	mockall::mock! {
 		Provider {}
@@ -278,7 +277,11 @@ mod tests {
 			async fn execute_replace(&self, replace_id: H256, tx_env: &[u8], scp_envs: &[u8], tx_set: &[u8]) -> Result<(), RuntimeError>;
 			async fn cancel_replace(&self, replace_id: H256) -> Result<(), RuntimeError>;
 			async fn get_new_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
-			async fn get_old_vault_replace_requests(&self, account_id: AccountId, filter: CustomFilter) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+			async fn get_old_vault_replace_requests<T: 'static>(
+				&self,
+				account_id: AccountId,
+				filter: Box<dyn Fn((H256, SpacewalkReplaceRequest)) -> Option<T> + Send>,
+			) -> Result<Vec<T>, RuntimeError>;
 			async fn get_replace_period(&self) -> Result<u32, RuntimeError>;
 			async fn get_replace_request(&self, replace_id: H256) -> Result<SpacewalkReplaceRequest, RuntimeError>;
 			async fn get_replace_dust_amount(&self) -> Result<u128, RuntimeError>;

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -247,6 +247,8 @@ mod tests {
 		}};
 	}
 
+	type CustomFilter = Box<dyn Fn((H256, SpacewalkReplaceRequest)) -> bool + Send>;
+
 	mockall::mock! {
 		Provider {}
 
@@ -266,6 +268,8 @@ mod tests {
 			async fn get_collateralization_from_vault(&self, vault_id: VaultId, only_issued: bool) -> Result<u128, RuntimeError>;
 		}
 
+
+
 		#[async_trait]
 		pub trait ReplacePallet {
 			async fn request_replace(&self, vault_id: &VaultId, amount: u128) -> Result<(), RuntimeError>;
@@ -274,7 +278,7 @@ mod tests {
 			async fn execute_replace(&self, replace_id: H256, tx_env: &[u8], scp_envs: &[u8], tx_set: &[u8]) -> Result<(), RuntimeError>;
 			async fn cancel_replace(&self, replace_id: H256) -> Result<(), RuntimeError>;
 			async fn get_new_vault_replace_requests(&self, account_id: AccountId) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
-			async fn get_old_vault_replace_requests(&self, account_id: AccountId, filter: impl Fn((H256, SpacewalkReplaceRequest)) -> bool + std::marker::Send) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
+			async fn get_old_vault_replace_requests(&self, account_id: AccountId, filter: CustomFilter) -> Result<Vec<(H256, SpacewalkReplaceRequest)>, RuntimeError>;
 			async fn get_replace_period(&self) -> Result<u32, RuntimeError>;
 			async fn get_replace_request(&self, replace_id: H256) -> Result<SpacewalkReplaceRequest, RuntimeError>;
 			async fn get_replace_dust_amount(&self) -> Result<u128, RuntimeError>;

--- a/clients/vault/src/replace.rs
+++ b/clients/vault/src/replace.rs
@@ -247,7 +247,6 @@ mod tests {
 		}};
 	}
 
-
 	mockall::mock! {
 		Provider {}
 

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -402,7 +402,7 @@ impl VaultService {
 
 		let startup_height = self.await_parachain_block().await?;
 		let account_id = self.spacewalk_parachain.get_account_id().clone();
-		
+
 		let mut amount_is_none: bool = false;
 		let parsed_auto_register = self
 			.config
@@ -425,7 +425,7 @@ impl VaultService {
 
 		// exit if auto-register uses faucet and faucet url not set
 		if amount_is_none && self.config.faucet_url.is_none() {
-			return Err(ServiceError::Abort(Error::FaucetUrlNotSet));
+			return Err(ServiceError::Abort(Error::FaucetUrlNotSet))
 		}
 
 		// Subscribe to an event (any event will do) so that a period of inactivity does not close

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -29,7 +29,7 @@ use crate::{
 
 const POLL_INTERVAL: u64 = 5000;
 /// See [Stellar doc](https://developers.stellar.org/api/introduction/pagination/page-arguments)
-pub const DEFAULT_PAGE_SIZE: i64 = 200;
+pub const DEFAULT_PAGE_SIZE: u8 = 200;
 
 pub fn horizon_url(is_public_network: bool, is_need_fallback: bool) -> &'static str {
 	if is_public_network {
@@ -61,7 +61,7 @@ impl HorizonClient for reqwest::Client {
 		account_id: A,
 		is_public_network: bool,
 		cursor: PagingToken,
-		limit: i64,
+		limit: u8,
 		order_ascending: bool,
 	) -> Result<HorizonTransactionsResponse, Error> {
 		let account_id_encoded = account_id.as_encoded_string()?;

--- a/clients/wallet/src/horizon/traits.rs
+++ b/clients/wallet/src/horizon/traits.rs
@@ -22,7 +22,7 @@ pub trait HorizonClient {
 		account_id: A,
 		is_public_network: bool,
 		cursor: PagingToken,
-		limit: i64,
+		limit: u8,
 		order_ascending: bool,
 	) -> Result<HorizonTransactionsResponse, Error>;
 

--- a/pallets/issue/src/lib.rs
+++ b/pallets/issue/src/lib.rs
@@ -28,7 +28,7 @@ use currency::Amount;
 pub use default_weights::{SubstrateWeight, WeightInfo};
 pub use pallet::*;
 use types::IssueRequestExt;
-use vault_registry::{CurrencySource, VaultStatus};
+use vault_registry::{CurrencySource};
 
 use crate::types::{BalanceOf, CurrencyId, DefaultVaultId};
 #[doc(inline)]
@@ -387,10 +387,8 @@ impl<T: Config> Pallet<T> {
 
 		Self::check_volume(amount_requested.clone())?;
 
-		let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
-
-		// ensure that the vault is accepting new issues
-		ensure!(vault.status == VaultStatus::Active(true), Error::<T>::VaultNotAcceptingNewIssues);
+		// ensure that the vault is accepting new issues (vault is active)
+		let _vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id).map_err(|_| Error::<T>::VaultNotAcceptingNewIssues)?;
 
 		// Check that the vault is currently not banned
 		ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;

--- a/pallets/issue/src/lib.rs
+++ b/pallets/issue/src/lib.rs
@@ -28,7 +28,7 @@ use currency::Amount;
 pub use default_weights::{SubstrateWeight, WeightInfo};
 pub use pallet::*;
 use types::IssueRequestExt;
-use vault_registry::{CurrencySource};
+use vault_registry::{CurrencySource, VaultStatus};
 
 use crate::types::{BalanceOf, CurrencyId, DefaultVaultId};
 #[doc(inline)]
@@ -388,7 +388,9 @@ impl<T: Config> Pallet<T> {
 		Self::check_volume(amount_requested.clone())?;
 
 		// ensure that the vault is accepting new issues (vault is active)
-		let _vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id).map_err(|_| Error::<T>::VaultNotAcceptingNewIssues)?;
+		let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
+
+		ensure!(vault.status == VaultStatus::Active(true), Error::<T>::VaultNotAcceptingNewIssues);
 
 		// Check that the vault is currently not banned
 		ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;

--- a/pallets/vault-registry/src/lib.rs
+++ b/pallets/vault-registry/src/lib.rs
@@ -198,7 +198,7 @@ pub mod pallet {
 			let vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
 			let amount = Amount::new(amount, currency_pair.collateral);
-
+			
 			Self::try_deposit_collateral(&vault_id, &amount)?;
 
 			Self::deposit_event(Event::<T>::DepositCollateral {
@@ -911,8 +911,6 @@ impl<T: Config> Pallet<T> {
 		vault_id: &DefaultVaultId<T>,
 		amount: &Amount<T>,
 	) -> DispatchResult {
-		// ensure the vault is active
-		let _vault = Self::get_active_rich_vault_from_id(vault_id)?;
 
 		// will fail if collateral ceiling exceeded
 		Self::try_increase_total_backing_collateral(&vault_id.currencies, amount)?;
@@ -1072,6 +1070,8 @@ impl<T: Config> Pallet<T> {
 					vault_id.currencies.collateral == amount.currency(),
 					Error::<T>::InvalidCurrency
 				);
+				//ensure vault is active
+				let _vault = Self::get_active_rich_vault_from_id(vault_id)?;
 				Self::try_deposit_collateral(vault_id, amount)?;
 			},
 			CurrencySource::AvailableReplaceCollateral(ref vault_id) => {

--- a/pallets/vault-registry/src/lib.rs
+++ b/pallets/vault-registry/src/lib.rs
@@ -912,6 +912,9 @@ impl<T: Config> Pallet<T> {
 		amount: &Amount<T>,
 	) -> DispatchResult {
 
+		// ensure the vault is active
+		let _vault = Self::get_active_rich_vault_from_id(vault_id)?;
+
 		// will fail if collateral ceiling exceeded
 		Self::try_increase_total_backing_collateral(&vault_id.currencies, amount)?;
 		// will fail if free_balance is insufficient
@@ -1070,8 +1073,6 @@ impl<T: Config> Pallet<T> {
 					vault_id.currencies.collateral == amount.currency(),
 					Error::<T>::InvalidCurrency
 				);
-				//ensure vault is active
-				let _vault = Self::get_active_rich_vault_from_id(vault_id)?;
 				Self::try_deposit_collateral(vault_id, amount)?;
 			},
 			CurrencySource::AvailableReplaceCollateral(ref vault_id) => {

--- a/pallets/vault-registry/src/lib.rs
+++ b/pallets/vault-registry/src/lib.rs
@@ -198,7 +198,6 @@ pub mod pallet {
 			let vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
 			let amount = Amount::new(amount, currency_pair.collateral);
-			
 			Self::try_deposit_collateral(&vault_id, &amount)?;
 
 			Self::deposit_event(Event::<T>::DepositCollateral {

--- a/pallets/vault-registry/src/lib.rs
+++ b/pallets/vault-registry/src/lib.rs
@@ -911,7 +911,6 @@ impl<T: Config> Pallet<T> {
 		vault_id: &DefaultVaultId<T>,
 		amount: &Amount<T>,
 	) -> DispatchResult {
-
 		// ensure the vault is active
 		let _vault = Self::get_active_rich_vault_from_id(vault_id)?;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -849,9 +849,13 @@ impl TransactionEnvelopeExt for TransactionEnvelope {
 		let tx_operations: Vec<Operation> = match self {
 			TransactionEnvelope::EnvelopeTypeTxV0(env) => env.tx.operations.get_vec().clone(),
 			TransactionEnvelope::EnvelopeTypeTx(env) => env.tx.operations.get_vec().clone(),
-			TransactionEnvelope::EnvelopeTypeTxFeeBump(_) => return BalanceConversion::unlookup(transferred_amount),
-			TransactionEnvelope::Default(_) => return BalanceConversion::unlookup(transferred_amount),
+			TransactionEnvelope::EnvelopeTypeTxFeeBump(_) => Vec::new(),
+			TransactionEnvelope::Default(_) => Vec::new(),
 		};
+
+		if tx_operations.len() == 0 {
+			return BalanceConversion::unlookup(transferred_amount);
+		}
 
 		transferred_amount = tx_operations
 			.iter()

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -593,11 +593,11 @@ impl TryFrom<(&str, AssetIssuer)> for CurrencyId {
 		if slice.len() <= 4 {
 			let mut code: Bytes4 = [0; 4];
 			code[..slice.len()].copy_from_slice(slice.as_bytes());
-			Ok(CurrencyId::AlphaNum4(code, issuer))
-		} else if slice.len() > 4 && slice.len() <= 12 {
+			return Ok(CurrencyId::AlphaNum4(code, issuer))
+		} else if  slice.len() <= 12 {
 			let mut code: Bytes12 = [0; 12];
 			code[..slice.len()].copy_from_slice(slice.as_bytes());
-			Ok(CurrencyId::AlphaNum12(code, issuer))
+			return Ok(CurrencyId::AlphaNum12(code, issuer))
 		} else {
 			Err("More than 12 bytes not supported")
 		}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -844,14 +844,16 @@ impl TransactionEnvelopeExt for TransactionEnvelope {
 		let recipient_account_muxed = MuxedAccount::KeyTypeEd25519(to);
 		let recipient_account_pk = PublicKey::PublicKeyTypeEd25519(to);
 
+		let mut transferred_amount: StellarStroops = 0;
+
 		let tx_operations: Vec<Operation> = match self {
 			TransactionEnvelope::EnvelopeTypeTxV0(env) => env.tx.operations.get_vec().clone(),
 			TransactionEnvelope::EnvelopeTypeTx(env) => env.tx.operations.get_vec().clone(),
-			TransactionEnvelope::EnvelopeTypeTxFeeBump(_) => Vec::new(),
-			TransactionEnvelope::Default(_) => Vec::new(),
+			TransactionEnvelope::EnvelopeTypeTxFeeBump(_) => return BalanceConversion::unlookup(transferred_amount),
+			TransactionEnvelope::Default(_) => return BalanceConversion::unlookup(transferred_amount),
 		};
 
-		let mut transferred_amount: StellarStroops = 0;
+		
 		for x in tx_operations {
 			match x.body {
 				OperationBody::Payment(payment) => {


### PR DESCRIPTION
Some notable mentions:

- LIY-04/LIT-05 was already solved since audit.

- LIV-01 "Duplicated Helper Function Call" -> I left this unchanged. In my opinion cannot be optimized without modifying (splitting) `try_deposit_collateral` from pallet vault-registry. Although in `deposit_collateral` extrinsic it is duplicated the active vault check, this function is used also externally outside the pallet.

- IMP-02 "Empty Strings as prefixes" -> I also left this unchanged. I believe this could be useful in the future, since it is already coded and works, for extension purposes.

- HOR-01/HOI-01 Unnecessary Variable cloning -> the code seems to have changed since then. Couldn't find that specific reference.

- EXC-02/EXU-03 Double filter() calls can be reduced with filter_map() -> Is addressed along with RPC-01, where the use of closures filter and transform the into `Request` type inside both  `get_vault_redeem_requests` and `get_old_vault_replace_requests`.