### PR TITLE
Make vault client retry connection to overlay connection when handshake fails

### DIFF
--- a/clients/stellar-relay-lib/examples/connect.rs
+++ b/clients/stellar-relay-lib/examples/connect.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	} else {
 		(
 			"./clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest1.json",
-			"./clients/stellar-relay-lib/resources/secretkey/stellar_secretkey_testnet_usdc",
+			"./clients/stellar-relay-lib/resources/secretkey/stellar_secretkey_testnet",
 		)
 	};
 	let cfg = StellarOverlayConfig::try_from_path(cfg_file_path)?;

--- a/clients/stellar-relay-lib/examples/connect.rs
+++ b/clients/stellar-relay-lib/examples/connect.rs
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let (cfg_file_path, sk_file_path) = if arg_network == "mainnet" {
 		(
-			"./clients/stellar-relay-lib/resources/config/mainnet/stellar_relay_config_iowa.json",
+			"./clients/stellar-relay-lib/resources/config/mainnet/stellar_relay_config_mainnet_iowa.json",
 			"./clients/stellar-relay-lib/resources/secretkey/stellar_secretkey_mainnet",
 		)
 	} else {
 		(
 			"./clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest1.json",
-			"./clients/stellar-relay-lib/resources/secretkey/stellar_secretkey_testnet",
+			"./clients/stellar-relay-lib/resources/secretkey/stellar_secretkey_testnet_usdc",
 		)
 	};
 	let cfg = StellarOverlayConfig::try_from_path(cfg_file_path)?;

--- a/clients/stellar-relay-lib/src/connection/connector/message_creation.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_creation.rs
@@ -46,7 +46,7 @@ impl Connector {
 	}
 
 	/// The hello message is dependent on the auth cert
-	pub fn create_hello_message(&mut self, valid_at: u64) -> Result<Vec<u8>, Error> {
+	pub fn create_hello_message(&mut self, valid_at: u64) -> Result<StellarMessage, Error> {
 		let auth_cert = match self.connection_auth.auth_cert(valid_at) {
 			Ok(auth_cert) => auth_cert.clone(),
 			Err(_) => {
@@ -66,14 +66,12 @@ impl Connector {
 
 		let local = self.local();
 		let peer_id = self.connection_auth.keypair().get_public();
-		let msg = handshake::create_hello_message(
+		handshake::create_hello_message(
 			peer_id.clone(),
 			local.nonce(),
 			auth_cert,
 			local.port(),
 			local.node(),
-		)?;
-
-		self.create_xdr_message(msg)
+		)
 	}
 }

--- a/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
@@ -30,12 +30,12 @@ impl Connector {
 			MessageType::ErrorMsg => match auth_msg.message {
 				StellarMessage::ErrorMsg(e) => {
 					log::error!(
-						"process_raw_message():: Received ErrorMsg:  {}",
+						"process_raw_message(): Received ErrorMsg:  {}",
 						error_to_string(e.clone())
 					);
 					return Err(Error::OverlayError(e.code))
 				},
-				other => log::error!("process_raw_message():: Received ErroMsg other: {:?}", other),
+				other => log::error!("process_raw_message(): Received ErroMsg other: {:?}", other),
 			},
 
 			_ => {
@@ -44,7 +44,7 @@ impl Connector {
 					self.verify_auth(&auth_msg, &data[4..(data.len() - 32)])?;
 					self.increment_remote_sequence()?;
 					log::trace!(
-						"process_raw_message():: proc_id: {proc_id}. Processing {msg_type:?} message: auth verified"
+						"process_raw_message(): proc_id: {proc_id}. Processing {msg_type:?} message: auth verified"
 					);
 				}
 
@@ -73,7 +73,7 @@ impl Connector {
 				} else {
 					self.send_auth_message().await?;
 				}
-				log::info!("process_stellar_message():: Hello message processed successfully");
+				log::info!("process_stellar_message(): Hello message processed successfully");
 			},
 
 			StellarMessage::Auth(_) => {
@@ -86,7 +86,7 @@ impl Connector {
 
 			other => {
 				log::trace!(
-					"proc_id: {p_id}. Processing {msg_type:?} message: received from overlay"
+					"process_stellar_message(): proc_id: {p_id}. Processing {msg_type:?} message: received from overlay"
 				);
 				self.send_to_user(StellarRelayMessage::Data {
 					p_id,
@@ -108,7 +108,7 @@ impl Connector {
 		self.handshake_completed();
 
 		if let Some(remote) = self.remote() {
-			log::debug!("process_auth_message:: sending connect message: {remote:?}");
+			log::debug!("process_auth_message(): sending connect message: {remote:?}");
 			self.send_to_user(StellarRelayMessage::Connect {
 				pub_key: remote.pub_key().clone(),
 				node_info: remote.node().clone(),
@@ -120,7 +120,7 @@ impl Connector {
 				remote.node().overlay_version,
 			);
 		} else {
-			log::warn!("process_auth_message:: No remote overlay version after handshake.");
+			log::warn!("process_auth_message(): No remote overlay version after handshake.");
 		}
 
 		self.check_to_send_more(MessageType::Auth).await

--- a/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
@@ -69,6 +69,13 @@ impl Connector {
 				self.process_auth_message().await?;
 			},
 
+			StellarMessage::ErrorMsg(e) => {
+				let msg = e.msg.get_vec();
+				let msg = std::str::from_utf8(msg);
+				let error_message = format!("code: {:?} message: {msg:?}", e.code);
+				self.send_to_user(StellarRelayMessage::Error(error_message)).await?;
+			},
+
 			other => {
 				log::trace!(
 					"proc_id: {p_id}. Processing {msg_type:?} message: received from overlay"

--- a/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
@@ -29,10 +29,13 @@ impl Connector {
 
 			MessageType::ErrorMsg => match auth_msg.message {
 				StellarMessage::ErrorMsg(e) => {
-					log::error!("Received Message: {}", error_to_string(e.clone()));
+					log::error!(
+						"process_raw_message():: Received ErrorMsg:  {}",
+						error_to_string(e.clone())
+					);
 					return Err(Error::OverlayError(e.code))
 				},
-				other => log::error!("Received Message: {:?}", other),
+				other => log::error!("process_raw_message():: Received ErroMsg other: {:?}", other),
 			},
 
 			_ => {
@@ -41,7 +44,7 @@ impl Connector {
 					self.verify_auth(&auth_msg, &data[4..(data.len() - 32)])?;
 					self.increment_remote_sequence()?;
 					log::trace!(
-						"proc_id: {proc_id}. Processing {msg_type:?} message: auth verified"
+						"process_raw_message():: proc_id: {proc_id}. Processing {msg_type:?} message: auth verified"
 					);
 				}
 
@@ -70,7 +73,7 @@ impl Connector {
 				} else {
 					self.send_auth_message().await?;
 				}
-				log::info!("Hello message processed successfully");
+				log::info!("process_stellar_message():: Hello message processed successfully");
 			},
 
 			StellarMessage::Auth(_) => {
@@ -105,7 +108,7 @@ impl Connector {
 		self.handshake_completed();
 
 		if let Some(remote) = self.remote() {
-			log::debug!("Processing auth message: sending connect message: {remote:?}");
+			log::debug!("process_auth_message:: sending connect message: {remote:?}");
 			self.send_to_user(StellarRelayMessage::Connect {
 				pub_key: remote.pub_key().clone(),
 				node_info: remote.node().clone(),
@@ -117,7 +120,7 @@ impl Connector {
 				remote.node().overlay_version,
 			);
 		} else {
-			log::warn!("Processing auth message: No remote overlay version after handshake.");
+			log::warn!("process_auth_message:: No remote overlay version after handshake.");
 		}
 
 		self.check_to_send_more(MessageType::Auth).await

--- a/clients/stellar-relay-lib/src/connection/error.rs
+++ b/clients/stellar-relay-lib/src/connection/error.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)] //todo: remove after being tested and implemented
 
 use crate::connection::xdr_converter::Error as XDRError;
-use substrate_stellar_sdk::StellarSdkError;
+use substrate_stellar_sdk::{types::ErrorCode, StellarSdkError};
 use tokio::sync;
 
 #[derive(Debug, err_derive::Error)]
@@ -53,6 +53,9 @@ pub enum Error {
 
 	#[error(display = "Config Error: {}", _0)]
 	ConfigError(String),
+
+	#[error(display = "Received Error from Overlay: {:?}", _0)]
+	OverlayError(ErrorCode),
 }
 
 impl From<XDRError> for Error {

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -48,3 +48,8 @@ pub fn error_to_string(e: Error) -> String {
 
 	format!("Error{{ code:{:?} message:{msg} }}", e.code)
 }
+
+pub fn to_base64_xdr_string<T: XdrCodec>(msg: &T) -> String {
+	let xdr = msg.to_base64_xdr();
+	String::from_utf8(xdr.clone()).unwrap_or(format!("{:?}", xdr))
+}

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -1,7 +1,10 @@
 use rand::Rng;
 use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
-use substrate_stellar_sdk::{types::Uint256, SecretKey};
+use substrate_stellar_sdk::{
+	types::{Error, Uint256},
+	SecretKey, XdrCodec,
+};
 
 /// a helpful macro to log an error (if it occurs) and return immediately.
 macro_rules! log_error {
@@ -37,4 +40,11 @@ pub fn time_now() -> u64 {
 		log::warn!("could not convert time at u128 to u64.");
 		u64::MAX
 	})
+}
+
+pub fn error_to_string(e: Error) -> String {
+	let msg = e.msg.get_vec();
+	let msg = String::from_utf8(msg.clone()).unwrap_or(format!("{:?}", e.msg.to_base64_xdr()));
+
+	format!("Error{{ code:{:?} message:{msg} }}", e.code)
 }

--- a/clients/stellar-relay-lib/src/connection/overlay_connection.rs
+++ b/clients/stellar-relay-lib/src/connection/overlay_connection.rs
@@ -47,7 +47,6 @@ impl StellarOverlayConnection {
 	pub async fn listen(&mut self) -> Option<StellarRelayMessage> {
 		let res = self.relay_message_receiver.recv().await;
 
-		// Reconnection only when the maximum number of retries has not been reached.
 		match &res {
 			Some(StellarRelayMessage::Timeout) | Some(StellarRelayMessage::Error(_)) | None => {
 				log::info!("listen(): Reconnecting to {:?}...", &self.conn_info.address);

--- a/clients/stellar-relay-lib/src/connection/services.rs
+++ b/clients/stellar-relay-lib/src/connection/services.rs
@@ -1,12 +1,13 @@
 use crate::{
 	connection::{
 		connector::{Connector, ConnectorActions},
-		helper::time_now,
+		helper::{time_now, to_base64_xdr_string},
 		log_error,
 		xdr_converter::get_xdr_message_length,
 	},
 	Error, StellarRelayMessage,
 };
+use substrate_stellar_sdk::types::StellarMessage;
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},
 	net::{tcp, TcpStream},
@@ -76,7 +77,7 @@ async fn read_unfinished_message(
 
 	// this partial message completes the previous message.
 	if actual_msg_len == *lack_bytes_from_prev {
-		log::trace!("proc_id: {} received continuation from the previous message.", proc_id);
+		log::trace!("read_unfinished_message(): proc_id: {} received continuation from the previous message.", proc_id);
 		readbuf.append(&mut cont_buf);
 
 		handle_message(actions_sender, *proc_id, readbuf.clone()).await?;
@@ -94,7 +95,7 @@ async fn read_unfinished_message(
 		cont_buf = cont_buf[0..actual_msg_len].to_owned();
 		readbuf.append(&mut cont_buf);
 		log::trace!(
-            "proc_id: {} not enough bytes to complete the previous message. Need {} bytes to complete.",
+            "read_unfinished_message(): proc_id: {} not enough bytes to complete the previous message. Need {} bytes to complete.",
             proc_id,
             lack_bytes_from_prev
         );
@@ -135,7 +136,7 @@ async fn read_message(
 	*lack_bytes_from_prev = xpect_msg_len - actual_msg_len;
 	*readbuf = readbuf[0..actual_msg_len].to_owned();
 	log::trace!(
-		"proc_id: {} received only partial message. Need {} bytes to complete.",
+		"read_message(): proc_id: {} received only partial message. Need {} bytes to complete.",
 		proc_id,
 		lack_bytes_from_prev
 	);
@@ -171,7 +172,7 @@ pub(crate) async fn receiving_service(
 		{
 			Ok(Ok(0)) => {
 				if retry_read >= retries {
-					log::error!("receiving_service():: proc_id: {proc_id}. Failed to read messages from the stream. Received 0 size more than {retries} times");
+					log::error!("receiving_service(): proc_id: {proc_id}. Failed to read messages from the stream. Received 0 size more than {retries} times");
 					return
 				}
 				retry_read += 1;
@@ -183,11 +184,11 @@ pub(crate) async fn receiving_service(
 				// then check the size of next stellar message.
 				// If it's not enough, skip it.
 				let expect_msg_len = next_message_length(&mut r_stream).await;
-				log::trace!("proc_id: {proc_id}. The next message length is {expect_msg_len}");
+				log::trace!("receiving_service(): proc_id: {proc_id}. The next message length is {expect_msg_len}");
 
 				if expect_msg_len == 0 {
 					// there's nothing to read; wait for the next iteration
-					log::trace!("proc_id: {proc_id}. Nothing left to read; waiting for next loop");
+					log::trace!("receiving_service(): proc_id: {proc_id}. Nothing left to read; waiting for next loop");
 					continue
 				}
 
@@ -204,7 +205,7 @@ pub(crate) async fn receiving_service(
 						expect_msg_len,
 					)
 					.await,
-					format!("receiving_service():: proc_id: {proc_id}. Failed to read message")
+					format!("receiving_service(): proc_id: {proc_id}. Failed to read message")
 				);
 			},
 
@@ -220,27 +221,39 @@ pub(crate) async fn receiving_service(
 						&mut proc_id,
 						&mut readbuf,
 					).await,
-					format!("receiving_service():: proc_id:{proc_id}. Error occurred while reading unfinished stellar message")
+					format!("receiving_service(): proc_id:{proc_id}. Error occurred while reading unfinished stellar message")
 				);
 			},
 			Ok(Err(e)) => {
-				log::error!("receiving_service():: proc_id: {proc_id}. Error occurred while reading the stream: {e:?}");
+				log::error!("receiving_service(): proc_id: {proc_id}. Error occurred while reading the stream: {e:?}");
 				return
 			},
 			Err(elapsed) => {
 				log::error!(
-					"receiving_service():: proc_id: {proc_id}. Timeout of {} seconds elapesd for reading messages from Stellar Node. Retry: #{retry}",
+					"receiving_service(): proc_id: {proc_id}. Timeout of {} seconds elapesd for reading messages from Stellar Node. Retry: #{retry}",
 					elapsed.to_string()
 				);
 
 				if retry >= retries {
-					log::error!("receiving_service():: proc_id: {proc_id}. Exhausted maximum retries for reading messages from Stellar Node.");
+					log::error!("receiving_service(): proc_id: {proc_id}. Exhausted maximum retries for reading messages from Stellar Node.");
 					return
 				}
 				retry += 1;
 			},
 		}
 	}
+}
+
+async fn _write_to_stream(
+	msg: StellarMessage,
+	connector: &mut Connector,
+	w_stream: &mut tcp::OwnedWriteHalf,
+) -> Result<(), Error> {
+	let xdr_msg = connector.create_xdr_message(msg)?;
+	w_stream
+		.write_all(&xdr_msg)
+		.await
+		.map_err(|e| Error::WriteFailed(e.to_string()))
 }
 
 async fn _connection_handler(
@@ -252,17 +265,17 @@ async fn _connection_handler(
 		// start the connection to Stellar node with a 'hello'
 		ConnectorActions::SendHello => {
 			let msg = connector.create_hello_message(time_now())?;
-			log::info!("_connection_handler():: Sending Hello Message...{:?}", msg);
-			w_stream.write_all(&msg).await.map_err(|e| Error::WriteFailed(e.to_string()))?;
+
+			log::info!(
+				"_connection_handler(): Sending Hello Message: {}",
+				to_base64_xdr_string(&msg)
+			);
+			_write_to_stream(msg, connector, w_stream).await?;
 		},
 
 		// write message to the stream
 		ConnectorActions::SendMessage(msg) => {
-			let xdr_msg = connector.create_xdr_message(*msg)?;
-			w_stream
-				.write_all(&xdr_msg)
-				.await
-				.map_err(|e| Error::WriteFailed(e.to_string()))?;
+			_write_to_stream(*msg, connector, w_stream).await?;
 		},
 
 		// handle incoming message from the stream
@@ -292,7 +305,7 @@ pub(crate) async fn connection_handler(
 			Ok(Some(ConnectorActions::Disconnect)) => {
 				log_error!(
 					w_stream.shutdown().await,
-					format!("connection_handler():: Failed to shutdown write half of stream:")
+					format!("connection_handler(): Failed to shutdown write half of stream:")
 				);
 				drop(connector);
 				drop(actions_receiver);
@@ -301,24 +314,24 @@ pub(crate) async fn connection_handler(
 
 			Ok(Some(action)) => {
 				if let Err(e) = _connection_handler(action, &mut connector, &mut w_stream).await {
-					log::error!("connection_handler():: {e:?}");
+					log::error!("connection_handler(): {e:?}");
 
 					log_error!(
 						connector.send_to_user(StellarRelayMessage::Error(e.to_string())).await,
-						format!("connection_handler():: sending error message")
+						format!("connection_handler(): sending error message")
 					);
 					return
 				}
 			},
 
 			Ok(None) => {
-				log::warn!("connection_handler():: Unexpected empty response from receiver");
+				log::warn!("connection_handler(): Unexpected empty response from receiver");
 			},
 
 			Err(_) => {
 				log_error!(
 					connector.send_to_user(StellarRelayMessage::Timeout).await,
-					format!("connection_handler():: Connection Timed out")
+					format!("connection_handler(): Connection Timed out")
 				);
 				return
 			},

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -208,7 +208,7 @@ mod tests {
 	#[serial]
 	async fn test_get_proof_for_current_slot() {
 		let agent =
-			start_oracle_agent(get_test_stellar_relay_config(false), &get_test_secret_key(false))
+			start_oracle_agent(get_test_stellar_relay_config(true), &get_test_secret_key(true))
 				.await
 				.expect("Failed to start agent");
 		sleep(Duration::from_secs(10)).await;
@@ -219,9 +219,9 @@ mod tests {
 			sleep(Duration::from_secs(1)).await;
 			latest_slot = agent.last_slot_index().await;
 		}
-		// use the next slot to prevent receiving not enough messages for the current slot
-		// because of bad timing when connecting to the network.
-		latest_slot += 1;
+		// use a future slot (2 slots ahead) to ensure enough messages can be collected
+		// and to avoid "missed" messages.
+		latest_slot += 2;
 
 		let proof_result = agent.get_proof(latest_slot).await;
 		assert!(proof_result.is_ok(), "Failed to get proof for slot: {}", latest_slot);

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -57,11 +57,11 @@ async fn handle_message(
 			let pub_key = pub_key.to_encoding();
 			let pub_key = std::str::from_utf8(&pub_key).unwrap_or("****");
 
-			tracing::info!("handle_message():: Connected: via public key: {pub_key}");
-			tracing::info!("handle_message():: Connected: with {:#?}", node_info)
+			tracing::info!("handle_message(): Connected: via public key: {pub_key}");
+			tracing::info!("handle_message(): Connected: with {:#?}", node_info)
 		},
 		StellarRelayMessage::Timeout => {
-			tracing::error!("handle_message():: The Stellar Relay timed out. Failed to process message: {message:?}");
+			tracing::error!("handle_message(): The Stellar Relay timed out. Failed to process message: {message:?}");
 		},
 		_ => {},
 	}
@@ -76,7 +76,7 @@ pub async fn start_oracle_agent(
 	config: StellarOverlayConfig,
 	secret_key: &str,
 ) -> Result<OracleAgent, Error> {
-	tracing::info!("Starting connection to Stellar overlay network...");
+	tracing::info!("start_oracle_agent(): Starting connection to Stellar overlay network...");
 
 	let mut overlay_conn = connect_to_stellar_overlay_network(config.clone(), secret_key).await?;
 
@@ -119,7 +119,7 @@ pub async fn start_oracle_agent(
 		let result_sending_disconnect =
 			actions_sender.send(disconnect_action).await.map_err(Error::from);
 		if let Err(e) = result_sending_disconnect {
-			tracing::error!("OracleAgent: Failed to send disconnect message: {:#?}", e);
+			tracing::error!("start_oracle_agent(): Failed to send disconnect message: {:#?}", e);
 		};
 	}));
 
@@ -154,14 +154,14 @@ impl OracleAgent {
 				let collector = collector.read().await;
 				match collector.build_proof(slot, &stellar_sender).await {
 					None => {
-						tracing::warn!("Failed to build proof for slot {slot}.");
+						tracing::warn!("get_proof(): Failed to build proof for slot {slot}.");
 						drop(collector);
 						// give 10 seconds interval for every retry
 						sleep(Duration::from_secs(10)).await;
 						continue
 					},
 					Some(proof) => {
-						tracing::info!("Successfully build proof for slot {slot}");
+						tracing::info!("get_proof(): Successfully build proof for slot {slot}");
 						tracing::trace!("  with proof: {proof:?}");
 						return Ok(proof)
 					},
@@ -184,9 +184,9 @@ impl OracleAgent {
 
 	/// Stops listening for new SCP messages.
 	pub fn stop(&self) -> Result<(), Error> {
-		tracing::debug!("Shutting down OracleAgent...");
+		tracing::debug!("stop(): Shutting down OracleAgent...");
 		if let Err(e) = self.shutdown_sender.send(()) {
-			tracing::error!("Failed to send shutdown signal in OracleAgent: {:?}", e);
+			tracing::error!("stop:() Failed to send shutdown signal in OracleAgent: {:?}", e);
 		}
 		Ok(())
 	}

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -57,11 +57,11 @@ async fn handle_message(
 			let pub_key = pub_key.to_encoding();
 			let pub_key = std::str::from_utf8(&pub_key).unwrap_or("****");
 
-			tracing::info!("Connected: via public key: {pub_key}");
-			tracing::info!("Connected: with {:#?}", node_info)
+			tracing::info!("handle_message():: Connected: via public key: {pub_key}");
+			tracing::info!("handle_message():: Connected: with {:#?}", node_info)
 		},
 		StellarRelayMessage::Timeout => {
-			tracing::error!("The Stellar Relay timed out. Failed to process message: {message:?}");
+			tracing::error!("handle_message():: The Stellar Relay timed out. Failed to process message: {message:?}");
 		},
 		_ => {},
 	}

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -169,8 +169,8 @@ impl OracleAgent {
 			}
 		})
 		.await
-		.map_err(|elapsed| {
-			Error::ProofTimeout(format!("Timeout elapsed for building proof: {:?}", elapsed))
+		.map_err(|_| {
+			Error::ProofTimeout(format!("Timeout elapsed for building proof of slot {slot}"))
 		})?
 	}
 

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -186,7 +186,7 @@ impl OracleAgent {
 	pub fn stop(&self) -> Result<(), Error> {
 		tracing::debug!("stop(): Shutting down OracleAgent...");
 		if let Err(e) = self.shutdown_sender.send(()) {
-			tracing::error!("stop:() Failed to send shutdown signal in OracleAgent: {:?}", e);
+			tracing::error!("stop(): Failed to send shutdown signal in OracleAgent: {:?}", e);
 		}
 		Ok(())
 	}

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -208,7 +208,7 @@ mod tests {
 	#[serial]
 	async fn test_get_proof_for_current_slot() {
 		let agent =
-			start_oracle_agent(get_test_stellar_relay_config(true), &get_test_secret_key(true))
+			start_oracle_agent(get_test_stellar_relay_config(false), &get_test_secret_key(false))
 				.await
 				.expect("Failed to start agent");
 		sleep(Duration::from_secs(10)).await;

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -99,9 +99,7 @@ impl ScpMessageCollector {
 			);
 			return
 		}
-		tracing::debug!(
-			"Proof Building for slot {slot}: requesting to StellarNode for messages..."
-		);
+		tracing::info!("Proof Building for slot {slot}: requesting to StellarNode for messages...");
 	}
 
 	/// fetches envelopes from the archive
@@ -132,8 +130,9 @@ impl ScpMessageCollector {
 		if let Some(envelopes) = self.envelopes_map().get(&slot) {
 			// lacking envelopes
 			if envelopes.len() < get_min_externalized_messages(self.is_public()) {
-				tracing::debug!(
-					"Proof Building for slot {slot}: not enough envelopes to build proof "
+				tracing::warn!(
+					"Proof Building for slot {slot}: {:?} envelopes is not enough to build proof",
+					envelopes.len()
 				);
 			} else {
 				return UnlimitedVarArray::new(envelopes.clone()).ok()
@@ -170,7 +169,7 @@ impl ScpMessageCollector {
 					tokio::spawn(self.get_txset_from_horizon_archive(slot));
 				}
 
-				tracing::debug!("Proof Building for slot {slot}: no txset found");
+				tracing::warn!("Proof Building for slot {slot}: no txset found");
 				None
 			},
 		}
@@ -201,7 +200,7 @@ impl ScpMessageCollector {
 			let tx_set = self.get_txset(slot, sender).await?;
 			return Some(Proof { slot, envelopes, tx_set })
 		} else {
-			tracing::debug!("Couldn't build proof for slot {slot} due to missing envelopes");
+			tracing::warn!("Couldn't build proof for slot {slot} due to missing envelopes");
 			return None
 		}
 	}
@@ -280,7 +279,7 @@ impl ScpMessageCollector {
 						let mut envelopes_map = envelopes_map_arc.write();
 
 						if envelopes_map.get(&slot).is_none() {
-							tracing::debug!(
+							tracing::info!(
 								"Adding {} archived SCP envelopes for slot {slot} to envelopes map. {} are externalized",
 								relevant_envelopes.len(),
 								externalized_envelopes_count
@@ -328,7 +327,7 @@ impl ScpMessageCollector {
 					.find(|&entry| Slot::from(entry.ledger_seq) == slot);
 
 				if let Some(target_history_entry) = value {
-					tracing::debug!("Adding archived tx set for slot {slot}");
+					tracing::info!("Adding archived tx set for slot {slot}");
 					let mut tx_set_map = txset_map_arc.write();
 					tx_set_map
 						.insert(slot, TransactionSetType::new(target_history_entry.tx_set.clone()));

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -19,7 +19,7 @@ use crate::oracle::{
 fn check_slot_still_recoverable_from_overlay(last_slot_index: Slot, slot: Slot) -> bool {
 	let recoverable_point = last_slot_index.saturating_sub(MAX_SLOTS_TO_REMEMBER);
 	log::trace!(
-		"Proof Building for slot {slot}: Last Slot to refer to overlay: {recoverable_point}"
+		"check_slot_still_recoverable_from_overlay(): Proof Building for slot {slot}: Last Slot to refer to overlay: {recoverable_point}"
 	);
 	last_slot_index != 0 && slot > recoverable_point
 }
@@ -69,12 +69,12 @@ impl ScpMessageCollector {
 		// If the current slot is still in the range of 'remembered' slots
 		if check_slot_still_recoverable_from_overlay(self.last_slot_index(), slot) {
 			tracing::debug!(
-				"Proof Building for slot {slot}: fetching missing envelopes from Stellar Node..."
+				"fetch_missing_envelopes(): Proof Building for slot {slot}: fetching missing envelopes from Stellar Node..."
 			);
 			self.ask_node_for_envelopes(slot, sender).await;
 		} else {
 			tracing::debug!(
-				"Proof Building for slot {slot}: fetching missing envelopes from Archive Node..."
+				"fetch_missing_envelopes(): Proof Building for slot {slot}: fetching missing envelopes from Archive Node..."
 			);
 			self.ask_archive_for_envelopes(slot).await;
 		}
@@ -87,7 +87,7 @@ impl ScpMessageCollector {
 			Ok(slot) => slot,
 			Err(e) => {
 				tracing::error!(
-					"Proof Building for slot {slot:} failed to convert slot value into u32 datatype: {e:?}"
+					"ask_node_for_envelopes(): Proof Building for slot {slot:} failed to convert slot value into u32 datatype: {e:?}"
 				);
 				return
 			},
@@ -95,11 +95,11 @@ impl ScpMessageCollector {
 
 		if let Err(e) = sender.send(StellarMessage::GetScpState(slot)).await {
 			tracing::error!(
-				"Proof Building for slot {slot}: failed to send `GetScpState` message: {e:?}"
+				"ask_node_for_envelopes(): Proof Building for slot {slot}: failed to send `GetScpState` message: {e:?}"
 			);
 			return
 		}
-		tracing::info!("Proof Building for slot {slot}: requesting to StellarNode for messages...");
+		tracing::info!("ask_node_for_envelopes(): Proof Building for slot {slot}: requesting to StellarNode for messages...");
 	}
 
 	/// fetches envelopes from the archive
@@ -108,7 +108,7 @@ impl ScpMessageCollector {
 			// Fetch from archives only on public network since no archive nodes
 			// are available on testnet
 			tracing::debug!(
-				"Proof Building for slot {slot}: Cannot fetch envelopes from archive for test network"
+				"ask_archive_for_envelopes(): Proof Building for slot {slot}: Cannot fetch envelopes from archive for test network"
 			);
 			return
 		}
@@ -131,7 +131,7 @@ impl ScpMessageCollector {
 			// lacking envelopes
 			if envelopes.len() < get_min_externalized_messages(self.is_public()) {
 				tracing::warn!(
-					"Proof Building for slot {slot}: {:?} envelopes is not enough to build proof",
+					"get_envelopes(): Proof Building for slot {slot}: {:?} envelopes is not enough to build proof",
 					envelopes.len()
 				);
 			} else {
@@ -169,7 +169,7 @@ impl ScpMessageCollector {
 					tokio::spawn(self.get_txset_from_horizon_archive(slot));
 				}
 
-				tracing::warn!("Proof Building for slot {slot}: no txset found");
+				tracing::warn!("get_txset(): Proof Building for slot {slot}: no txset found");
 				None
 			},
 		}
@@ -180,9 +180,9 @@ impl ScpMessageCollector {
 	async fn fetch_missing_txset_from_overlay(&self, slot: Slot, sender: &StellarMessageSender) {
 		// we need the txset hash to create the message.
 		if let Some(txset_hash) = self.get_txset_hash_by_slot(&slot) {
-			tracing::debug!("Proof Building for slot {slot}: Fetching TxSet from overlay...");
+			tracing::debug!("fetch_missing_txset_from_overlay(): Proof Building for slot {slot}: Fetching TxSet from overlay...");
 			if let Err(error) = sender.send(StellarMessage::GetTxSet(txset_hash)).await {
-				tracing::error!("Proof Building for slot {slot}: failed to send GetTxSet message to overlay {:?}", error);
+				tracing::error!("fetch_missing_txset_from_overlay(): Proof Building for slot {slot}: failed to send GetTxSet message to overlay {:?}", error);
 			}
 		}
 	}
@@ -200,7 +200,9 @@ impl ScpMessageCollector {
 			let tx_set = self.get_txset(slot, sender).await?;
 			return Some(Proof { slot, envelopes, tx_set })
 		} else {
-			tracing::warn!("Couldn't build proof for slot {slot} due to missing envelopes");
+			tracing::warn!(
+				"build_proof(): Couldn't build proof for slot {slot} due to missing envelopes"
+			);
 			return None
 		}
 	}
@@ -212,13 +214,13 @@ impl ScpMessageCollector {
 	/// * `envelopes_map_lock` - the map to insert the envelopes to.
 	/// * `slot` - the slot where the envelopes belong to
 	fn get_envelopes_from_horizon_archive(&self, slot: Slot) -> impl Future<Output = ()> {
-		tracing::debug!("Fetching SCP envelopes from horizon archive for slot {slot}...");
+		tracing::debug!("get_envelopes_from_horizon_archive(): Fetching SCP envelopes from horizon archive for slot {slot}...");
 		let envelopes_map_arc = self.envelopes_map_clone();
 
 		let archive_urls = self.stellar_history_archive_urls();
 		async move {
 			if archive_urls.is_empty() {
-				tracing::error!("Cannot get envelopes from horizon archive for slot {slot}: no archive URLs configured");
+				tracing::error!("get_envelopes_from_horizon_archive(): Cannot get envelopes from horizon archive for slot {slot}: no archive URLs configured");
 				return
 			}
 
@@ -229,7 +231,7 @@ impl ScpMessageCollector {
 				let scp_archive_result = scp_archive_storage.get_archive(slot).await;
 				if let Err(e) = scp_archive_result {
 					tracing::error!(
-						"Could not get SCPArchive for slot {slot} from Horizon Archive: {e:?}"
+						"get_envelopes_from_horizon_archive(): Could not get SCPArchive for slot {slot} from Horizon Archive: {e:?}"
 					);
 					continue
 				}
@@ -270,7 +272,7 @@ impl ScpMessageCollector {
 						// Ensure that at least one envelope is externalized
 						if externalized_envelopes_count == 0 {
 							tracing::error!(
-							"The contained archive entry fetched from {} for slot {slot} is invalid because it does not contain any externalized envelopes.",
+							"get_envelopes_from_horizon_archive(): The contained archive entry fetched from {} for slot {slot} is invalid because it does not contain any externalized envelopes.",
 								scp_archive_storage.0
 						);
 							continue
@@ -280,7 +282,7 @@ impl ScpMessageCollector {
 
 						if envelopes_map.get(&slot).is_none() {
 							tracing::info!(
-								"Adding {} archived SCP envelopes for slot {slot} to envelopes map. {} are externalized",
+								"get_envelopes_from_horizon_archive(): Adding {} archived SCP envelopes for slot {slot} to envelopes map. {} are externalized",
 								relevant_envelopes.len(),
 								externalized_envelopes_count
 							);
@@ -289,7 +291,7 @@ impl ScpMessageCollector {
 						}
 					}
 				} else {
-					tracing::warn!("Could not get ScpHistory entry from archive for slot {slot}");
+					tracing::warn!("get_envelopes_from_horizon_archive(): Could not get ScpHistory entry from archive for slot {slot}");
 				}
 			}
 		}
@@ -302,7 +304,9 @@ impl ScpMessageCollector {
 	/// * `txset` - the map to insert the txset to.
 	/// * `slot` - the slot where the txset belong to.
 	fn get_txset_from_horizon_archive(&self, slot: Slot) -> impl Future<Output = ()> {
-		tracing::info!("Fetching TxSet for slot {slot} from horizon archive");
+		tracing::info!(
+			"get_txset_from_horizon_archive(): Fetching TxSet for slot {slot} from horizon archive"
+		);
 		let txset_map_arc = self.txset_map_clone();
 		let archive_urls = self.stellar_history_archive_urls();
 
@@ -315,7 +319,7 @@ impl ScpMessageCollector {
 					Ok(value) => value,
 					Err(e) => {
 						tracing::error!(
-							"Could not get TransactionsArchive for slot {slot} from horizon archive: {e:?}"
+							"get_txset_from_horizon_archive(): Could not get TransactionsArchive for slot {slot} from horizon archive: {e:?}"
 						);
 						continue
 					},
@@ -327,14 +331,16 @@ impl ScpMessageCollector {
 					.find(|&entry| Slot::from(entry.ledger_seq) == slot);
 
 				if let Some(target_history_entry) = value {
-					tracing::info!("Adding archived tx set for slot {slot}");
+					tracing::info!(
+						"get_txset_from_horizon_archive(): Adding archived tx set for slot {slot}"
+					);
 					let mut tx_set_map = txset_map_arc.write();
 					tx_set_map
 						.insert(slot, TransactionSetType::new(target_history_entry.tx_set.clone()));
 					break
 				} else {
 					tracing::warn!(
-						"Could not get TransactionHistory entry from archive for slot {slot}"
+						"get_txset_from_horizon_archive(): Could not get TransactionHistory entry from archive for slot {slot}"
 					);
 				}
 			}

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -183,6 +183,17 @@ async fn test_replace_succeeds() {
 				async {
 					old_vault_provider.request_replace(&old_vault_id, issue_amount).await.unwrap();
 
+					assert_event::<RequestReplaceEvent, _>(
+						TIMEOUT,
+						old_vault_provider.clone(),
+						|e| {
+							assert_eq!(e.old_vault_id, old_vault_id);
+							assert_eq!(e.amount, issue_amount);
+							true
+						},
+					)
+					.await;
+
 					assert_event::<AcceptReplaceEvent, _>(
 						TIMEOUT,
 						old_vault_provider.clone(),
@@ -193,6 +204,7 @@ async fn test_replace_succeeds() {
 						},
 					)
 					.await;
+
 					assert_event::<ExecuteReplaceEvent, _>(
 						TIMEOUT,
 						old_vault_provider.clone(),

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -7,8 +7,8 @@ use futures::{
 };
 
 use primitives::{
-	stellar::{ClaimableBalanceId, PublicKey, TransactionEnvelope, XdrCodec},
-	StellarTypeToString, TransactionEnvelopeExt,
+	stellar::{ClaimableBalanceId, PublicKey, StellarTypeToString, TransactionEnvelope, XdrCodec},
+	TransactionEnvelopeExt,
 };
 use rand::seq::SliceRandom;
 use serde::de::DeserializeOwned;

--- a/clients/wallet/src/horizon/traits.rs
+++ b/clients/wallet/src/horizon/traits.rs
@@ -7,9 +7,8 @@ use crate::{
 	types::PagingToken,
 };
 use async_trait::async_trait;
-use primitives::{
-	stellar::{ClaimableBalanceId, PublicKey, TransactionEnvelope},
-	StellarTypeToString,
+use primitives::stellar::{
+	ClaimableBalanceId, PublicKey, StellarTypeToString, TransactionEnvelope,
 };
 use serde::de::DeserializeOwned;
 

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -4,7 +4,8 @@ use std::{fmt::Formatter, sync::Arc};
 use primitives::stellar::{
 	network::{Network, PUBLIC_NETWORK, TEST_NETWORK},
 	types::SequenceNumber,
-	Asset as StellarAsset, Operation, PublicKey, SecretKey, TransactionEnvelope,
+	Asset as StellarAsset, Operation, PublicKey, SecretKey, StellarTypeToString,
+	TransactionEnvelope,
 };
 use tokio::sync::{oneshot, Mutex};
 
@@ -26,9 +27,7 @@ use crate::{
 	},
 	types::PagingToken,
 };
-use primitives::{
-	StellarPublicKeyRaw, StellarStroops, StellarTypeToString, TransactionEnvelopeExt,
-};
+use primitives::{StellarPublicKeyRaw, StellarStroops, TransactionEnvelopeExt};
 
 #[derive(Clone)]
 pub struct StellarWallet {

--- a/pallets/replace/src/lib.rs
+++ b/pallets/replace/src/lib.rs
@@ -401,13 +401,16 @@ impl<T: Config> Pallet<T> {
 			&griefing_collateral,
 		)?;
 
-		// Emit RequestReplace event
-		Self::deposit_event(Event::<T>::RequestReplace {
+		let event = Event::<T>::RequestReplace {
 			old_vault_id: vault_id,
 			amount: to_be_replaced_increase.amount(),
 			asset: to_be_replaced_increase.currency(),
 			griefing_collateral: griefing_collateral.amount(),
-		});
+		};
+		log::info!("broadcasting event: {event:?}");
+		// Emit RequestReplace event
+		Self::deposit_event(event);
+
 		Ok(())
 	}
 

--- a/pallets/replace/src/lib.rs
+++ b/pallets/replace/src/lib.rs
@@ -407,7 +407,6 @@ impl<T: Config> Pallet<T> {
 			asset: to_be_replaced_increase.currency(),
 			griefing_collateral: griefing_collateral.amount(),
 		};
-		log::info!("broadcasting event: {event:?}");
 		// Emit RequestReplace event
 		Self::deposit_event(event);
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -30,8 +30,7 @@ use stellar::{
 pub use substrate_stellar_sdk as stellar;
 use substrate_stellar_sdk::{
 	types::{OperationBody, SequenceNumber},
-	ClaimPredicate, ClaimableBalanceId, Claimant, Memo, MuxedAccount, Operation,
-	TransactionEnvelope, XdrCodec,
+	ClaimPredicate, Claimant, Memo, MuxedAccount, Operation, TransactionEnvelope,
 };
 
 #[cfg(test)]
@@ -106,56 +105,6 @@ impl<AccountId, CurrencyId: Copy> VaultId<AccountId, CurrencyId> {
 }
 
 pub type StellarPublicKeyRaw = [u8; 32];
-
-/// A trait used to convert any Stellar specific type `T` as a String
-/// This also immediately converts the standard Error to a user-defined Error `E`
-/// Helpful for functions that will accept:
-///  * the Stellar type itself;
-///  * encoded &str version of the Stellar type;
-///  * a `Vec<u8>` version of th Stellar type
-#[cfg(feature = "std")]
-pub trait StellarTypeToString<T, E: From<std::str::Utf8Error>> {
-	fn as_encoded_string(&self) -> Result<String, E>;
-}
-
-#[cfg(feature = "std")]
-impl<E: From<std::str::Utf8Error>> StellarTypeToString<Self, E> for PublicKey {
-	fn as_encoded_string(&self) -> Result<String, E> {
-		let x = self.to_encoding();
-		let str = std::str::from_utf8(&x).map_err(E::from)?;
-		Ok(str.to_string())
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: From<std::str::Utf8Error>> StellarTypeToString<PublicKey, E> for &str {
-	fn as_encoded_string(&self) -> Result<String, E> {
-		Ok(self.to_string())
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: From<std::str::Utf8Error>> StellarTypeToString<PublicKey, E> for Vec<u8> {
-	fn as_encoded_string(&self) -> Result<String, E> {
-		let str = std::str::from_utf8(self).map_err(E::from)?;
-		Ok(str.to_string())
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: From<std::str::Utf8Error>> StellarTypeToString<Self, E> for ClaimableBalanceId {
-	fn as_encoded_string(&self) -> Result<String, E> {
-		let xdr = self.to_xdr();
-		Ok(hex::encode(xdr))
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: From<std::str::Utf8Error>> StellarTypeToString<ClaimableBalanceId, E> for &str {
-	fn as_encoded_string(&self) -> Result<String, E> {
-		Ok(self.to_string())
-	}
-}
 
 #[cfg(feature = "std")]
 fn serialize_as_string<S: Serializer, T: std::fmt::Display>(


### PR DESCRIPTION
Reconnection:

There are 2 threads that run independently (found in service.rs)
* `fn connection_handler()` - handles action from the connection
* `fn receiving_service()` - handles messages from the server
If connection fails, both should stop running.

In the case of an Error Message received, reconnection is required. 
example: **` Error{ code:ErrConf message:already-connected peer: `**:
* `fn connection_handler()` - relays the error message and return (which stops the thread)
* `fn receiving_service()` - no more data found in the read stream  and return (which stops the thread)

The error message is relayed inside `fn listen()` (found in agent.rs) and it goes through the "reconnect logic".