### PR TITLE
434 add configuration for automatic changelog generation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,32 +1,34 @@
 ## Highlights
 
-[ADD_BULLETPOINTS_HERE]
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+  {{ end }}
+  {{ end -}}
+  {{ end -}}
 
 {{ range .Versions }}
 <a name="{{ .Tag.Name }}"></a>
-
 ## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
-
 {{ range .CommitGroups -}}
-
 ### {{ .Title }}
-
-{{ range .MergeCommits -}}
-
-{{ .TrimmedBody }} [#{{ .Merge.Source }}](https://github.com/interlay/interbtc/issues/{{ .Merge.Source }}) {{ end }} {{ end -}}
-{{ range .CommitGroups -}}
-
 {{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
 
-* {{ .Subject }}
-  {{ end }}
-  {{ end -}}
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
 
 {{- if .NoteGroups -}}
 {{ range .NoteGroups -}}
-
 ### {{ .Title }}
-
 {{ range .Notes }}
 {{ .Body }}
 {{ end }}

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,28 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
+
+{{ range .CommitGroups -}}
+{{ range .Commits -}}
+* {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+
+{{ range .MergeCommits -}}
+* {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,23 +1,30 @@
+## Highlights
+
+[ADD_BULLETPOINTS_HERE]
+
 {{ range .Versions }}
 <a name="{{ .Tag.Name }}"></a>
+
 ## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
 
 {{ range .CommitGroups -}}
-{{ range .Commits -}}
-* {{ .Header }}
-{{ end }}
-{{ end -}}
 
-{{- if .MergeCommits -}}
-### Pull Requests
+### {{ .Title }}
 
 {{ range .MergeCommits -}}
-* {{ .Header }}
-{{ end }}
-{{ end -}}
+
+{{ .TrimmedBody }} [#{{ .Merge.Source }}](https://github.com/interlay/interbtc/issues/{{ .Merge.Source }}) {{ end }} {{ end -}}
+{{ range .CommitGroups -}}
+
+{{ range .Commits -}}
+
+* {{ .Subject }}
+  {{ end }}
+  {{ end -}}
 
 {{- if .NoteGroups -}}
 {{ range .NoteGroups -}}
+
 ### {{ .Title }}
 
 {{ range .Notes }}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -5,12 +5,14 @@ info:
   repository_url: https://github.com/pendulum-chain/spacewalk
 options:
   commits:
-    # filters:
-    #   Type: []
   commit_groups:
-    # title_maps: []
   header:
-    pattern: "^(.*)$"
+    pattern: "^(\\w*)[!]?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  merges:
+    pattern: "^.*$"
     pattern_maps:
       - Subject
   notes:

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -4,13 +4,6 @@ info:
   title: CHANGELOG
   repository_url: https://github.com/pendulum-chain/spacewalk
 options:
-  commits:
-  commit_groups:
-  header:
-    pattern: "^(\\w*)[!]?\\:\\s(.*)$"
-    pattern_maps:
-      - Type
-      - Subject
   merges:
     pattern: "^.*$"
     pattern_maps:

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,18 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/pendulum-chain/spacewalk
+options:
+  commits:
+    # filters:
+    #   Type: []
+  commit_groups:
+    # title_maps: []
+  header:
+    pattern: "^(.*)$"
+    pattern_maps:
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE


### PR DESCRIPTION
This template can be used to create a changelog. Its main purpose is to be used in Spacewalk's release flow to automatically generate a description for the new releases. 

To generate the changelog you need to install git-chglog, see [here](https://github.com/git-chglog/git-chglog?tab=readme-ov-file#installation) and then run `git-chglog -o CHANGELOG.md`.

The CI job will run the generation with the latest tag as the argument so that the changelog is only generated containing the changes for the latest release. For example to generate the release notes for release `v1.0.3`, it will use `git-chglog -o CHANGELOG.md v1.0.3..`.

Closes #434.