### PR TITLE
Fix occasional consensus error

### DIFF
--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -439,7 +439,6 @@ async fn test_cancel_scheduler_succeeds() {
 							// Create two new blocks so that the current requests expire (since we
 							// set the periods to 1 before)
 							parachain_rpc.manual_seal().await;
-							sleep(Duration::from_secs(10)).await;
 							parachain_rpc.manual_seal().await;
 						},
 						assert_event::<CancelIssueEvent, _>(


### PR DESCRIPTION
Maybe the `sleep` statement is the problem, but not 100% sure.

I ran the `test_cancel_scheduler_succeeds()` locally 10 times and it passed for each of them. Let's see if it also works in the CI job by running it a couple of times. 

The CI job passed 4 out of 5 times and the one time it failed was with a different error (unrelated to this problem).

Closes #386. 