### PR TITLE
425 add a new asset category currencyid to the runtime for stablecoins

### DIFF
--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -159,6 +159,7 @@ pub mod currency_id {
 						"ZenlinkLPToken({},{},{},{})",
 						token1_id, token1_type, token2_id, token2_type
 					)),
+				CurrencyId::Token(token_id) => Ok(format!("Token({})", token_id)),
 			}
 		}
 	}

--- a/pallets/oracle/src/dia.rs
+++ b/pallets/oracle/src/dia.rs
@@ -75,7 +75,8 @@ impl<T: NativeCurrencyKey + XCMCurrencyConversion> Convert<OracleKey, Option<(Ve
 					Some((FIAT_DIA_BLOCKCHAIN.as_bytes().to_vec(), fiat_quote))
 				},
 				CurrencyId::Stellar(primitives::Asset::AlphaNum12 { .. }) |
-				CurrencyId::ZenlinkLPToken(_, _, _, _) => unimplemented!(),
+				CurrencyId::ZenlinkLPToken(_, _, _, _) => None,
+				CurrencyId::Token(_) => None,
 			},
 		}
 	}

--- a/pallets/oracle/src/testing_utils/mock_convertors.rs
+++ b/pallets/oracle/src/testing_utils/mock_convertors.rs
@@ -18,7 +18,8 @@ impl Convert<Key, Option<(Vec<u8>, Vec<u8>)>> for MockOracleKeyConvertor {
 				CurrencyId::Stellar(Asset::AlphaNum12 { code, .. }) =>
 					Some((vec![5u8], code.to_vec())),
 				CurrencyId::ZenlinkLPToken(token1_id, token1_type, token2_id, token2_type) =>
-					Some((vec![6], vec![token1_id, token1_type, token2_id, token2_type])),
+					Some((vec![6u8], vec![token1_id, token1_type, token2_id, token2_type])),
+				CurrencyId::Token(_) => None,
 			},
 		}
 	}
@@ -47,6 +48,7 @@ impl Convert<(Vec<u8>, Vec<u8>), Option<Key>> for MockOracleKeyConvertor {
 			6u8 => Some(Key::ExchangeRate(CurrencyId::ZenlinkLPToken(
 				symbol[0], symbol[1], symbol[2], symbol[3],
 			))),
+			7u8 => None,
 			_ => None,
 		}
 	}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -495,6 +495,7 @@ pub enum CurrencyId {
 	XCM(u8),
 	Stellar(Asset),
 	ZenlinkLPToken(u8, u8, u8, u8),
+	Token(u64),
 }
 
 impl CurrencyId {
@@ -504,7 +505,10 @@ impl CurrencyId {
 		match self {
 			CurrencyId::Stellar(asset) => asset.decimals(),
 			// We assume that all other assets have 12 decimals
-			CurrencyId::Native | CurrencyId::XCM(_) | CurrencyId::ZenlinkLPToken(_, _, _, _) => 12,
+			CurrencyId::Native |
+			CurrencyId::XCM(_) |
+			CurrencyId::ZenlinkLPToken(_, _, _, _) |
+			CurrencyId::Token(_) => 12,
 		}
 	}
 
@@ -611,6 +615,7 @@ impl TryInto<stellar::Asset> for CurrencyId {
 				})),
 			Self::ZenlinkLPToken(_, _, _, _) =>
 				Err("Zenlink LP Token not defined in the Stellar world."),
+			Self::Token(_) => Err("Token not defined in the Stellar world."),
 		}
 	}
 }
@@ -652,6 +657,7 @@ impl fmt::Debug for CurrencyId {
 					token1_id, token1_type, token2_id, token2_type
 				)
 			},
+			Self::Token(id) => write!(f, "Token({})", id),
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the `Token` to the `CurrencyId` enum used in Spacewalk and also adjusts the other usages accordingly. 

Closes #425.