### PR TITLE
Add the `ref: development` parameter to the build.yml file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,4 @@ jobs:
           host: "https://gitlab.com"
           token: ${{ secrets.GITLABAPI }}
           project_id: 43970950
+          ref: development


### PR DESCRIPTION
This fixes issues with the Gitlab pipeline not being called properly.