### PR TITLE
313 - retry integration tests for `tx_bad_seq` errors

### DIFF
--- a/clients/vault/tests/helper/helper.rs
+++ b/clients/vault/tests/helper/helper.rs
@@ -1,7 +1,7 @@
 use crate::helper::DEFAULT_TESTING_CURRENCY;
 use async_trait::async_trait;
 use frame_support::assert_ok;
-use primitives::{CurrencyId, StellarStroops, H256, stellar::Asset as StellarAsset };
+use primitives::{stellar::Asset as StellarAsset, CurrencyId, StellarStroops, H256};
 use runtime::{
 	integration::{
 		assert_event, get_required_vault_collateral_for_issue, setup_provider, SubxtClient,
@@ -14,8 +14,7 @@ use sp_runtime::traits::StaticLookup;
 use std::{sync::Arc, time::Duration};
 use stellar_relay_lib::sdk::PublicKey;
 use vault::{oracle::OracleAgent, ArcRwLock};
-use wallet::error::Error;
-use wallet::{StellarWallet, TransactionResponse};
+use wallet::{error::Error, StellarWallet, TransactionResponse};
 
 pub fn default_destination() -> SecretKey {
 	SecretKey::from_encoding(crate::helper::DEFAULT_TESTNET_DEST_SECRET_KEY).expect("Should work")
@@ -112,19 +111,20 @@ pub async fn assert_execute_redeem_event(
 		.await
 }
 
-
 pub async fn send_payment_to_address(
-	wallet:ArcRwLock<StellarWallet>,
+	wallet: ArcRwLock<StellarWallet>,
 	destination_address: PublicKey,
 	asset: StellarAsset,
 	stroop_amount: StellarStroops,
 	request_id: [u8; 32],
 	stroop_fee_per_operation: u32,
 	is_payment_for_redeem_request: bool,
-) -> Result<TransactionResponse,Error> {
+) -> Result<TransactionResponse, Error> {
 	let response;
 	loop {
-		let result = wallet.write().await
+		let result = wallet
+			.write()
+			.await
 			.send_payment_to_address(
 				destination_address.clone(),
 				asset.clone(),
@@ -137,13 +137,12 @@ pub async fn send_payment_to_address(
 
 		match &result {
 			// if the error is `tx_bad_seq` perform the process again
-			Err(Error::HorizonSubmissionError { reason, .. }) if reason.contains("tx_bad_seq")  => {
-				continue
-			},
+			Err(Error::HorizonSubmissionError { reason, .. }) if reason.contains("tx_bad_seq") =>
+				continue,
 			_ => {
 				response = result;
-				break;
-			}
+				break
+			},
 		}
 	}
 
@@ -177,8 +176,10 @@ pub async fn assert_issue(
 		stroop_amount,
 		issue.issue_id.0,
 		300,
-		false
-	).await.expect("should return ok");
+		false,
+	)
+	.await
+	.expect("should return ok");
 
 	let slot = response.ledger as u64;
 

--- a/clients/vault/tests/helper/helper.rs
+++ b/clients/vault/tests/helper/helper.rs
@@ -12,7 +12,6 @@ use runtime::{
 use sp_keyring::AccountKeyring;
 use sp_runtime::traits::StaticLookup;
 use std::{sync::Arc, time::Duration};
-use tokio::sync::RwLockWriteGuard;
 use stellar_relay_lib::sdk::PublicKey;
 use vault::{oracle::OracleAgent, ArcRwLock};
 use wallet::error::Error;

--- a/clients/vault/tests/helper/helper.rs
+++ b/clients/vault/tests/helper/helper.rs
@@ -1,7 +1,7 @@
 use crate::helper::DEFAULT_TESTING_CURRENCY;
 use async_trait::async_trait;
 use frame_support::assert_ok;
-use primitives::{CurrencyId, StellarStroops, H256};
+use primitives::{CurrencyId, StellarStroops, H256, stellar::Asset as StellarAsset };
 use runtime::{
 	integration::{
 		assert_event, get_required_vault_collateral_for_issue, setup_provider, SubxtClient,
@@ -12,9 +12,11 @@ use runtime::{
 use sp_keyring::AccountKeyring;
 use sp_runtime::traits::StaticLookup;
 use std::{sync::Arc, time::Duration};
+use tokio::sync::RwLockWriteGuard;
 use stellar_relay_lib::sdk::PublicKey;
 use vault::{oracle::OracleAgent, ArcRwLock};
-use wallet::StellarWallet;
+use wallet::error::Error;
+use wallet::{StellarWallet, TransactionResponse};
 
 pub fn default_destination() -> SecretKey {
 	SecretKey::from_encoding(crate::helper::DEFAULT_TESTNET_DEST_SECRET_KEY).expect("Should work")
@@ -111,6 +113,46 @@ pub async fn assert_execute_redeem_event(
 		.await
 }
 
+
+pub async fn send_payment_to_address(
+	wallet:ArcRwLock<StellarWallet>,
+	destination_address: PublicKey,
+	asset: StellarAsset,
+	stroop_amount: StellarStroops,
+	request_id: [u8; 32],
+	stroop_fee_per_operation: u32,
+	is_payment_for_redeem_request: bool,
+) -> Result<TransactionResponse,Error> {
+	let response;
+	loop {
+		let result = wallet.write().await
+			.send_payment_to_address(
+				destination_address.clone(),
+				asset.clone(),
+				stroop_amount,
+				request_id,
+				stroop_fee_per_operation,
+				is_payment_for_redeem_request,
+			)
+			.await;
+
+		match &result {
+			// if the error is `tx_bad_seq` perform the process again
+			Err(Error::HorizonSubmissionError { reason, .. }) if reason.contains("tx_bad_seq")  => {
+				continue
+			},
+			_ => {
+				response = result;
+				break;
+			}
+		}
+	}
+
+	drop(wallet);
+
+	response
+}
+
 /// request, pay and execute an issue
 pub async fn assert_issue(
 	parachain_rpc: &SpacewalkParachain,
@@ -127,20 +169,17 @@ pub async fn assert_issue(
 	let asset = primitives::AssetConversion::lookup(issue.asset).expect("Invalid asset");
 	let stroop_amount = primitives::BalanceConversion::lookup(amount).expect("Invalid amount");
 
-	let mut wallet_write = wallet.write().await;
 	let destination_public_key = PublicKey::from_binary(issue.vault_stellar_public_key);
 
-	let response = wallet_write
-		.send_payment_to_address(
-			destination_public_key,
-			asset,
-			stroop_amount,
-			issue.issue_id.0,
-			300,
-			false,
-		)
-		.await
-		.expect("Failed to send payment");
+	let response = send_payment_to_address(
+		wallet,
+		destination_public_key,
+		asset,
+		stroop_amount,
+		issue.issue_id.0,
+		300,
+		false
+	).await.expect("should return ok");
 
 	let slot = response.ledger as u64;
 

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -593,15 +593,15 @@ async fn test_issue_overpayment_succeeds() {
 
 			let transaction_response = send_payment_to_address(
 				user_wallet,
-					destination_public_key,
-					stellar_asset,
-					stroop_amount.try_into().unwrap(),
-					issue.issue_id.0,
-					300,
-					false,
-				)
-				.await
-				.expect("Sending payment failed");
+				destination_public_key,
+				stellar_asset,
+				stroop_amount.try_into().unwrap(),
+				issue.issue_id.0,
+				300,
+				false,
+			)
+			.await
+			.expect("Sending payment failed");
 
 			assert!(transaction_response.successful);
 
@@ -687,9 +687,9 @@ async fn test_automatic_issue_execution_succeeds() {
 					issue.issue_id.0,
 					300,
 					false,
-					)
-					.await
-					.expect("should return a result");
+				)
+				.await
+				.expect("should return a result");
 
 				tracing::warn!("Sent payment successfully: {:?}", result);
 
@@ -818,14 +818,14 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 
 				let result = send_payment_to_address(
 					user_wallet,
-						destination_public_key,
-						stellar_asset,
-						stroop_amount,
-						issue.issue_id.0,
-						300,
-						false,
-					)
-					.await;
+					destination_public_key,
+					stellar_asset,
+					stroop_amount,
+					issue.issue_id.0,
+					300,
+					false,
+				)
+				.await;
 				assert!(result.is_ok());
 
 				tracing::info!("Sent payment to address. Ledger is {:?}", result.unwrap().ledger);
@@ -976,7 +976,8 @@ async fn test_execute_open_requests_succeeds() {
 					redeem_ids[0].0,
 					300,
 					false
-				).await
+				)
+				.await
 			);
 			// Sleep 3 seconds to give other thread some time to receive the RequestIssue event and
 			// add it to the set

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -995,10 +995,10 @@ async fn test_execute_open_requests_succeeds() {
 				.map(Result::unwrap),
 				// Redeem 0 should be executed without creating an extra payment since we already
 				// sent one just before
-				assert_execute_redeem_event(TIMEOUT, user_provider.clone(), redeem_ids[0]),
+				assert_execute_redeem_event(TIMEOUT * 3, user_provider.clone(), redeem_ids[0]),
 				// Redeem 1 and 2 should be executed after creating an extra payment
-				assert_execute_redeem_event(TIMEOUT, user_provider.clone(), redeem_ids[1]),
-				assert_execute_redeem_event(TIMEOUT, user_provider.clone(), redeem_ids[2]),
+				assert_execute_redeem_event(TIMEOUT * 3, user_provider.clone(), redeem_ids[1]),
+				assert_execute_redeem_event(TIMEOUT * 3, user_provider.clone(), redeem_ids[2]),
 			)
 			.await;
 		},


### PR DESCRIPTION
closes #313 

## General overview of the changes:
Created a loop for `send_payment_to_address` to keep resending the same transaction, should the error be `tx_bad_seq` error. 
This is _only_ for integration tests.