### PR TITLE
452 vault client retries transaction submission for unrecoverable errors

### DIFF
--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -151,9 +151,7 @@ impl Error {
 
 	pub fn is_pool_issue(&self) -> bool {
 		self.map_custom_error(|custom_error| {
-			if custom_error.code() == POOL_UNACTIONABLE ||
-				custom_error.code() == POOL_UNKNOWN_VALIDITY
-			{
+			if custom_error.code() == POOL_UNKNOWN_VALIDITY {
 				Some(())
 			} else {
 				None
@@ -252,4 +250,3 @@ const BASE_ERROR: i32 = 1000;
 const POOL_INVALID_TX: i32 = BASE_ERROR + 10;
 const POOL_UNKNOWN_VALIDITY: i32 = POOL_INVALID_TX + 1;
 const POOL_TOO_LOW_PRIORITY: i32 = POOL_INVALID_TX + 4;
-const POOL_UNACTIONABLE: i32 = POOL_INVALID_TX + 8;

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -125,18 +125,19 @@ impl Error {
 
 	pub fn is_invalid_transaction(&self) -> Option<Error>{
 		// TODO define elsewhere
-		let not_recoverable_errors = ["InvalidQuorumSetNotEnoughValidators"];
+		let recoverable_errors = [""];
 	
 		self.map_custom_error(|custom_error| {
 			if custom_error.code() == POOL_INVALID_TX {
 				let data_string = custom_error.data().map(ToString::to_string).unwrap_or_default();
 				
-				for error in not_recoverable_errors {
+				for error in recoverable_errors {
 					if data_string.contains(error) {
-						return Some(Error::InvalidTransactionUnrecoverable(data_string));
+						
+						return Some(Error::InvalidTransaction(data_string))
 					}
 				}
-				Some(Error::InvalidTransaction(data_string))
+				return Some(Error::InvalidTransactionUnrecoverable(data_string));
 			} else {
 				None
 			}

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -134,8 +134,6 @@ impl Error {
 	}
 
 	pub fn is_invalid_transaction(&self) -> Option<Recoverability> {
-		let recoverable_errors = ["Inability to pay some fees", "Transaction is outdated"];
-
 		self.map_custom_error(|custom_error| {
 			if custom_error.code() == POOL_INVALID_TX {
 				let data_string = custom_error.data().map(ToString::to_string).unwrap_or_default();
@@ -229,7 +227,7 @@ impl RecoverableError {
 	fn is_recoverable(error_message: &str) -> bool {
 		[RecoverableError::InabilityToPayFees, RecoverableError::OutdatedTransaction]
 			.iter()
-			.any(|&error| error_message.contains(error.as_str()))
+			.any(|error| error_message.contains(error.as_str()))
 	}
 }
 

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -88,6 +88,8 @@ pub enum Error {
 	CurrencyNotFound,
 	#[error("PrometheusError: {0}")]
 	PrometheusError(#[from] PrometheusError),
+	#[error("Unkown transaction pool issue")]
+	TransactionPoolIssue,
 }
 
 pub enum Recoverability{
@@ -147,7 +149,15 @@ impl Error {
 		})
 	}
 
-
+	pub fn is_pool_issue(&self) -> Option<()> {
+		self.map_custom_error(|custom_error| {
+			if custom_error.code() == POOL_UNACTIONABLE || custom_error.code() == POOL_UNKNOWN_VALIDITY {
+				Some(())
+			} else {
+				None
+			}
+		})
+	}
 
 	pub fn is_pool_too_low_priority(&self) -> Option<()> {
 		self.map_custom_error(|custom_error| {
@@ -218,4 +228,6 @@ pub enum KeyLoadingError {
 // https://github.com/paritytech/substrate/blob/e60597dff0aa7ffad623be2cc6edd94c7dc51edd/client/rpc-api/src/author/error.rs#L80
 const BASE_ERROR: i32 = 1000;
 const POOL_INVALID_TX: i32 = BASE_ERROR + 10;
+const POOL_UNKNOWN_VALIDITY: i32 = POOL_INVALID_TX + 1;
 const POOL_TOO_LOW_PRIORITY: i32 = POOL_INVALID_TX + 4;
+const POOL_UNACTIONABLE: i32 = POOL_INVALID_TX + 8;

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -88,8 +88,6 @@ pub enum Error {
 	CurrencyNotFound,
 	#[error("PrometheusError: {0}")]
 	PrometheusError(#[from] PrometheusError),
-	#[error("Unkown transaction pool issue")]
-	TransactionPoolIssue,
 }
 
 pub enum Recoverability {
@@ -147,17 +145,6 @@ impl Error {
 				None
 			}
 		})
-	}
-
-	pub fn is_pool_issue(&self) -> bool {
-		self.map_custom_error(|custom_error| {
-			if custom_error.code() == POOL_UNKNOWN_VALIDITY {
-				Some(())
-			} else {
-				None
-			}
-		})
-		.is_some()
 	}
 
 	pub fn is_pool_too_low_priority(&self) -> bool {
@@ -248,5 +235,4 @@ pub enum KeyLoadingError {
 // https://github.com/paritytech/substrate/blob/e60597dff0aa7ffad623be2cc6edd94c7dc51edd/client/rpc-api/src/author/error.rs#L80
 const BASE_ERROR: i32 = 1000;
 const POOL_INVALID_TX: i32 = BASE_ERROR + 10;
-const POOL_UNKNOWN_VALIDITY: i32 = POOL_INVALID_TX + 1;
 const POOL_TOO_LOW_PRIORITY: i32 = POOL_INVALID_TX + 4;

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -149,7 +149,7 @@ impl Error {
 		})
 	}
 
-	pub fn is_pool_issue(&self) -> Option<()> {
+	pub fn is_pool_issue(&self) -> bool {
 		self.map_custom_error(|custom_error| {
 			if custom_error.code() == POOL_UNACTIONABLE ||
 				custom_error.code() == POOL_UNKNOWN_VALIDITY
@@ -159,9 +159,10 @@ impl Error {
 				None
 			}
 		})
+		.is_some()
 	}
 
-	pub fn is_pool_too_low_priority(&self) -> Option<()> {
+	pub fn is_pool_too_low_priority(&self) -> bool {
 		self.map_custom_error(|custom_error| {
 			if custom_error.code() == POOL_TOO_LOW_PRIORITY {
 				Some(())
@@ -169,6 +170,7 @@ impl Error {
 				None
 			}
 		})
+		.is_some()
 	}
 
 	pub fn is_rpc_disconnect_error(&self) -> bool {
@@ -217,6 +219,8 @@ impl Error {
 
 impl RecoverableError {
 	// The string which is used to match the error type
+	// For definitions, see: https://github.com/paritytech/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/primitives/runtime/src/transaction_validity.rs#L99
+
 	fn as_str(&self) -> &'static str {
 		match self {
 			RecoverableError::InabilityToPayFees => "Inability to pay some fees",

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -12,7 +12,7 @@ use subxt::{
 };
 
 pub use assets::TryFromSymbol;
-pub use error::{Error, SubxtError};
+pub use error::{Error, SubxtError, Recoverability};
 pub use primitives::CurrencyInfo;
 pub use retry::{notify_retry, RetryPolicy};
 #[cfg(feature = "testing-utils")]

--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -12,7 +12,7 @@ use subxt::{
 };
 
 pub use assets::TryFromSymbol;
-pub use error::{Error, SubxtError, Recoverability};
+pub use error::{Error, Recoverability, SubxtError};
 pub use primitives::CurrencyInfo;
 pub use retry::{notify_retry, RetryPolicy};
 #[cfg(feature = "testing-utils")]

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -246,9 +246,7 @@ impl SpacewalkParachain {
 							} else if err.is_block_hash_not_found_error() {
 								log::info!("Re-sending transaction after apparent fork");
 								Err(RetryPolicy::Skip(Error::BlockHashNotFound))
-							} else if err.is_pool_issue() {
-								Err(RetryPolicy::Skip(Error::TransactionPoolIssue))
-							} else {
+							}else {
 								Err(RetryPolicy::Throw(err))
 							}
 						},

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -247,6 +247,8 @@ impl SpacewalkParachain {
 							} else if err.is_block_hash_not_found_error() {
 								log::info!("Re-sending transaction after apparent fork");
 								Err(RetryPolicy::Skip(Error::BlockHashNotFound))
+							}else if err.is_pool_issue().is_some() {
+								Err(RetryPolicy::Skip(Error::TransactionPoolIssue))
 							} else {
 								Err(RetryPolicy::Throw(err))
 							}

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -246,7 +246,7 @@ impl SpacewalkParachain {
 							} else if err.is_block_hash_not_found_error() {
 								log::info!("Re-sending transaction after apparent fork");
 								Err(RetryPolicy::Skip(Error::BlockHashNotFound))
-							}else {
+							} else {
 								Err(RetryPolicy::Throw(err))
 							}
 						},

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -241,12 +241,12 @@ impl SpacewalkParachain {
 							Err(RetryPolicy::Throw(Error::InvalidTransaction(data))),
 						None => {
 							// Handle other errors
-							if err.is_pool_too_low_priority().is_some() {
+							if err.is_pool_too_low_priority() {
 								Err(RetryPolicy::Skip(Error::PoolTooLowPriority))
 							} else if err.is_block_hash_not_found_error() {
 								log::info!("Re-sending transaction after apparent fork");
 								Err(RetryPolicy::Skip(Error::BlockHashNotFound))
-							} else if err.is_pool_issue().is_some() {
+							} else if err.is_pool_issue() {
 								Err(RetryPolicy::Skip(Error::TransactionPoolIssue))
 							} else {
 								Err(RetryPolicy::Throw(err))

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -233,7 +233,7 @@ impl SpacewalkParachain {
 			},
 			|result| async {
 				match result.map_err(Into::<Error>::into) {
-					Ok(te) => Ok(te),
+					Ok(ok) => Ok(ok),
 					Err(err) => match err.is_invalid_transaction() {
 						Some(Recoverability::Recoverable(data)) =>
 							Err(RetryPolicy::Skip(Error::InvalidTransaction(data))),

--- a/clients/runtime/src/tests.rs
+++ b/clients/runtime/src/tests.rs
@@ -74,7 +74,7 @@ async fn test_too_low_priority_matching() {
 	let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
 	let parachain_rpc = setup_provider(client.clone(), AccountKeyring::Alice).await;
 	let err = parachain_rpc.get_too_low_priority_error(AccountKeyring::Bob.into()).await;
-	assert!(err.is_pool_too_low_priority().is_some())
+	assert!(err.is_pool_too_low_priority())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/clients/vault/src/requests/execution.rs
+++ b/clients/vault/src/requests/execution.rs
@@ -172,7 +172,7 @@ async fn execute_open_request_async(
 					request.request_type(),
 					request.hash()
 				);
-				retry_count += 1; // increase retry count
+				break; // There is also no need to retry on an unrecoverable error.
 			},
 			Err(error) => {
 				retry_count += 1; // increase retry count

--- a/clients/vault/src/requests/execution.rs
+++ b/clients/vault/src/requests/execution.rs
@@ -172,7 +172,7 @@ async fn execute_open_request_async(
 					request.request_type(),
 					request.hash()
 				);
-				break; // There is also no need to retry on an unrecoverable error.
+				break // There is also no need to retry on an unrecoverable error.
 			},
 			Err(error) => {
 				retry_count += 1; // increase retry count

--- a/clients/vault/src/requests/structs.rs
+++ b/clients/vault/src/requests/structs.rs
@@ -6,9 +6,9 @@ use crate::{
 };
 use primitives::{stellar::PublicKey, CurrencyId};
 use runtime::{
-	OraclePallet, RedeemPallet, ReplacePallet, SecurityPallet, SpacewalkRedeemRequest,
-	SpacewalkReplaceRequest, StellarPublicKeyRaw, StellarRelayPallet, UtilFuncs, VaultId,
-	VaultRegistryPallet, H256,Recoverability,RetryPolicy, Error as EnrichedError
+	Error as EnrichedError, OraclePallet, Recoverability, RedeemPallet, ReplacePallet, RetryPolicy,
+	SecurityPallet, SpacewalkRedeemRequest, SpacewalkReplaceRequest, StellarPublicKeyRaw,
+	StellarRelayPallet, UtilFuncs, VaultId, VaultRegistryPallet, H256,
 };
 use sp_runtime::traits::StaticLookup;
 use std::{convert::TryInto, sync::Arc, time::Duration};
@@ -210,12 +210,11 @@ impl Request {
 							// Handle other errors
 							if err.is_pool_too_low_priority() {
 								Err(RetryPolicy::Skip(EnrichedError::PoolTooLowPriority))
-							}else if err.is_rpc_disconnect_error() {
+							} else if err.is_rpc_disconnect_error() {
 								Err(RetryPolicy::Throw(err))
 							} else if err.is_block_hash_not_found_error() {
 								Err(RetryPolicy::Skip(EnrichedError::BlockHashNotFound))
-								
-							}else {
+							} else {
 								Err(RetryPolicy::Throw(err))
 							}
 						},

--- a/clients/vault/src/requests/structs.rs
+++ b/clients/vault/src/requests/structs.rs
@@ -200,7 +200,7 @@ impl Request {
 			},
 			|result| async {
 				match result.map_err(Into::<EnrichedError>::into) {
-					Ok(te) => Ok(te),
+					Ok(ok) => Ok(ok),
 					Err(err) => match err.is_invalid_transaction() {
 						Some(Recoverability::Recoverable(data)) =>
 							Err(RetryPolicy::Skip(EnrichedError::InvalidTransaction(data))),

--- a/clients/vault/src/requests/structs.rs
+++ b/clients/vault/src/requests/structs.rs
@@ -8,7 +8,7 @@ use primitives::{stellar::PublicKey, CurrencyId};
 use runtime::{
 	OraclePallet, RedeemPallet, ReplacePallet, SecurityPallet, SpacewalkRedeemRequest,
 	SpacewalkReplaceRequest, StellarPublicKeyRaw, StellarRelayPallet, UtilFuncs, VaultId,
-	VaultRegistryPallet, H256,
+	VaultRegistryPallet, H256,Recoverability,RetryPolicy, Error as EnrichedError
 };
 use sp_runtime::traits::StaticLookup;
 use std::{convert::TryInto, sync::Arc, time::Duration};
@@ -199,11 +199,27 @@ impl Request {
 				)
 			},
 			|result| async {
-				match result {
-					Ok(ok) => Ok(ok),
-					Err(err) if err.is_rpc_disconnect_error() =>
-						Err(runtime::RetryPolicy::Throw(err)),
-					Err(err) => Err(runtime::RetryPolicy::Skip(err)),
+				match result.map_err(Into::<EnrichedError>::into) {
+					Ok(te) => Ok(te),
+					Err(err) => match err.is_invalid_transaction() {
+						Some(Recoverability::Recoverable(data)) =>
+							Err(RetryPolicy::Skip(EnrichedError::InvalidTransaction(data))),
+						Some(Recoverability::Unrecoverable(data)) =>
+							Err(RetryPolicy::Throw(EnrichedError::InvalidTransaction(data))),
+						None => {
+							// Handle other errors
+							if err.is_pool_too_low_priority() {
+								Err(RetryPolicy::Skip(EnrichedError::PoolTooLowPriority))
+							}else if err.is_rpc_disconnect_error() {
+								Err(RetryPolicy::Throw(err))
+							} else if err.is_block_hash_not_found_error() {
+								Err(RetryPolicy::Skip(EnrichedError::BlockHashNotFound))
+								
+							}else {
+								Err(RetryPolicy::Throw(err))
+							}
+						},
+					},
 				}
 			},
 		)

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -288,7 +288,6 @@ impl Service<VaultServiceConfig, Error> for VaultService {
 		} else {
 			result
 		}
-		
 	}
 }
 

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -281,7 +281,14 @@ impl Service<VaultServiceConfig, Error> for VaultService {
 	}
 
 	async fn start(&mut self) -> Result<(), ServiceError<Error>> {
-		self.run_service().await
+		let result = self.run_service().await;
+		if let Err(error) = result {
+			let _ = self.shutdown.send(());
+			Err(error)
+		} else {
+			result
+		}
+		
 	}
 }
 


### PR DESCRIPTION
Closes #452 

### Changes
- Uses the string `data` filed on the parsed error to detect recoverable errors (lack of funds, incorrect nonce).
- Otherwise, the service will avoid retry of the same call, since it is impossible to obtain a different result without modifying it (except vault operator's input).
- A new condition is added so that if the error is of type `POOL_UNACTIONABLE` or `POOL_UNKNOWN_VALIDITY` (which are not necessarily invalid transactions) the vault will retry the transaction.
- If the service fails to start it will send a [shutdown signal](https://github.com/pendulum-chain/spacewalk/compare/452-vault-client-retries-transaction-submission-for-unrecoverable-errors?expand=1#diff-0f76594421d4493b3bba1c9ed7864cdab7148f19c5d3a18a9bcc9a174bb85aa8R286) to avoid waiting a dead process.