### PR TITLE
Change requirement for validators to build valid quorum set

### DIFF
--- a/pallets/stellar-relay/src/tests.rs
+++ b/pallets/stellar-relay/src/tests.rs
@@ -315,6 +315,12 @@ fn validate_stellar_transaction_fails_when_using_the_same_validator_multiple_tim
 		let sdf_validators = validators.drain(0..3).collect::<Vec<ValidatorOf<Test>>>();
 		let sdf_validator_secret_keys =
 			validator_secret_keys.drain(0..3).collect::<Vec<SecretKey>>();
+
+		// Remove all keybase validators (otherwise the quorum set would still be valid because the
+		// SDF validators are not required for a valid quorum)
+		validators.drain(0..3);
+		validator_secret_keys.drain(0..3);
+
 		// Pick first removed sdf validator to be re-used
 		let reused_validator = sdf_validators.get(0).unwrap();
 		let reused_validator_secret_key = sdf_validator_secret_keys.get(0).unwrap();


### PR DESCRIPTION
Changes the validation logic so that not each organization has to meet the requirement of >1/2 validators but only >2/3 of the total organizations have to meet it. This aligns to the discussion in [this](https://www.notion.so/satoshipay/23-11-29-Stellar-relay-consensus-issues-d587d75c4616429eb8c4a134dd54ece2) notion page.

Closes #457.