### PR TITLE
release: Fix bug in test and retry release 1.0.3

### DIFF
--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -8,9 +8,7 @@ use tokio::{
 
 use runtime::ShutdownSender;
 use stellar_relay_lib::{
-	connect_to_stellar_overlay_network,
-	helper::to_base64_xdr_string,
-	sdk::{types::StellarMessage, SecretKey},
+	connect_to_stellar_overlay_network, helper::to_base64_xdr_string, sdk::types::StellarMessage,
 	StellarOverlayConfig,
 };
 
@@ -209,7 +207,6 @@ mod tests {
 		get_random_secret_key, get_test_secret_key, get_test_stellar_relay_config,
 		traits::ArchiveStorage, ScpArchiveStorage, TransactionsArchiveStorage,
 	};
-	use std::str::from_utf8;
 
 	use super::*;
 	use serial_test::serial;

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -8,7 +8,9 @@ use tokio::{
 
 use runtime::ShutdownSender;
 use stellar_relay_lib::{
-	connect_to_stellar_overlay_network, helper::to_base64_xdr_string, sdk::types::StellarMessage,
+	connect_to_stellar_overlay_network,
+	helper::to_base64_xdr_string,
+	sdk::{types::StellarMessage, SecretKey},
 	StellarOverlayConfig,
 };
 
@@ -203,11 +205,11 @@ impl OracleAgent {
 
 #[cfg(test)]
 mod tests {
-
 	use crate::oracle::{
-		get_test_secret_key, get_test_stellar_relay_config, traits::ArchiveStorage,
-		ScpArchiveStorage, TransactionsArchiveStorage,
+		get_random_secret_key, get_test_secret_key, get_test_stellar_relay_config,
+		traits::ArchiveStorage, ScpArchiveStorage, TransactionsArchiveStorage,
 	};
+	use std::str::from_utf8;
 
 	use super::*;
 	use serial_test::serial;
@@ -217,9 +219,11 @@ mod tests {
 	#[serial]
 	async fn test_get_proof_for_current_slot() {
 		let shutdown_sender = ShutdownSender::new();
+
+		// We use a random secret key to avoid conflicts with other tests.
 		let agent = start_oracle_agent(
 			get_test_stellar_relay_config(true),
-			&get_test_secret_key(true),
+			&get_random_secret_key(),
 			shutdown_sender,
 		)
 		.await

--- a/clients/vault/src/oracle/collector/proof_builder.rs
+++ b/clients/vault/src/oracle/collector/proof_builder.rs
@@ -358,7 +358,10 @@ impl ScpMessageCollector {
 
 #[cfg(test)]
 mod test {
-	use crate::oracle::collector::proof_builder::check_slot_still_recoverable_from_overlay;
+	use crate::oracle::{
+		collector::proof_builder::check_slot_still_recoverable_from_overlay,
+		types::constants::MAX_SLOTS_TO_REMEMBER,
+	};
 
 	#[test]
 	fn test_check_slot_position() {
@@ -367,7 +370,14 @@ mod test {
 		assert!(!check_slot_still_recoverable_from_overlay(last_slot, 50));
 		assert!(!check_slot_still_recoverable_from_overlay(last_slot, 100));
 		assert!(!check_slot_still_recoverable_from_overlay(last_slot, 30_000));
-		assert!(check_slot_still_recoverable_from_overlay(last_slot, 40_500));
-		assert!(check_slot_still_recoverable_from_overlay(last_slot, 49_500));
+		assert!(!check_slot_still_recoverable_from_overlay(
+			last_slot,
+			last_slot - MAX_SLOTS_TO_REMEMBER
+		));
+		assert!(check_slot_still_recoverable_from_overlay(last_slot, last_slot - 1));
+		assert!(check_slot_still_recoverable_from_overlay(
+			last_slot,
+			last_slot - MAX_SLOTS_TO_REMEMBER + 1
+		));
 	}
 }

--- a/clients/vault/src/oracle/testing_utils.rs
+++ b/clients/vault/src/oracle/testing_utils.rs
@@ -1,3 +1,5 @@
+use stellar_relay_lib::sdk::SecretKey;
+
 pub fn get_test_stellar_relay_config(is_mainnet: bool) -> stellar_relay_lib::StellarOverlayConfig {
 	use rand::seq::SliceRandom;
 
@@ -21,4 +23,14 @@ pub fn get_test_secret_key(is_mainnet: bool) -> String {
 	let file_name = if is_mainnet { "mainnet" } else { "testnet" };
 	let path = format!("./resources/secretkey/stellar_secretkey_{file_name}");
 	std::fs::read_to_string(path).expect("should return a string")
+}
+
+pub fn get_random_secret_key() -> String {
+	// Generate a new random Stellar keypair
+	let secret = SecretKey::from_binary(rand::random());
+	let secret_encoded = secret.to_encoding();
+	// Convert the secret key to a string
+	let secret_string = std::str::from_utf8(&secret_encoded).expect("Failed to convert to string");
+
+	secret_string.to_string()
 }


### PR DESCRIPTION
Fixes some tests. The test to get the current proof was changed to use a random keypair so that we could rule out issues with the client already being connected to the overlay node, thus encountering a timeout in that test.