### PR TITLE
add-try-runtime-feature

### DIFF
--- a/pallets/clients-info/Cargo.toml
+++ b/pallets/clients-info/Cargo.toml
@@ -40,3 +40,7 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
 ]
+
+try-runtime = [
+    "frame-system/try-runtime",
+]

--- a/pallets/currency/Cargo.toml
+++ b/pallets/currency/Cargo.toml
@@ -58,3 +58,11 @@ testing-utils = [
 # This feature has to be separate from the testing-utils feature because combining them causes the 'duplicate lang item' error
 # when compiling the testchain runtime
 testing-constants = []
+
+try-runtime = [
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-transaction-payment/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+]

--- a/pallets/fee/Cargo.toml
+++ b/pallets/fee/Cargo.toml
@@ -77,3 +77,16 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "currency/testing-constants"
 ]
+
+try-runtime = [
+    "frame-system/try-runtime",
+    "currency/try-runtime",
+    "pallet-balances/try-runtime",
+    "security/try-runtime",
+    "staking/try-runtime",
+    "pooled-rewards/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "reward-distribution/try-runtime",
+    "oracle/try-runtime",
+]

--- a/pallets/issue/Cargo.toml
+++ b/pallets/issue/Cargo.toml
@@ -102,4 +102,17 @@ runtime-benchmarks = [
     "security/testing-utils",
     "oracle/testing-utils"
 ]
-try-runtime = ["frame-support/try-runtime"]
+try-runtime = [
+    "frame-system/try-runtime",
+    "currency/try-runtime",
+    "fee/try-runtime",
+    "pallet-balances/try-runtime",
+    "stellar-relay/try-runtime",
+    "vault-registry/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "security/try-runtime",
+    "pooled-rewards/try-runtime",
+    "reward-distribution/try-runtime",
+    "oracle/try-runtime",
+]

--- a/pallets/nomination/Cargo.toml
+++ b/pallets/nomination/Cargo.toml
@@ -89,3 +89,20 @@ runtime-benchmarks = [
     "security/testing-utils",
     "oracle/testing-utils"
 ]
+
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "currency/try-runtime",
+    "security/try-runtime",
+    "vault-registry/try-runtime",
+    "fee/try-runtime",
+    "pooled-rewards/try-runtime",
+    "oracle/try-runtime",
+    "staking/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "reward-distribution/try-runtime",
+]

--- a/pallets/oracle/Cargo.toml
+++ b/pallets/oracle/Cargo.toml
@@ -82,3 +82,16 @@ runtime-benchmarks = [
     "testing-utils"
 ]
 testing-utils = ["spin", "once_cell"]
+
+try-runtime = [
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "security/try-runtime",
+    "staking/try-runtime",
+    "currency/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "orml-oracle/try-runtime",
+    "dia-oracle/try-runtime",
+]

--- a/pallets/pooled-rewards/Cargo.toml
+++ b/pallets/pooled-rewards/Cargo.toml
@@ -56,3 +56,9 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
 ]
+
+try-runtime = [
+    "frame-system/try-runtime",
+     "frame-system/try-runtime",
+     "currency/try-runtime",
+]

--- a/pallets/redeem/Cargo.toml
+++ b/pallets/redeem/Cargo.toml
@@ -96,3 +96,20 @@ runtime-benchmarks = [
     "oracle/testing-utils",
     "currency/testing-constants"
 ]
+
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "pooled-rewards/try-runtime",
+    "currency/try-runtime",
+    "fee/try-runtime",
+    "oracle/try-runtime",
+    "security/try-runtime",
+    "stellar-relay/try-runtime",
+    "vault-registry/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "reward-distribution/try-runtime",
+]

--- a/pallets/replace/Cargo.toml
+++ b/pallets/replace/Cargo.toml
@@ -99,3 +99,21 @@ runtime-benchmarks = [
     "security/testing-utils",
     "oracle/testing-utils"
 ]
+
+try-runtime = [
+     "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "pallet-timestamp/try-runtime",
+    "pooled-rewards/try-runtime",
+    "currency/try-runtime",
+    "fee/try-runtime",
+    "nomination/try-runtime",
+    "oracle/try-runtime",
+    "security/try-runtime",
+    "stellar-relay/try-runtime",
+    "vault-registry/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "reward-distribution/try-runtime",
+]

--- a/pallets/reward-distribution/Cargo.toml
+++ b/pallets/reward-distribution/Cargo.toml
@@ -71,3 +71,16 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
 ]
+
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+    "pallet-balances/try-runtime",
+    "currency/try-runtime",
+    "pooled-rewards/try-runtime",
+    "oracle/try-runtime",
+    "orml-currencies/try-runtime",
+    "orml-tokens/try-runtime",
+    "security/try-runtime",
+    "staking/try-runtime",
+]

--- a/pallets/reward/Cargo.toml
+++ b/pallets/reward/Cargo.toml
@@ -53,3 +53,8 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
 ]
+
+try-runtime = [
+     "frame-support/try-runtime",
+    "frame-system/try-runtime",
+]

--- a/pallets/security/Cargo.toml
+++ b/pallets/security/Cargo.toml
@@ -36,3 +36,8 @@ std = [
   "frame-system/std",
 ]
 testing-utils = []
+
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+]

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -57,3 +57,8 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
 ]
+
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+]

--- a/pallets/vault-registry/Cargo.toml
+++ b/pallets/vault-registry/Cargo.toml
@@ -91,3 +91,20 @@ std = [
   "staking/std",
   "primitives/std",
 ]
+
+
+try-runtime = [
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-timestamp/try-runtime",
+  "pooled-rewards/try-runtime",
+  "orml-currencies/try-runtime",
+  "orml-tokens/try-runtime",
+  "oracle/try-runtime",
+  "fee/try-runtime",
+  "security/try-runtime",
+  "currency/try-runtime",
+  "reward/try-runtime",
+  "staking/try-runtime",
+]


### PR DESCRIPTION

This PR adds the `try-runtime` features to some of the pallets such that we can compile the runtime with this feature enabled.
This is related to [tasks/#64](https://github.com/pendulum-chain/tasks/issues/64), but overall we require this so we can tests future runtime upgrades or other tests with `try-runtime`. 