### PR TITLE
312 use stellar fee statistics to derive transaction fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +784,42 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cached"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b0116662497bc24e4b177c90eaf8870e39e2714c3fcfa296327a93f593fc21"
+dependencies = [
+ "ahash 0.8.3",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures 0.3.28",
+ "hashbrown 0.14.0",
+ "instant",
+ "once_cell",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c878c71c2821aa2058722038a59a67583a4240524687c6028571c9b395ded61f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "camino"
@@ -2993,6 +3035,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "headers"
@@ -11224,6 +11270,7 @@ name = "wallet"
 version = "1.0.3"
 dependencies = [
  "async-trait",
+ "cached",
  "futures 0.3.28",
  "mockall 0.8.3",
  "mocktopus",

--- a/clients/vault/src/requests/structs.rs
+++ b/clients/vault/src/requests/structs.rs
@@ -16,10 +16,6 @@ use stellar_relay_lib::sdk::{Asset, TransactionEnvelope, XdrCodec};
 use tokio::sync::RwLock;
 use wallet::{StellarWallet, TransactionResponse};
 
-/// Determines how much the vault is going to pay for the Stellar transaction fees.
-/// We use a fixed fee of 300 stroops for now but might want to make this dynamic in the future.
-const DEFAULT_STROOP_FEE_PER_OPERATION: u32 = 300;
-
 #[derive(Debug, Clone, PartialEq)]
 struct Deadline {
 	parachain: u32,
@@ -291,7 +287,6 @@ impl Request {
 						self.asset.clone(),
 						stroop_amount,
 						request_id,
-						DEFAULT_STROOP_FEE_PER_OPERATION,
 						true,
 					)
 					.await,
@@ -302,7 +297,6 @@ impl Request {
 						self.asset.clone(),
 						stroop_amount,
 						request_id,
-						DEFAULT_STROOP_FEE_PER_OPERATION,
 						false,
 					)
 					.await,

--- a/clients/vault/tests/helper/helper.rs
+++ b/clients/vault/tests/helper/helper.rs
@@ -117,7 +117,6 @@ pub async fn send_payment_to_address(
 	asset: StellarAsset,
 	stroop_amount: StellarStroops,
 	request_id: [u8; 32],
-	stroop_fee_per_operation: u32,
 	is_payment_for_redeem_request: bool,
 ) -> Result<TransactionResponse, Error> {
 	let response;
@@ -130,7 +129,6 @@ pub async fn send_payment_to_address(
 				asset.clone(),
 				stroop_amount,
 				request_id,
-				stroop_fee_per_operation,
 				is_payment_for_redeem_request,
 			)
 			.await;
@@ -175,7 +173,6 @@ pub async fn assert_issue(
 		asset,
 		stroop_amount,
 		issue.issue_id.0,
-		300,
 		false,
 	)
 	.await

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -597,7 +597,6 @@ async fn test_issue_overpayment_succeeds() {
 				stellar_asset,
 				stroop_amount.try_into().unwrap(),
 				issue.issue_id.0,
-				300,
 				false,
 			)
 			.await
@@ -685,7 +684,6 @@ async fn test_automatic_issue_execution_succeeds() {
 					stellar_asset,
 					stroop_amount,
 					issue.issue_id.0,
-					300,
 					false,
 				)
 				.await
@@ -822,7 +820,6 @@ async fn test_automatic_issue_execution_succeeds_for_other_vault() {
 					stellar_asset,
 					stroop_amount,
 					issue.issue_id.0,
-					300,
 					false,
 				)
 				.await;
@@ -974,7 +971,6 @@ async fn test_execute_open_requests_succeeds() {
 					asset,
 					stroop_amount,
 					redeem_ids[0].0,
-					300,
 					false
 				)
 				.await

--- a/clients/wallet/Cargo.toml
+++ b/clients/wallet/Cargo.toml
@@ -11,6 +11,7 @@ testing-utils = []
 [dependencies]
 async-trait = "0.1.40"
 futures = "0.3.5"
+cached = { version = "0.47.0", features = ["async"]}
 parity-scale-codec = "3.0.0"
 rand = "0.8.5"
 reqwest = { version = "0.11", features = ["json"] }

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
 
 	#[error("Cannot send payment to self")]
 	SelfPaymentError,
+
+	#[error("Failed to get fee: {0}")]
+	FailedToGetFee(String),
 }
 
 impl Error {

--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -18,7 +18,7 @@ use crate::{
 	error::Error,
 	horizon::{
 		responses::{
-			interpret_response, HorizonAccountResponse, HorizonClaimableBalanceResponse,
+			interpret_response, FeeStats, HorizonAccountResponse, HorizonClaimableBalanceResponse,
 			HorizonTransactionsResponse, TransactionResponse, TransactionsResponseIter,
 		},
 		traits::HorizonClient,
@@ -95,7 +95,7 @@ impl HorizonClient for reqwest::Client {
 	) -> Result<HorizonAccountResponse, Error> {
 		let account_id_encoded = account_id.as_encoded_string()?;
 		let base_url = horizon_url(is_public_network, false);
-		let url = format!("{}/accounts/{}", base_url, account_id_encoded);
+		let url = format!("{base_url}/accounts/{account_id_encoded}");
 
 		self.get_from_url(&url).await
 	}
@@ -107,7 +107,14 @@ impl HorizonClient for reqwest::Client {
 	) -> Result<HorizonClaimableBalanceResponse, Error> {
 		let id_encoded = claimable_balance_id.as_encoded_string()?;
 		let base_url = horizon_url(is_public_network, false);
-		let url = format!("{}/claimable_balances/{}", base_url, id_encoded);
+		let url = format!("{base_url}/claimable_balances/{id_encoded}");
+
+		self.get_from_url(&url).await
+	}
+
+	async fn get_fee_stats(&self, is_public_network: bool) -> Result<FeeStats, Error> {
+		let base_url = horizon_url(is_public_network, false);
+		let url = format!("{base_url}/fee_stats");
 
 		self.get_from_url(&url).await
 	}

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -1,7 +1,7 @@
 use crate::{
 	error::Error,
 	horizon::{serde::*, traits::HorizonClient, Ledger},
-	types::{PagingToken, StatusCode},
+	types::{FeeAttribute, PagingToken, StatusCode},
 };
 use parity_scale_codec::{Decode, Encode};
 use primitives::{
@@ -354,6 +354,71 @@ pub struct EmbeddedClaimableBalance {
 pub struct HorizonClaimableBalanceResponse {
 	#[serde(flatten)]
 	pub claimable_balance: ClaimableBalance,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct FeeDistribution {
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub max: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub min: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub mode: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p10: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p20: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p30: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p40: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p50: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p60: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p70: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p80: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p90: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p95: u32,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub p99: u32,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct FeeStats {
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub last_ledger: Ledger,
+	#[serde(deserialize_with = "de_string_to_u32")]
+	pub last_ledger_base_fee: u32,
+	#[serde(deserialize_with = "de_string_to_f64")]
+	pub ledger_capacity_usage: f64,
+	pub fee_charged: FeeDistribution,
+	pub max_fee: FeeDistribution,
+}
+
+impl FeeStats {
+	pub fn fee_charged_by(&self, fee_attr: FeeAttribute) -> u32 {
+		match fee_attr {
+			FeeAttribute::max => self.fee_charged.max,
+			FeeAttribute::min => self.fee_charged.min,
+			FeeAttribute::mode => self.fee_charged.mode,
+			FeeAttribute::p10 => self.fee_charged.p10,
+			FeeAttribute::p20 => self.fee_charged.p20,
+			FeeAttribute::p30 => self.fee_charged.p30,
+			FeeAttribute::p40 => self.fee_charged.p40,
+			FeeAttribute::p50 => self.fee_charged.p50,
+			FeeAttribute::p60 => self.fee_charged.p60,
+			FeeAttribute::p70 => self.fee_charged.p70,
+			FeeAttribute::p80 => self.fee_charged.p80,
+			FeeAttribute::p90 => self.fee_charged.p90,
+			FeeAttribute::p95 => self.fee_charged.p95,
+			FeeAttribute::p99 => self.fee_charged.p99,
+		}
+	}
 }
 
 // This represents each record for a claimable balance in the Horizon API response

--- a/clients/wallet/src/horizon/serde.rs
+++ b/clients/wallet/src/horizon/serde.rs
@@ -41,6 +41,14 @@ where
 	f64::from_str(s).map_err(serde::de::Error::custom)
 }
 
+pub fn de_string_to_u32<'de, D>(de: D) -> Result<u32, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let s: &str = Deserialize::deserialize(de)?;
+	u32::from_str(s).map_err(serde::de::Error::custom)
+}
+
 pub fn de_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
 where
 	D: Deserializer<'de>,

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -213,3 +213,9 @@ async fn fetch_horizon_and_process_new_transactions_success() {
 
 	assert!(!slot_env_map.read().await.is_empty());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn horizon_get_fee() {
+	let horizon_client = reqwest::Client::new();
+	assert!(horizon_client.get_fee_stats(false).await.is_ok());
+}

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -218,4 +218,5 @@ async fn fetch_horizon_and_process_new_transactions_success() {
 async fn horizon_get_fee() {
 	let horizon_client = reqwest::Client::new();
 	assert!(horizon_client.get_fee_stats(false).await.is_ok());
+	assert!(horizon_client.get_fee_stats(true).await.is_ok());
 }

--- a/clients/wallet/src/horizon/traits.rs
+++ b/clients/wallet/src/horizon/traits.rs
@@ -1,8 +1,8 @@
 use crate::{
 	error::Error,
 	horizon::responses::{
-		HorizonAccountResponse, HorizonClaimableBalanceResponse, HorizonTransactionsResponse,
-		TransactionResponse,
+		FeeStats, HorizonAccountResponse, HorizonClaimableBalanceResponse,
+		HorizonTransactionsResponse, TransactionResponse,
 	},
 	types::PagingToken,
 };
@@ -36,6 +36,8 @@ pub trait HorizonClient {
 		claimable_balance_id: A,
 		is_public_network: bool,
 	) -> Result<HorizonClaimableBalanceResponse, Error>;
+
+	async fn get_fee_stats(&self, is_public_network: bool) -> Result<FeeStats, Error>;
 
 	async fn submit_transaction(
 		&self,

--- a/clients/wallet/src/mock.rs
+++ b/clients/wallet/src/mock.rs
@@ -42,8 +42,7 @@ impl StellarWallet {
 		let account_merge_op =
 			create_account_merge_operation(destination_address, self.public_key())?;
 
-		self.send_to_address([9u8; 32], DEFAULT_STROOP_FEE_PER_OPERATION, vec![account_merge_op])
-			.await
+		self.send_to_address([9u8; 32], vec![account_merge_op]).await
 	}
 
 	pub fn create_payment_envelope(

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -344,7 +344,6 @@ mod test {
 					asset.clone(),
 					amount,
 					rand::random(),
-					DEFAULT_STROOP_FEE_PER_OPERATION,
 					false,
 				)
 				.await

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -230,6 +230,8 @@ impl StellarWallet {
 	}
 }
 
+/// Returns a fee for performing an operation.
+/// This function will be re-executed after the cache expires (according to `time` seconds).
 #[cached(time = 600)]
 async fn get_fee(is_public_network: bool, fee_attr: FeeAttribute) -> Result<u32, String> {
 	let horizon_client = Client::new();

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -231,8 +231,9 @@ impl StellarWallet {
 }
 
 /// Returns a fee for performing an operation.
-/// This function will be re-executed after the cache expires (according to `time` seconds).
-#[cached(time = 600)]
+/// This function will be re-executed after the cache expires (according to `time` seconds) OR
+/// when the result is NOT `Ok`.
+#[cached(result = true, time = 600)]
 async fn get_fee(is_public_network: bool, fee_attr: FeeAttribute) -> Result<u32, String> {
 	let horizon_client = Client::new();
 	let fee_stats = horizon_client

--- a/clients/wallet/src/types.rs
+++ b/clients/wallet/src/types.rs
@@ -1,11 +1,44 @@
 use crate::horizon::responses::TransactionResponse;
 use primitives::stellar::TransactionEnvelope;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt, fmt::Formatter};
 
 pub type PagingToken = u128;
 pub type Slot = u32;
 pub type StatusCode = u16;
 pub type LedgerTxEnvMap = HashMap<Slot, TransactionEnvelope>;
+
+/// The child attributes of the `fee_charged` attribute of
+/// [Fee Stats Object](https://developers.stellar.org/api/horizon/aggregations/fee-stats/object).
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FeeAttribute {
+	max,
+	min,
+	mode,
+	p10,
+	p20,
+	p30,
+	p40,
+	p50,
+	p60,
+	p70,
+	p80,
+	p90,
+	p95,
+	p99,
+}
+
+impl fmt::Display for FeeAttribute {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		write!(f, "{:?}", self)
+	}
+}
+
+impl Default for FeeAttribute {
+	fn default() -> Self {
+		FeeAttribute::p90
+	}
+}
 
 /// A filter trait to check whether `T` should be processed.
 pub trait FilterWith<T: Clone, U: Clone> {


### PR DESCRIPTION
closes #312 

## General overview of the changes:
1. **Remove** _`DEFAULT_STROOP_FEE_PER_OPERATION`_ constant in production code.
2. **Remove** _`stroop_fee_per_operation`_ parameters on method **`fn send_to_address()`**; since
3. fee will be queried from horizon; the method is called`fn get_fee_stats()`
4. Memoization using the [cached](https://docs.rs/cached/0.47.0/cached/) lib to return the same result until 10 minutes (or 600 seconds) have elapsed.

~~todo: only memoize for `Ok()` results.~~

----  
## How to begin the review:    
1. `clients/wallet/src/types.rs` -> has the `FeeAttribute` enum, where you can pick which one to base the operation on
2. `clients/wallet/src/horizon/responses.rs` -> Defining the response into a struct of `FeeStats` and `FeeDistribution`
3. `clients/wallet/src/horizon/serde.rs` -> Implements deserialization of the fields in `FeeStats` and `FeeDistribution` to u32
5.  `clients/wallet/src/horizon/traits.rs` -> add another method to the trait: `fn get_fee_stats()` and should return the struct `FeeStats`
6. ` clients/wallet/src/horizon/horizon.rs` -> implements `fn get_fee_stats()`
7. `clients/wallet/src/horizon/tests.rs` -> testing the method `fn get_fee_stats()`
8. `clients/wallet/src/stellar_wallet.rs`
    * the method `fn get_fee()` is introduced, with caching: 
       ```
          #[cached(result = true, time = 600)]
      ```
   * the method `fn get_fee()` is called inside `fn send_to_address(...)`, removing the `stroop_fee_per_operation` param
9. ALL calls of `fn send_to_address(...)` will not need to pass a `stroop_fee_per_operation`

