### PR TITLE
Replacing Tokio's `TcpStream` with `async-std` `TcpStream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +401,35 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0c4a4f319e45986f347ee47fef8bf5e81c9abc3f6f58dc2391439f30df65f0"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.0",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -421,6 +460,39 @@ checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
 ]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite 0.2.10",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
@@ -694,6 +766,22 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blocking"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c36a4d0d48574b3dd360b4b7d95cc651d2b6557b6402848a27d4b228a473e2a"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "fastrand 2.0.0",
+ "futures-io",
+ "futures-lite",
+ "piper",
+ "tracing",
+]
 
 [[package]]
 name = "bounded-collections"
@@ -3827,6 +3915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "kvdb"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,6 +4592,9 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -6021,6 +6121,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.0",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -9965,6 +10076,7 @@ dependencies = [
 name = "stellar-relay-lib"
 version = "1.0.3"
 dependencies = [
+ "async-std",
  "base64 0.13.1",
  "env_logger 0.9.3",
  "err-derive",
@@ -11120,9 +11232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-bag"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdbaf5e132e593e9fc1de6a15bbec912395b11fb9719e061cf64f804524c503"
+
+[[package]]
 name = "vault"
 version = "1.0.3"
 dependencies = [
+ "async-std",
  "async-trait",
  "base64 0.13.1",
  "bincode",

--- a/clients/stellar-relay-lib/Cargo.toml
+++ b/clients/stellar-relay-lib/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { version = "1.0", features = [
     "sync",             # to make channels available
     "time"              # for timeouts and sleep, when reconnecting
 ] }
+async-std = { version = "1.12.0", features = ["attributes"] }
 
 [features]
 std = [

--- a/clients/stellar-relay-lib/Cargo.toml
+++ b/clients/stellar-relay-lib/Cargo.toml
@@ -36,9 +36,7 @@ err-derive = "0.3.1"
 tokio = { version = "1.0", features = [
     "macros",           # allows main function to be async
     "rt-multi-thread",  # for multi-thread runtime
-    "net",              # contains the TcpStream
     "sync",             # to make channels available
-    "io-util",          # for async read/write operations
     "time"              # for timeouts and sleep, when reconnecting
 ] }
 

--- a/clients/stellar-relay-lib/examples/connect.rs
+++ b/clients/stellar-relay-lib/examples/connect.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let mut overlay_connection = connect_to_stellar_overlay_network(cfg, &secret_key).await?;
 
-	while let Ok(Some(msg)) = overlay_connection.listen().await {
+	while let Ok(Some(msg)) = overlay_connection.listen() {
 		match msg {
 			StellarMessage::ScpMessage(msg) => {
 				let node_id = msg.statement.node_id.to_encoding();

--- a/clients/stellar-relay-lib/examples/connect.rs
+++ b/clients/stellar-relay-lib/examples/connect.rs
@@ -40,12 +40,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 					ScpStatementPledges::ScpStExternalize(_) => "ScpStExternalize",
 					ScpStatementPledges::ScpStNominate(_) => "ScpStNominate ",
 				};
-				log::info!(
-					"{} sent StellarMessage of type {} for ledger {}",
-					node_id,
-					stmt_type,
-					slot
-				);
+				// log::info!(
+				// 	"{} sent StellarMessage of type {} for ledger {}",
+				// 	node_id,
+				// 	stmt_type,
+				// 	slot
+				// );
 			},
 			_ => {
 				let _ = overlay_connection.send_to_node(StellarMessage::GetPeers).await;

--- a/clients/stellar-relay-lib/examples/connect.rs
+++ b/clients/stellar-relay-lib/examples/connect.rs
@@ -40,12 +40,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 					ScpStatementPledges::ScpStExternalize(_) => "ScpStExternalize",
 					ScpStatementPledges::ScpStNominate(_) => "ScpStNominate ",
 				};
-				// log::info!(
-				// 	"{} sent StellarMessage of type {} for ledger {}",
-				// 	node_id,
-				// 	stmt_type,
-				// 	slot
-				// );
+				log::info!(
+					"{} sent StellarMessage of type {} for ledger {}",
+					node_id,
+					stmt_type,
+					slot
+				);
 			},
 			_ => {
 				let _ = overlay_connection.send_to_node(StellarMessage::GetPeers).await;

--- a/clients/stellar-relay-lib/src/connection/connector/connector.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/connector.rs
@@ -1,9 +1,12 @@
-use std::fmt::{Debug, Formatter};
+use std::{
+	fmt::{Debug, Formatter},
+	net::TcpStream,
+	time::Duration,
+};
 use substrate_stellar_sdk::{
 	types::{AuthenticatedMessageV0, Curve25519Public, HmacSha256Mac, MessageType},
 	XdrCodec,
 };
-use tokio::net::tcp::OwnedWriteHalf;
 
 use crate::{
 	connection::{
@@ -33,7 +36,7 @@ pub struct Connector {
 	flow_controller: FlowController,
 
 	/// for writing xdr messages to stream.
-	pub(crate) write_stream_overlay: OwnedWriteHalf,
+	pub(crate) tcp_stream: TcpStream,
 }
 
 impl Debug for Connector {
@@ -109,18 +112,24 @@ impl Connector {
 		}
 	}
 
-	pub fn new(
-		local_node: NodeInfo,
-		conn_info: ConnectionInfo,
-		write_stream_overlay: OwnedWriteHalf,
-	) -> Self {
+	/// returns a Connector and starts creating a connection to Stellar
+	pub fn start(local_node: NodeInfo, conn_info: ConnectionInfo) -> Result<Self, Error> {
 		let connection_auth = ConnectionAuth::new(
 			&local_node.network_id,
 			conn_info.keypair(),
 			conn_info.auth_cert_expiration,
 		);
 
-		Connector {
+		let tcp_stream = TcpStream::connect(conn_info.address())
+			.map_err(|e| Error::ConnectionFailed(e.to_string()))?;
+
+		if let Err(e) =
+			tcp_stream.set_read_timeout(Some(Duration::from_secs(conn_info.timeout_in_secs)))
+		{
+			log::warn!("start(): failed to set ttl: {e:?}");
+		}
+
+		let mut connector = Connector {
 			local: LocalInfo::new(local_node),
 			remote_info: None,
 			hmac_keys: None,
@@ -131,14 +140,17 @@ impl Connector {
 			receive_scp_messages: conn_info.recv_scp_msgs,
 			handshake_state: HandshakeState::Connecting,
 			flow_controller: FlowController::default(),
-			write_stream_overlay,
-		}
-	}
+			tcp_stream,
+		};
 
-	pub fn set_write_stream_overlay(&mut self, write_stream_overlay: OwnedWriteHalf) {
-		self.write_stream_overlay = write_stream_overlay;
-	}
+		connector.send_hello_message()?;
 
+		Ok(connector)
+	}
+}
+
+// getters setters
+impl Connector {
 	pub fn local(&self) -> &LocalInfo {
 		&self.local
 	}
@@ -211,25 +223,24 @@ impl Connector {
 		self.flow_controller.enable(local_overlay_version, remote_overlay_version)
 	}
 }
-
 #[cfg(test)]
 mod test {
 	use crate::{connection::hmac::HMacKeys, node::RemoteInfo, StellarOverlayConfig};
 	use serial_test::serial;
+	use std::net::Shutdown;
 
 	use substrate_stellar_sdk::{
 		compound_types::LimitedString,
 		types::{Hello, MessageType},
 		PublicKey,
 	};
-	use tokio::{io::AsyncWriteExt, net::tcp::OwnedReadHalf};
 
 	use crate::{
 		connection::{
 			authentication::{create_auth_cert, ConnectionAuth},
 			Connector,
 		},
-		helper::{create_stream, time_now},
+		helper::time_now,
 		node::NodeInfo,
 		ConnectionInfo,
 	};
@@ -249,14 +260,14 @@ mod test {
 	}
 
 	impl Connector {
-		fn shutdown(&mut self, read_half: OwnedReadHalf) {
-			let _ = self.write_stream_overlay.shutdown();
-
-			drop(read_half);
+		fn shutdown(&mut self) {
+			self.tcp_stream
+				.shutdown(Shutdown::Both)
+				.expect("should shutdown both read and write of stream");
 		}
 	}
 
-	async fn create_connector() -> (NodeInfo, ConnectionInfo, Connector, OwnedReadHalf) {
+	async fn create_connector() -> (NodeInfo, ConnectionInfo, Connector) {
 		let cfg_file_path = "./resources/config/testnet/stellar_relay_config_sdftest1.json";
 		let secret_key_path = "./resources/secretkey/stellar_secretkey_testnet";
 		let secret_key =
@@ -268,16 +279,15 @@ mod test {
 		let conn_info = cfg.connection_info(&secret_key).expect("should create a connection info");
 		// this is a channel to communicate with the connection/config (this needs renaming)
 
-		let (read_half, write_half) =
-			create_stream(&conn_info.address()).await.expect("should return a stream");
-		let connector = Connector::new(node_info.clone(), conn_info.clone(), write_half);
-		(node_info, conn_info, connector, read_half)
+		let connector = Connector::start(node_info.clone(), conn_info.clone())
+			.expect("should create a connector");
+		(node_info, conn_info, connector)
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn create_new_connector_works() {
-		let (node_info, _, mut connector, read_half) = create_connector().await;
+		let (node_info, _, mut connector) = create_connector().await;
 
 		let connector_local_node = connector.local.node();
 
@@ -287,24 +297,24 @@ mod test {
 		assert_eq!(connector_local_node.version_str, node_info.version_str);
 		assert_eq!(connector_local_node.network_id, node_info.network_id);
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn connector_local_sequence_works() {
-		let (_, _, mut connector, read_half) = create_connector().await;
+		let (_, _, mut connector) = create_connector().await;
 		assert_eq!(connector.local_sequence(), 0);
 		connector.increment_local_sequence();
 		assert_eq!(connector.local_sequence(), 1);
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn connector_set_remote_works() {
-		let (_, _, mut connector, read_half) = create_connector().await;
+		let (_, _, mut connector) = create_connector().await;
 
 		let connector_auth = &connector.connection_auth;
 		let new_auth_cert = create_auth_cert_from_connection_auth(connector_auth);
@@ -324,13 +334,13 @@ mod test {
 
 		assert!(connector.remote().is_some());
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn connector_increment_remote_sequence_works() {
-		let (_, _, mut connector, read_half) = create_connector().await;
+		let (_, _, mut connector) = create_connector().await;
 
 		let connector_auth = &connector.connection_auth;
 		let new_auth_cert = create_auth_cert_from_connection_auth(connector_auth);
@@ -354,14 +364,14 @@ mod test {
 		connector.increment_remote_sequence().unwrap();
 		assert_eq!(connector.remote().unwrap().sequence(), 3);
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn connector_get_and_set_hmac_keys_works() {
 		//arrange
-		let (_, _, mut connector, read_half) = create_connector().await;
+		let (_, _, mut connector) = create_connector().await;
 		let connector_auth = &connector.connection_auth;
 		let new_auth_cert = create_auth_cert_from_connection_auth(connector_auth);
 
@@ -392,13 +402,13 @@ mod test {
 		//assert
 		assert!(connector.hmac_keys().is_some());
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn connector_method_works() {
-		let (_, conn_config, mut connector, read_half) = create_connector().await;
+		let (_, conn_config, mut connector) = create_connector().await;
 
 		assert_eq!(connector.remote_called_us(), conn_config.remote_called_us);
 		assert_eq!(connector.receive_tx_messages(), conn_config.recv_tx_msgs);
@@ -410,17 +420,17 @@ mod test {
 		connector.handshake_completed();
 		assert!(connector.is_handshake_created());
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn enable_flow_controller_works() {
-		let (node_info, _, mut connector, read_half) = create_connector().await;
+		let (node_info, _, mut connector) = create_connector().await;
 
 		assert!(!connector.inner_check_to_send_more(MessageType::ScpMessage));
 		connector.enable_flow_controller(node_info.overlay_version, node_info.overlay_version);
 
-		connector.shutdown(read_half);
+		connector.shutdown();
 	}
 }

--- a/clients/stellar-relay-lib/src/connection/connector/connector.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/connector.rs
@@ -135,6 +135,10 @@ impl Connector {
 		}
 	}
 
+	pub fn set_write_stream_overlay(&mut self, write_stream_overlay: OwnedWriteHalf) {
+		self.write_stream_overlay = write_stream_overlay;
+	}
+
 	pub fn local(&self) -> &LocalInfo {
 		&self.local
 	}

--- a/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
@@ -40,7 +40,7 @@ impl Connector {
 					return Err(Error::from(e))
 				},
 				other => log::error!(
-					"process_raw_message(): Received ErroMsg during authentication: {:?}",
+					"process_raw_message(): Received ErrorMsg during authentication: {:?}",
 					other
 				),
 			},
@@ -99,8 +99,11 @@ impl Connector {
 
 			other => {
 				log::trace!(
-					"process_stellar_message():  Processing {other:?} message: received from overlay"
+					"process_stellar_message():  Processing {} message: received from overlay",
+					String::from_utf8(other.to_base64_xdr())
+						.unwrap_or(format!("{:?}", other.to_base64_xdr()))
 				);
+
 				self.check_to_send_more(msg_type)?;
 				return Ok(Some(other))
 			},
@@ -117,13 +120,10 @@ impl Connector {
 		self.handshake_completed();
 
 		if let Some(remote) = self.remote() {
-			log::debug!("process_auth_message(): sending connect message: {remote:?}");
 			self.enable_flow_controller(
 				self.local().node().overlay_version,
 				remote.node().overlay_version,
 			);
-		} else {
-			log::warn!("process_auth_message(): No remote overlay version after handshake.");
 		}
 
 		self.check_to_send_more(MessageType::Auth)

--- a/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
@@ -24,7 +24,7 @@ impl Connector {
 		match msg_type {
 			MessageType::Transaction | MessageType::FloodAdvert if !self.receive_tx_messages() => {
 				self.increment_remote_sequence()?;
-				self.check_to_send_more(MessageType::Transaction).await?;
+				self.check_to_send_more(MessageType::Transaction)?;
 			},
 
 			MessageType::ScpMessage if !self.receive_scp_messages() => {
@@ -76,15 +76,15 @@ impl Connector {
 				self.got_hello();
 
 				if self.remote_called_us() {
-					self.send_hello_message().await?;
+					self.send_hello_message()?;
 				} else {
-					self.send_auth_message().await?;
+					self.send_auth_message()?;
 				}
 				log::info!("process_stellar_message(): Hello message processed successfully");
 			},
 
 			StellarMessage::Auth(_) => {
-				self.process_auth_message().await?;
+				self.process_auth_message()?;
 			},
 
 			StellarMessage::ErrorMsg(e) => {
@@ -101,7 +101,7 @@ impl Connector {
 				log::trace!(
 					"process_stellar_message():  Processing {other:?} message: received from overlay"
 				);
-				self.check_to_send_more(msg_type).await?;
+				self.check_to_send_more(msg_type)?;
 				return Ok(Some(other))
 			},
 		}
@@ -109,9 +109,9 @@ impl Connector {
 		Ok(None)
 	}
 
-	async fn process_auth_message(&mut self) -> Result<(), Error> {
+	fn process_auth_message(&mut self) -> Result<(), Error> {
 		if self.remote_called_us() {
-			self.send_auth_message().await?;
+			self.send_auth_message()?;
 		}
 
 		self.handshake_completed();
@@ -126,7 +126,7 @@ impl Connector {
 			log::warn!("process_auth_message(): No remote overlay version after handshake.");
 		}
 
-		self.check_to_send_more(MessageType::Auth).await
+		self.check_to_send_more(MessageType::Auth)
 	}
 
 	/// Updates the config based on the hello message that was received from the Stellar Node

--- a/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_handler.rs
@@ -103,7 +103,6 @@ impl Connector {
 					String::from_utf8(other.to_base64_xdr())
 						.unwrap_or(format!("{:?}", other.to_base64_xdr()))
 				);
-
 				self.check_to_send_more(msg_type).await?;
 				return Ok(Some(other))
 			},
@@ -124,6 +123,8 @@ impl Connector {
 				self.local().node().overlay_version,
 				remote.node().overlay_version,
 			);
+		} else {
+			log::warn!("process_auth_message(): No remote overlay version after handshake.");
 		}
 
 		self.check_to_send_more(MessageType::Auth).await

--- a/clients/stellar-relay-lib/src/connection/connector/message_reader.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_reader.rs
@@ -6,7 +6,6 @@ use std::{
 };
 use substrate_stellar_sdk::{types::StellarMessage, XdrCodec};
 
-use std::{thread, time::Duration};
 use tokio::sync::{mpsc, mpsc::error::TryRecvError};
 
 /// Polls for messages coming from the Stellar Node and communicates it back to the user
@@ -160,7 +159,7 @@ async fn read_message_from_stellar(stream_clone: Arc<Mutex<TcpStream>>) -> Resul
 					},
 				}
 			},
-			
+
 			Err(e) => {
 				log::trace!("read_message_from_stellar(): ERROR reading messages: {e:?}");
 				return Err(Error::ReadFailed(e.to_string()))
@@ -210,7 +209,7 @@ fn read_message(
 /// * `lack_bytes_from_prev` - the number of bytes remaining, to complete the previous message
 /// * `readbuf` - the buffer that holds the bytes of the previous and incomplete message
 fn read_unfinished_message(
-	mut stream: Arc<Mutex<TcpStream>>,
+	stream: Arc<Mutex<TcpStream>>,
 	lack_bytes_from_prev: &mut usize,
 	readbuf: &mut Vec<u8>,
 ) -> Result<Option<Xdr>, Error> {

--- a/clients/stellar-relay-lib/src/connection/connector/message_reader.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_reader.rs
@@ -1,11 +1,6 @@
 use crate::connection::{xdr_converter::get_xdr_message_length, Connector, Error, Xdr};
-use std::{
-	io::Read,
-	net::{Shutdown, TcpStream},
-	sync::{Arc, Mutex},
-};
+use async_std::io::ReadExt;
 use substrate_stellar_sdk::{types::StellarMessage, XdrCodec};
-
 use tokio::sync::{mpsc, mpsc::error::TryRecvError};
 
 /// Polls for messages coming from the Stellar Node and communicates it back to the user
@@ -21,7 +16,7 @@ pub(crate) async fn poll_messages_from_stellar(
 	mut send_to_node_receiver: mpsc::Receiver<StellarMessage>,
 ) {
 	log::info!("poll_messages_from_stellar(): started.");
-	// clone the stream to perform a read operation on the next function calls
+
 	loop {
 		if send_to_user_sender.is_closed() {
 			log::info!("poll_messages_from_stellar(): closing receiver during disconnection");
@@ -35,20 +30,12 @@ pub(crate) async fn poll_messages_from_stellar(
 				if let Err(e) = connector.send_to_node(msg).await {
 					log::error!("poll_messages_from_stellar(): Error occurred during sending message to node: {e:?}");
 				},
-			Err(TryRecvError::Disconnected) => {
-				log::trace!("poll_messages_from_stellar(): Recv channel (for sending message to node) got disconnected.");
-				break
-			},
+			Err(TryRecvError::Disconnected) => break,
 			Err(TryRecvError::Empty) => {},
 		}
 
 		// check for messages from Stellar Node.
-		let stream_clone = connector.tcp_stream.clone();
-		// Spawn a blocking task to read from the stream
-		let xdr_result = read_message_from_stellar(stream_clone).await;
-
-		// Check the result of the blocking task
-		let xdr = match xdr_result {
+		let xdr = match read_message_from_stellar(&mut connector).await {
 			Err(e) => {
 				log::error!("poll_messages_from_stellar(): {e:?}");
 				break
@@ -72,18 +59,17 @@ pub(crate) async fn poll_messages_from_stellar(
 			},
 		}
 	}
-	// make sure to shutdown the stream
-	if let Err(e) = connector.tcp_stream.clone().lock().unwrap().shutdown(Shutdown::Both) {
-		log::error!("poll_messages_from_stellar(): Failed to shutdown the tcp stream: {e:?}");
-	};
+
+	// make sure to shutdown the connector
+	connector.stop();
 	send_to_node_receiver.close();
 	drop(send_to_user_sender);
 
-	log::info!("poll_messages_from_stellar(): stopped.");
+	log::debug!("poll_messages_from_stellar(): stopped.");
 }
 
 /// Returns Xdr format of the `StellarMessage` sent from the Stellar Node
-async fn read_message_from_stellar(stream_clone: Arc<Mutex<TcpStream>>) -> Result<Xdr, Error> {
+async fn read_message_from_stellar(connector: &mut Connector) -> Result<Xdr, Error> {
 	// holds the number of bytes that were missing from the previous stellar message.
 	let mut lack_bytes_from_prev = 0;
 	let mut readbuf: Vec<u8> = vec![];
@@ -93,18 +79,8 @@ async fn read_message_from_stellar(stream_clone: Arc<Mutex<TcpStream>>) -> Resul
 		// check whether or not we should read the bytes as:
 		// 1. the length of the next stellar message
 		// 2. the remaining bytes of the previous stellar message
-		// Temporary scope for locking
-		let result = {
-			let mut stream = stream_clone.lock().unwrap();
-			stream.read(&mut buff_for_reading)
-		};
-
-		match result {
-			Ok(size) if size == 0 => {
-				// No data available to read
-				tokio::task::yield_now().await;
-				continue
-			},
+		match connector.tcp_stream.read(&mut buff_for_reading).await {
+			Ok(size) if size == 0 => continue,
 			Ok(_) if lack_bytes_from_prev == 0 => {
 				// if there are no more bytes lacking from the previous message,
 				// then check the size of next stellar message.
@@ -113,23 +89,22 @@ async fn read_message_from_stellar(stream_clone: Arc<Mutex<TcpStream>>) -> Resul
 				// If it's not enough, skip it.
 				if expect_msg_len == 0 {
 					// there's nothing to read; wait for the next iteration
-					log::trace!(
-						"read_message_from_stellar(): Nothing left to read; waiting for next loop"
-					);
-					tokio::task::yield_now().await;
+					log::trace!("read_message_from_stellar(): expect_msg_len == 0");
 					continue
 				}
+
+				// let's start reading the actual stellar message.
 				readbuf = vec![0; expect_msg_len];
+
 				match read_message(
-					stream_clone.clone(),
+					connector,
 					&mut lack_bytes_from_prev,
 					&mut readbuf,
 					expect_msg_len,
-				) {
-					Ok(None) => {
-						tokio::task::yield_now().await;
-						continue
-					},
+				)
+				.await
+				{
+					Ok(None) => continue,
 					Ok(Some(xdr)) => return Ok(xdr),
 					Err(e) => {
 						log::trace!("read_message_from_stellar(): ERROR: {e:?}");
@@ -141,17 +116,14 @@ async fn read_message_from_stellar(stream_clone: Arc<Mutex<TcpStream>>) -> Resul
 				// The next few bytes was read. Add it to the readbuf.
 				lack_bytes_from_prev -= size;
 				readbuf.append(&mut buff_for_reading);
+				// make sure to cleanup the buffer
+				buff_for_reading = vec![0; 4];
 
 				// let's read the continuation number of bytes from the previous message.
-				match read_unfinished_message(
-					stream_clone.clone(),
-					&mut lack_bytes_from_prev,
-					&mut readbuf,
-				) {
-					Ok(None) => {
-						tokio::task::yield_now().await;
-						continue
-					},
+				match read_unfinished_message(connector, &mut lack_bytes_from_prev, &mut readbuf)
+					.await
+				{
+					Ok(None) => continue,
 					Ok(Some(xdr)) => return Ok(xdr),
 					Err(e) => {
 						log::trace!("read_message_from_stellar(): ERROR: {e:?}");
@@ -172,18 +144,22 @@ async fn read_message_from_stellar(stream_clone: Arc<Mutex<TcpStream>>) -> Resul
 /// This reads a number of bytes based on the expected message length.
 ///
 /// # Arguments
-/// * `stream` - the TcpStream for reading the xdr stellar message
+/// * `connector` - a ref struct that contains the config and necessary info for connecting to
+///   Stellar Node
 /// * `lack_bytes_from_prev` - the number of bytes remaining, to complete the previous message
 /// * `readbuf` - the buffer that holds the bytes of the previous and incomplete message
 /// * `xpect_msg_len` - the expected # of bytes of the Stellar message
-fn read_message(
-	stream: Arc<Mutex<TcpStream>>,
+async fn read_message(
+	connector: &mut Connector,
 	lack_bytes_from_prev: &mut usize,
 	readbuf: &mut Vec<u8>,
 	xpect_msg_len: usize,
 ) -> Result<Option<Xdr>, Error> {
-	let mut stream = stream.lock().unwrap();
-	let actual_msg_len = stream.read(readbuf).map_err(|e| Error::ReadFailed(e.to_string()))?;
+	let actual_msg_len = connector
+		.tcp_stream
+		.read(readbuf)
+		.await
+		.map_err(|e| Error::ReadFailed(e.to_string()))?;
 
 	// only when the message has the exact expected size bytes, should we send to user.
 	if actual_msg_len == xpect_msg_len {
@@ -205,21 +181,22 @@ fn read_message(
 /// Reads a continuation of bytes that belong to the previous message
 ///
 /// # Arguments
-/// * `stream` - the TcpStream for reading the xdr stellar message
+/// * `connector` - a ref struct that contains the config and necessary info for connecting to
+///   Stellar Node
 /// * `lack_bytes_from_prev` - the number of bytes remaining, to complete the previous message
 /// * `readbuf` - the buffer that holds the bytes of the previous and incomplete message
-fn read_unfinished_message(
-	stream: Arc<Mutex<TcpStream>>,
+async fn read_unfinished_message(
+	connector: &mut Connector,
 	lack_bytes_from_prev: &mut usize,
 	readbuf: &mut Vec<u8>,
 ) -> Result<Option<Xdr>, Error> {
 	// let's read the continuation number of bytes from the previous message.
 	let mut cont_buf = vec![0; *lack_bytes_from_prev];
 
-	let actual_msg_len = stream
-		.lock()
-		.unwrap()
+	let actual_msg_len = connector
+		.tcp_stream
 		.read(&mut cont_buf)
+		.await
 		.map_err(|e| Error::ReadFailed(e.to_string()))?;
 
 	// this partial message completes the previous message.

--- a/clients/stellar-relay-lib/src/connection/connector/message_sender.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_sender.rs
@@ -1,7 +1,5 @@
-use std::time::Duration;
+use std::io::Write;
 use substrate_stellar_sdk::types::{MessageType, SendMore, StellarMessage};
-use tokio::{io::AsyncWriteExt, time::timeout};
-use tokio::io::Interest;
 
 use crate::connection::{
 	flow_controller::MAX_FLOOD_MSG_CAP,
@@ -11,68 +9,35 @@ use crate::connection::{
 };
 
 impl Connector {
-	pub async fn send_to_node(&mut self, msg: StellarMessage) -> Result<(), Error> {
+	pub fn send_to_node(&mut self, msg: StellarMessage) -> Result<(), Error> {
 		let xdr_msg = &self.create_xdr_message(msg)?;
 
-		match timeout(
-			Duration::from_secs(self.timeout_in_secs),
-			self.write_stream_overlay.write_all(&xdr_msg),
-		)
-		.await
-		{
-			Ok(res) => {
-				let result = res.map_err(|e| {
-					log::error!("send_to_node(): Failed to send message to node: {e:?}");
-					Error::WriteFailed(e.to_string())
-				});
-
-				let ready_status = self.write_stream_overlay.ready(Interest::WRITABLE | Interest::READABLE)
-					.await.map_err(|e| {
-						log::error!("send_to_node(): Stream not ready for reading or writing: {e:?}");
-						Error::ConnectionFailed(e.to_string())
-				})?;
-
-				if ready_status.is_readable() {
-					log::trace!("send_to_node(): stream is readable");
-				}
-
-				if ready_status.is_writable() {
-					log::trace!("send_to_node(): stream is writable");
-				}
-
-				if ready_status.is_empty() {
-					log::trace!("send_to_node(): stream is empty");
-				}
-
-				result
-			},
-			Err(_) => Err(Error::Timeout),
-		}
+		self.tcp_stream.write_all(&xdr_msg).map_err(|e| {
+			log::error!("send_to_node(): Failed to send message to node: {e:?}");
+			Error::WriteFailed(e.to_string())
+		})
 	}
 
-	pub async fn send_hello_message(&mut self) -> Result<(), Error> {
+	pub fn send_hello_message(&mut self) -> Result<(), Error> {
 		let msg = self.create_hello_message(time_now())?;
 		log::info!("send_hello_message(): Sending Hello Message: {}", to_base64_xdr_string(&msg));
 
-		self.send_to_node(msg).await
+		self.send_to_node(msg)
 	}
 
-	pub(super) async fn send_auth_message(&mut self) -> Result<(), Error> {
+	pub(super) fn send_auth_message(&mut self) -> Result<(), Error> {
 		let msg = create_auth_message();
 		log::info!("send_auth_message(): Sending Auth Message: {}", to_base64_xdr_string(&msg));
 
-		self.send_to_node(create_auth_message()).await
+		self.send_to_node(create_auth_message())
 	}
 
-	pub(super) async fn check_to_send_more(
-		&mut self,
-		message_type: MessageType,
-	) -> Result<(), Error> {
+	pub(super) fn check_to_send_more(&mut self, message_type: MessageType) -> Result<(), Error> {
 		if !self.inner_check_to_send_more(message_type) {
 			return Ok(())
 		}
 
 		let msg = StellarMessage::SendMore(SendMore { num_messages: MAX_FLOOD_MSG_CAP });
-		self.send_to_node(msg).await
+		self.send_to_node(msg)
 	}
 }

--- a/clients/stellar-relay-lib/src/connection/connector/message_sender.rs
+++ b/clients/stellar-relay-lib/src/connection/connector/message_sender.rs
@@ -9,35 +9,55 @@ use crate::connection::{
 };
 
 impl Connector {
-	pub fn send_to_node(&mut self, msg: StellarMessage) -> Result<(), Error> {
-		let xdr_msg = &self.create_xdr_message(msg)?;
+	pub async fn send_to_node(&mut self, msg: StellarMessage) -> Result<(), Error> {
+		// Create the XDR message outside the closure
+		let xdr_msg = self.create_xdr_message(msg)?;
 
-		self.tcp_stream.write_all(&xdr_msg).map_err(|e| {
-			log::error!("send_to_node(): Failed to send message to node: {e:?}");
-			Error::WriteFailed(e.to_string())
-		})
+		// Clone the TcpStream (or its Arc<Mutex<_>> wrapper)
+		let stream_clone = self.tcp_stream.clone();
+
+		// this may really not be necessary
+		let write_result = tokio::task::spawn_blocking(move || {
+			let mut stream = stream_clone.lock().unwrap();
+			stream.write_all(&xdr_msg).map_err(|e| {
+				log::error!("send_to_node(): Failed to send message to node: {e:?}");
+				Error::WriteFailed(e.to_string())
+			})
+		});
+
+		// Await the result of the blocking task
+		match write_result.await {
+			Ok(result) => result,
+			Err(e) => {
+				log::error!("send_to_node(): Error occurred in blocking task: {e:?}");
+				Err(Error::WriteFailed(e.to_string()))
+			},
+		}
 	}
 
-	pub fn send_hello_message(&mut self) -> Result<(), Error> {
+	pub async fn send_hello_message(&mut self) -> Result<(), Error> {
 		let msg = self.create_hello_message(time_now())?;
 		log::info!("send_hello_message(): Sending Hello Message: {}", to_base64_xdr_string(&msg));
 
-		self.send_to_node(msg)
+		self.send_to_node(msg).await
 	}
 
-	pub(super) fn send_auth_message(&mut self) -> Result<(), Error> {
+	pub(super) async fn send_auth_message(&mut self) -> Result<(), Error> {
 		let msg = create_auth_message();
 		log::info!("send_auth_message(): Sending Auth Message: {}", to_base64_xdr_string(&msg));
 
-		self.send_to_node(create_auth_message())
+		self.send_to_node(create_auth_message()).await
 	}
 
-	pub(super) fn check_to_send_more(&mut self, message_type: MessageType) -> Result<(), Error> {
+	pub(super) async fn check_to_send_more(
+		&mut self,
+		message_type: MessageType,
+	) -> Result<(), Error> {
 		if !self.inner_check_to_send_more(message_type) {
 			return Ok(())
 		}
 
 		let msg = StellarMessage::SendMore(SendMore { num_messages: MAX_FLOOD_MSG_CAP });
-		self.send_to_node(msg)
+		self.send_to_node(msg).await
 	}
 }

--- a/clients/stellar-relay-lib/src/connection/error.rs
+++ b/clients/stellar-relay-lib/src/connection/error.rs
@@ -52,9 +52,6 @@ pub enum Error {
 	XDRConversionError(XDRError),
 
 	#[error(display = "{:?}", _0)]
-	StdIOError(std::io::Error),
-
-	#[error(display = "{:?}", _0)]
 	StellarSdkError(StellarSdkError),
 
 	#[error(display = "Stellar overlay disconnected")]
@@ -71,12 +68,6 @@ pub enum Error {
 
 	#[error(display = "Config Error: Version String too long")]
 	VersionStrTooLong,
-}
-
-impl From<std::io::Error> for Error {
-	fn from(e: std::io::Error) -> Self {
-		Error::StdIOError(e)
-	}
 }
 
 impl From<XDRError> for Error {

--- a/clients/stellar-relay-lib/src/connection/error.rs
+++ b/clients/stellar-relay-lib/src/connection/error.rs
@@ -52,6 +52,9 @@ pub enum Error {
 	XDRConversionError(XDRError),
 
 	#[error(display = "{:?}", _0)]
+	StdIOError(std::io::Error),
+
+	#[error(display = "{:?}", _0)]
 	StellarSdkError(StellarSdkError),
 
 	#[error(display = "Stellar overlay disconnected")]
@@ -68,6 +71,12 @@ pub enum Error {
 
 	#[error(display = "Config Error: Version String too long")]
 	VersionStrTooLong,
+}
+
+impl From<std::io::Error> for Error {
+	fn from(e: std::io::Error) -> Self {
+		Error::StdIOError(e)
+	}
 }
 
 impl From<XDRError> for Error {

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -68,5 +68,9 @@ pub async fn create_stream(
 		log::trace!("create_stream(): stream is empty");
 	}
 
+	if res.is_read_closed() {
+		log::trace!("create_strea(): stream's read half is closed.");
+	}
+
 	Ok(stream.into_split())
 }

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -45,14 +45,7 @@ pub fn to_base64_xdr_string<T: XdrCodec>(msg: &T) -> String {
 
 pub async fn create_stream(
 	address: &str,
-) -> Result<((tcp::OwnedReadHalf, tcp::OwnedWriteHalf), std::net::TcpStream), crate::Error> {
-	 let net_stream = std::net::TcpStream::connect(address)
-		 .map_err(|e| {
-			 log::error!("create_stream(): net stream failed to connect: {e:?}");
-			 crate::Error::ConnectionFailed(e.to_string())
-		 })?;
-
-
+) -> Result<(tcp::OwnedReadHalf, tcp::OwnedWriteHalf), crate::Error> {
 	let stream = TcpStream::connect(address)
 		.await
 		.map_err(|e| crate::Error::ConnectionFailed(e.to_string()))?;
@@ -79,5 +72,5 @@ pub async fn create_stream(
 		log::trace!("create_strea(): stream's read half is closed.");
 	}
 
-	Ok((stream.into_split(), net_stream))
+	Ok(stream.into_split())
 }

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -5,10 +5,6 @@ use substrate_stellar_sdk::{
 	types::{Error, Uint256},
 	SecretKey, XdrCodec,
 };
-use tokio::{
-	io::Interest,
-	net::{tcp, TcpStream},
-};
 
 /// Returns a new BigNumber with a pseudo-random value equal to or greater than 0 and less than 1.
 pub fn generate_random_nonce() -> Uint256 {
@@ -43,35 +39,4 @@ pub fn error_to_string(e: Error) -> String {
 pub fn to_base64_xdr_string<T: XdrCodec>(msg: &T) -> String {
 	let xdr = msg.to_base64_xdr();
 	String::from_utf8(xdr.clone()).unwrap_or(format!("{:?}", xdr))
-}
-
-pub async fn create_stream(
-	address: &str,
-) -> Result<(tcp::OwnedReadHalf, tcp::OwnedWriteHalf), crate::Error> {
-	let stream = TcpStream::connect(address)
-		.await
-		.map_err(|e| crate::Error::ConnectionFailed(e.to_string()))?;
-
-	let res = stream.ready(Interest::READABLE | Interest::WRITABLE).await.map_err(|e| {
-		log::error!("create_stream(): Stream not ready for reading or writing: {e:?}");
-		crate::Error::ConnectionFailed(e.to_string())
-	})?;
-
-	if res.is_readable() {
-		log::trace!("create_stream(): stream is readable");
-	}
-
-	if res.is_writable() {
-		log::trace!("create_stream(): stream is writable");
-	}
-
-	if res.is_empty() {
-		log::trace!("create_stream(): stream is empty");
-	}
-
-	if res.is_read_closed() {
-		log::trace!("create_strea(): stream's read half is closed.");
-	}
-
-	Ok(stream.into_split())
 }

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -45,7 +45,14 @@ pub fn to_base64_xdr_string<T: XdrCodec>(msg: &T) -> String {
 
 pub async fn create_stream(
 	address: &str,
-) -> Result<(tcp::OwnedReadHalf, tcp::OwnedWriteHalf), crate::Error> {
+) -> Result<((tcp::OwnedReadHalf, tcp::OwnedWriteHalf), std::net::TcpStream), crate::Error> {
+	 let net_stream = std::net::TcpStream::connect(address)
+		 .map_err(|e| {
+			 log::error!("create_stream(): net stream failed to connect: {e:?}");
+			 crate::Error::ConnectionFailed(e.to_string())
+		 })?;
+
+
 	let stream = TcpStream::connect(address)
 		.await
 		.map_err(|e| crate::Error::ConnectionFailed(e.to_string()))?;
@@ -72,5 +79,5 @@ pub async fn create_stream(
 		log::trace!("create_strea(): stream's read half is closed.");
 	}
 
-	Ok(stream.into_split())
+	Ok((stream.into_split(), net_stream))
 }

--- a/clients/stellar-relay-lib/src/connection/helper.rs
+++ b/clients/stellar-relay-lib/src/connection/helper.rs
@@ -5,8 +5,10 @@ use substrate_stellar_sdk::{
 	types::{Error, Uint256},
 	SecretKey, XdrCodec,
 };
-use tokio::io::Interest;
-use tokio::net::{tcp, TcpStream};
+use tokio::{
+	io::Interest,
+	net::{tcp, TcpStream},
+};
 
 /// Returns a new BigNumber with a pseudo-random value equal to or greater than 0 and less than 1.
 pub fn generate_random_nonce() -> Uint256 {
@@ -50,11 +52,10 @@ pub async fn create_stream(
 		.await
 		.map_err(|e| crate::Error::ConnectionFailed(e.to_string()))?;
 
-	let res = stream.ready(Interest::READABLE | Interest::WRITABLE).await
-		.map_err(|e| {
-			log::error!("create_stream(): Stream not ready for reading or writing: {e:?}");
-			crate::Error::ConnectionFailed(e.to_string())
-		})?;
+	let res = stream.ready(Interest::READABLE | Interest::WRITABLE).await.map_err(|e| {
+		log::error!("create_stream(): Stream not ready for reading or writing: {e:?}");
+		crate::Error::ConnectionFailed(e.to_string())
+	})?;
 
 	if res.is_readable() {
 		log::trace!("create_stream(): stream is readable");

--- a/clients/stellar-relay-lib/src/overlay.rs
+++ b/clients/stellar-relay-lib/src/overlay.rs
@@ -41,7 +41,7 @@ impl StellarOverlayConnection {
 
 		let (send_to_node_sender, send_to_node_receiver) = mpsc::channel::<StellarMessage>(1024);
 
-		let connector = Connector::start(local_node_info, conn_info)?;
+		let connector = Connector::start(local_node_info, conn_info).await?;
 
 		tokio::spawn(poll_messages_from_stellar(
 			connector,

--- a/clients/stellar-relay-lib/src/overlay.rs
+++ b/clients/stellar-relay-lib/src/overlay.rs
@@ -55,7 +55,7 @@ impl StellarOverlayConnection {
 		})
 	}
 
-	pub async fn listen(&mut self) -> Result<Option<StellarMessage>, Error> {
+	pub fn listen(&mut self) -> Result<Option<StellarMessage>, Error> {
 		loop {
 			if !self.is_alive() {
 				self.disconnect();

--- a/clients/stellar-relay-lib/src/overlay.rs
+++ b/clients/stellar-relay-lib/src/overlay.rs
@@ -58,7 +58,6 @@ impl StellarOverlayConnection {
 	pub fn listen(&mut self) -> Result<Option<StellarMessage>, Error> {
 		loop {
 			if !self.is_alive() {
-				self.disconnect();
 				return Err(Error::Disconnected)
 			}
 
@@ -82,20 +81,20 @@ impl StellarOverlayConnection {
 		let is_closed = self.sender.is_closed();
 
 		if is_closed {
-			self.disconnect();
+			self.stop();
 		}
 
 		!is_closed
 	}
 
-	pub fn disconnect(&mut self) {
-		log::info!("disconnect(): closing connection to overlay network");
+	pub fn stop(&mut self) {
+		log::info!("stop(): closing connection to overlay network");
 		self.receiver.close();
 	}
 }
 
 impl Drop for StellarOverlayConnection {
 	fn drop(&mut self) {
-		self.disconnect();
+		self.stop();
 	}
 }

--- a/clients/stellar-relay-lib/src/tests/mod.rs
+++ b/clients/stellar-relay-lib/src/tests/mod.rs
@@ -138,7 +138,6 @@ async fn stellar_overlay_should_receive_tx_set() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn stellar_overlay_disconnect_works() {
-	env_logger::init();
 	let (node_info, conn_info) = overlay_infos(false);
 
 	let mut overlay_connection =

--- a/clients/stellar-relay-lib/src/tests/mod.rs
+++ b/clients/stellar-relay-lib/src/tests/mod.rs
@@ -56,7 +56,7 @@ async fn stellar_overlay_should_receive_scp_messages() {
 
 	timeout(Duration::from_secs(300), async move {
 		let mut ov_conn_locked = ov_conn.lock().await;
-		if let Ok(Some(msg)) = ov_conn_locked.listen().await {
+		if let Ok(Some(msg)) = ov_conn_locked.listen() {
 			scps_vec_clone.lock().await.push(msg);
 
 			ov_conn_locked.disconnect();
@@ -93,7 +93,7 @@ async fn stellar_overlay_should_receive_tx_set() {
 	timeout(Duration::from_secs(500), async move {
 		let mut ov_conn_locked = ov_conn.lock().await;
 
-		while let Ok(Some(msg)) = ov_conn_locked.listen().await {
+		while let Ok(Some(msg)) = ov_conn_locked.listen() {
 			match msg {
 				StellarMessage::ScpMessage(msg) =>
 					if let ScpStatementPledges::ScpStExternalize(stmt) = &msg.statement.pledges {

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -20,6 +20,7 @@ parachain-metadata-foucoco = ["runtime/parachain-metadata-foucoco"]
 integration-test = ["runtime/standalone-metadata", "integration"]
 
 [dependencies]
+async-std = "1.12.0"
 async-trait = "0.1.40"
 base64 = { version = '0.13.0', default-features = false, features = ['alloc'] }
 bincode = "1.3.3"

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest1.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest1.json
@@ -7,7 +7,7 @@
     "ledger_version": 20,
     "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
+    "version_str": "stellar-core 20.2.0.rc1 (3076c138d77735c6ce8230886a540f4d54d85c59)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest2.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest2.json
@@ -7,7 +7,7 @@
     "ledger_version": 20,
     "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
+    "version_str": "stellar-core 20.2.0.rc1 (3076c138d77735c6ce8230886a540f4d54d85c59)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest3.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest3.json
@@ -7,7 +7,7 @@
     "ledger_version": 20,
     "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
+    "version_str": "stellar-core 20.2.0.rc1 (3076c138d77735c6ce8230886a540f4d54d85c59)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -91,7 +91,6 @@ pub async fn start_oracle_agent(
 				// if a disconnect signal was sent, disconnect from Stellar.
 				Ok(_) | Err(TryRecvError::Disconnected) => {
 					tracing::info!("start_oracle_agent(): disconnect overlay...");
-					overlay_conn.disconnect();
 					break
 				},
 				Err(TryRecvError::Empty) => {},
@@ -112,7 +111,6 @@ pub async fn start_oracle_agent(
 				Ok(None) => {},
 				// connection got lost
 				Err(e) => {
-					overlay_conn.disconnect();
 					tracing::error!("start_oracle_agent(): encounter error in overlay: {e:?}");
 
 					if let Err(e) = shutdown_sender_clone2.send(()) {
@@ -124,10 +122,13 @@ pub async fn start_oracle_agent(
 				},
 			}
 		}
+
+		// shutdown the overlay connection
+		overlay_conn.stop();
 	});
 
 	tokio::spawn(on_shutdown(shutdown_sender.clone(), async move {
-		tracing::info!("start_oracle_agent(): sending signal to shutdown overlay connection...");
+		tracing::debug!("start_oracle_agent(): sending signal to shutdown overlay connection...");
 		if let Err(e) = disconnect_signal_sender.send(()).await {
 			tracing::warn!("start_oracle_agent(): failed to send disconnect signal: {e:?}");
 		}
@@ -139,6 +140,12 @@ pub async fn start_oracle_agent(
 		message_sender: Some(sender),
 		shutdown_sender,
 	})
+}
+
+impl Drop for OracleAgent {
+	fn drop(&mut self) {
+		self.stop();
+	}
 }
 
 impl OracleAgent {
@@ -192,19 +199,18 @@ impl OracleAgent {
 	}
 
 	/// Stops listening for new SCP messages.
-	pub fn stop(&self) -> Result<(), Error> {
-		tracing::info!("stop(): Shutting down OracleAgent...");
+	pub fn stop(&self) {
+		tracing::debug!("stop(): Shutting down OracleAgent...");
 		if let Err(e) = self.shutdown_sender.send(()) {
 			tracing::error!("stop(): Failed to send shutdown signal in OracleAgent: {:?}", e);
 		}
-		Ok(())
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use crate::oracle::{
-		get_random_secret_key, get_test_secret_key, get_test_stellar_relay_config,
+		get_random_secret_key, get_test_secret_key, specific_stellar_relay_config,
 		traits::ArchiveStorage, ScpArchiveStorage, TransactionsArchiveStorage,
 	};
 
@@ -215,11 +221,15 @@ mod tests {
 	#[ntest::timeout(1_800_000)] // timeout at 30 minutes
 	#[serial]
 	async fn test_get_proof_for_current_slot() {
+		// let it run for a few seconds, making sure that the other tests have successfully shutdown
+		// their connection to Stellar Node
+		sleep(Duration::from_secs(2)).await;
+
 		let shutdown_sender = ShutdownSender::new();
 
 		// We use a random secret key to avoid conflicts with other tests.
 		let agent = start_oracle_agent(
-			get_test_stellar_relay_config(true),
+			specific_stellar_relay_config(true, 0),
 			&get_random_secret_key(),
 			shutdown_sender,
 		)
@@ -244,12 +254,16 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	#[serial]
 	async fn test_get_proof_for_archived_slot() {
+		// let it run for a few seconds, making sure that the other tests have successfully shutdown
+		// their connection to Stellar Node
+		sleep(Duration::from_secs(2)).await;
+
 		let scp_archive_storage = ScpArchiveStorage::default();
 		let tx_archive_storage = TransactionsArchiveStorage::default();
 
 		let shutdown_sender = ShutdownSender::new();
 		let agent = start_oracle_agent(
-			get_test_stellar_relay_config(true),
+			specific_stellar_relay_config(true, 1),
 			&get_test_secret_key(true),
 			shutdown_sender,
 		)
@@ -266,17 +280,19 @@ mod tests {
 		// These might return an error if the file does not exist, but that's fine.
 		let _ = scp_archive_storage.remove_file(target_slot);
 		let _ = tx_archive_storage.remove_file(target_slot);
-
-		agent.stop().expect("Failed to stop the agent");
 	}
 
 	#[tokio::test(flavor = "multi_thread")]
 	#[serial]
 	async fn test_get_proof_for_archived_slot_with_fallback() {
+		// let it run for a few seconds, making sure that the other tests have successfully shutdown
+		// their connection to Stellar Node
+		sleep(Duration::from_secs(2)).await;
+
 		let scp_archive_storage = ScpArchiveStorage::default();
 		let tx_archive_storage = TransactionsArchiveStorage::default();
 
-		let base_config = get_test_stellar_relay_config(true);
+		let base_config = specific_stellar_relay_config(true, 2);
 		// We add two fake archive urls to the config to make sure that the agent will actually fall
 		// back to other archives.
 		let mut archive_urls = base_config.stellar_history_archive_urls().clone();
@@ -302,18 +318,15 @@ mod tests {
 		// These might return an error if the file does not exist, but that's fine.
 		let _ = scp_archive_storage.remove_file(target_slot);
 		let _ = tx_archive_storage.remove_file(target_slot);
-
-		agent.stop().expect("Failed to stop the agent");
 	}
 
 	#[tokio::test(flavor = "multi_thread")]
 	#[serial]
 	async fn test_get_proof_for_archived_slot_fails_without_archives() {
-		env_logger::init();
 		let scp_archive_storage = ScpArchiveStorage::default();
 		let tx_archive_storage = TransactionsArchiveStorage::default();
 
-		let base_config = get_test_stellar_relay_config(true);
+		let base_config = specific_stellar_relay_config(true, 0);
 		let modified_config: StellarOverlayConfig =
 			StellarOverlayConfig { stellar_history_archive_urls: vec![], ..base_config };
 
@@ -324,6 +337,8 @@ mod tests {
 
 		// This slot should be archived on the public network
 		let target_slot = 44041116;
+		tracing::info!("let's sleep for 3 seconds,to get the network up and running");
+		sleep(Duration::from_secs(3)).await;
 		let proof_result = agent.get_proof(target_slot).await;
 
 		assert!(matches!(proof_result, Err(Error::ProofTimeout(_))));
@@ -331,8 +346,5 @@ mod tests {
 		// These might return an error if the file does not exist, but that's fine.
 		let _ = scp_archive_storage.remove_file(target_slot);
 		let _ = tx_archive_storage.remove_file(target_slot);
-
-		println!("HOY PLEAAASE");
-		agent.stop().expect("Failed to stop the agent");
 	}
 }

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -153,7 +153,7 @@ impl OracleAgent {
 		let collector = self.collector.clone();
 
 		#[cfg(test)]
-		let timeout_seconds = 180;
+		let timeout_seconds = 60;
 
 		#[cfg(not(test))]
 		let timeout_seconds = 60;

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -153,7 +153,7 @@ impl OracleAgent {
 		let collector = self.collector.clone();
 
 		#[cfg(test)]
-		let timeout_seconds = 60;
+		let timeout_seconds = 180;
 
 		#[cfg(not(test))]
 		let timeout_seconds = 60;

--- a/clients/vault/src/oracle/collector/collector.rs
+++ b/clients/vault/src/oracle/collector/collector.rs
@@ -234,7 +234,7 @@ mod test {
 
 	use crate::oracle::{
 		collector::{collector::AddTxSet, ScpMessageCollector},
-		get_test_stellar_relay_config,
+		random_stellar_relay_config,
 		traits::FileHandler,
 		EnvelopesFileHandler,
 	};
@@ -273,7 +273,7 @@ mod test {
 	}
 
 	fn stellar_history_archive_urls() -> Vec<String> {
-		get_test_stellar_relay_config(true).stellar_history_archive_urls()
+		random_stellar_relay_config(true).stellar_history_archive_urls()
 	}
 
 	#[test]

--- a/clients/vault/src/oracle/storage/impls.rs
+++ b/clients/vault/src/oracle/storage/impls.rs
@@ -160,8 +160,8 @@ mod test {
 	use crate::oracle::{
 		constants::MAX_SLOTS_PER_FILE,
 		errors::Error,
-		get_test_stellar_relay_config,
 		impls::ArchiveStorage,
+		random_stellar_relay_config,
 		storage::{
 			traits::{FileHandler, FileHandlerExt},
 			EnvelopesFileHandler,
@@ -174,7 +174,7 @@ mod test {
 
 	impl Default for ScpArchiveStorage {
 		fn default() -> Self {
-			let cfg = get_test_stellar_relay_config(true);
+			let cfg = random_stellar_relay_config(true);
 			let archive_urls = cfg.stellar_history_archive_urls();
 			let archive_url = archive_urls.first().expect("should have an archive url");
 			ScpArchiveStorage(archive_url.clone())
@@ -183,7 +183,7 @@ mod test {
 
 	impl Default for TransactionsArchiveStorage {
 		fn default() -> Self {
-			let cfg = get_test_stellar_relay_config(true);
+			let cfg = random_stellar_relay_config(true);
 			let archive_urls = cfg.stellar_history_archive_urls();
 			let archive_url = archive_urls.first().expect("should have an archive url");
 			TransactionsArchiveStorage(archive_url.clone())

--- a/clients/vault/src/oracle/testing_utils.rs
+++ b/clients/vault/src/oracle/testing_utils.rs
@@ -1,19 +1,43 @@
 use stellar_relay_lib::sdk::SecretKey;
 
-pub fn get_test_stellar_relay_config(is_mainnet: bool) -> stellar_relay_lib::StellarOverlayConfig {
+pub fn random_stellar_relay_config(is_mainnet: bool) -> stellar_relay_lib::StellarOverlayConfig {
 	use rand::seq::SliceRandom;
 
-	let stellar_node_points: Vec<&str> = if is_mainnet {
+	let (stellar_node_points, dir) = stellar_relay_config_choices(is_mainnet);
+
+	let node_point = stellar_node_points
+		.choose(&mut rand::thread_rng())
+		.expect("should return a value");
+
+	stellar_relay_config_abs_path(dir, node_point)
+}
+
+pub fn specific_stellar_relay_config(
+	is_mainnet: bool,
+	index: usize,
+) -> stellar_relay_lib::StellarOverlayConfig {
+	let (stellar_node_points, dir) = stellar_relay_config_choices(is_mainnet);
+
+	let node_point = stellar_node_points.get(index).expect("should return a value");
+
+	stellar_relay_config_abs_path(dir, node_point)
+}
+
+fn stellar_relay_config_choices(is_mainnet: bool) -> (Vec<&'static str>, &'static str) {
+	let node_points = if is_mainnet {
 		vec!["frankfurt", "iowa", "singapore"]
 	} else {
 		vec!["sdftest1", "sdftest2", "sdftest3"]
 	};
-	let dir = if is_mainnet { "mainnet" } else { "testnet" };
 
-	let res = stellar_node_points
-		.choose(&mut rand::thread_rng())
-		.expect("should return a value");
-	let path_string = format!("./resources/config/{dir}/stellar_relay_config_{res}.json");
+	let dir = if is_mainnet { "mainnet" } else { "testnet" };
+	(node_points, dir)
+}
+fn stellar_relay_config_abs_path(
+	dir: &str,
+	node_point: &str,
+) -> stellar_relay_lib::StellarOverlayConfig {
+	let path_string = format!("./resources/config/{dir}/stellar_relay_config_{node_point}.json");
 
 	stellar_relay_lib::StellarOverlayConfig::try_from_path(path_string.as_str())
 		.expect("should be able to extract config")

--- a/clients/vault/tests/helper/mod.rs
+++ b/clients/vault/tests/helper/mod.rs
@@ -20,7 +20,7 @@ use std::{future::Future, sync::Arc};
 use stellar_relay_lib::StellarOverlayConfig;
 use tokio::sync::RwLock;
 use vault::{
-	oracle::{get_test_secret_key, get_test_stellar_relay_config, start_oracle_agent, OracleAgent},
+	oracle::{get_test_secret_key, random_stellar_relay_config, start_oracle_agent, OracleAgent},
 	ArcRwLock,
 };
 use wallet::StellarWallet;
@@ -28,7 +28,7 @@ use wallet::StellarWallet;
 pub type StellarPublicKey = [u8; 32];
 
 lazy_static! {
-	pub static ref CFG: StellarOverlayConfig = get_test_stellar_relay_config(false);
+	pub static ref CFG: StellarOverlayConfig = random_stellar_relay_config(false);
 	pub static ref SECRET_KEY: String = get_test_secret_key(false);
 	// TODO clean this up by extending the `get_test_secret_key()` function
 	pub static ref DESTINATION_SECRET_KEY: String = "SDNQJEIRSA6YF5JNS6LQLCBF2XVWZ2NJV3YLC322RGIBJIJRIRGWKLEF".to_string();


### PR DESCRIPTION
Somehow in **_K8s_**, Tokio's [TcpStream](https://github.com/tokio-rs/tokio/blob/1b1b9dc7e388d0619fe7bfe6a7618fff596fdee1/tokio/src/net/tcp/stream.rs#L69-L72) is stuck at "write ready" and is never "read ready". 
Even after connecting using Rust's [Tcpstream](https://doc.rust-lang.org/src/std/net/tcp.rs.html#156-158) and then converting it to [Tokio's](https://github.com/tokio-rs/tokio/blob/1b1b9dc7e388d0619fe7bfe6a7618fff596fdee1/tokio/src/net/tcp/stream.rs#L202-L206), the stream _never_ changes to "read ready".

That's when I decided to use ~Rust's [Tcpstream](https://doc.rust-lang.org/std/net/struct.TcpStream.html) completely.~ [`async-std` library](https://github.com/async-rs/async-std).

In terms of code changes, these are the difference you will see:
| Tokio | Async-Std | ~Rust Std~ | 
| --- | --- | --- |
| Can [split the stream to read/write halves](https://github.com/tokio-rs/tokio/blob/1b1b9dc7e388d0619fe7bfe6a7618fff596fdee1/tokio/src/net/tcp/stream.rs#L1271-L1273), with the write half owned by a struct (`Connector`)| provided an [example](https://book.async.rs/patterns/small-patterns.html?highlight=split#splitting-streams) but `Connector` now owns the `TcpStream`, so I found no need to split | ~Can only [try to clone](https://doc.rust-lang.org/src/std/net/tcp.rs.html#254-256)~ |
| Everything is async | Async | ~Doesn't need async~ |
| Need to add timeout logic | potentially will need it | ~Can [set it in the stream](https://doc.rust-lang.org/src/std/net/tcp.rs.html#298-300)~ |

This also implies removing some tokio features that were added primarily for TCP reasons: `net` and `io-util`.

----  
## How to begin the review:   
1. clients/stellar-relay-lib/src/connection/connector/connector.rs 
     *  As mentioned above, the whole `TcpStream` is owned by the Connector:
        ```rust
             pub struct Connector {
                 ...
                 - write_stream_overlay: OwnedWriteHalf,
                 + tcp_stream: TcpStream,
             }
        ```
     * renamed `fn new(...)` to `fn start(...)` where it also **_starts connecting to Stellar Node_**
2. clients/stellar-relay-lib/src/overlay.rs
     * `StellarOverlayConnection`'s `fn connect(...)` will directly use `Connector`'s `fn start(...) . No more `fn create_stream(...)` calls.
     * renamed `fn disconnect()` to `fn stop()` to make it similar to other structs (`Agent`, `Connector`).
3. clients/stellar-relay-lib/src/connection/helper.rs
     * removal of `fn create_stream(...)`
4. clients/stellar-relay-lib/src/connection/connector/message_reader.rs
     * all `r_stream: &mut tcp::OwnedReadHalf` is replaced with `mut stream: TcpStream`, removing `async` in these methods.
     * in `fn read_message_from_stellar(...)`:
          * instead of "peeking" first, I changed it to actually **"reading"** the 1st 4 bytes, to avoid double operations. On the previous logic, it usually 1. peeks first, 2. and then read. Doing only 1 operation saves time.
          * ~to pass the stream around, it has to be cloned; hence the call to`try_clone()`~ 
          * a reference of the `Connector` is being passed around. This eliminates cloning.
5. clients/vault/src/oracle/testing_utils.rs
    * created a helper function: `fn specific_stellar_relay_config(...)` to specifically connect to certain config. And there are only 3 choices, based on the _**index**_ of its list:
        * testnet have: sdftest1, sdftest2, sdftest3
        * mainnet have: Iowa, Frankfurt, Singapore
