### PR TITLE
476 update stellar overlay configuration files

### DIFF
--- a/clients/stellar-relay-lib/resources/config/mainnet/stellar_relay_config_mainnet_iowa.json
+++ b/clients/stellar-relay-lib/resources/config/mainnet/stellar_relay_config_mainnet_iowa.json
@@ -4,13 +4,15 @@
     "port": 11625
   },
   "node_info": {
-    "ledger_version": 19,
-    "overlay_version": 29,
+    "ledger_version": 20,
+    "overlay_version": 30,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 19.14.0 (5664eff4e76ca6a277883d4085711dc3fa7c318a)",
+    "version_str": "stellar-core 20.0.2 (669916b56106a72a7f79ab8b4a7898e77b28b49e)",
     "is_pub_net": true
   },
   "stellar_history_archive_urls": [
-    "http://history.stellar.org/prd/core-live/core_live_002"
+    "https://stellar-history-us-iowa.satoshipay.io",
+    "https://stellar-history-de-fra.satoshipay.io",
+    "https://stellar-history-sg-sin.satoshipay.io"
   ]
 }

--- a/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest1.json
+++ b/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest1.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 30,
+    "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.0.0.rc1 (ecb24df104c2453a00fa5097d2e879d7731b9596)",
+    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest2.json
+++ b/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest2.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 30,
+    "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.0.0.rc1 (ecb24df104c2453a00fa5097d2e879d7731b9596)",
+    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest3.json
+++ b/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest3.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 30,
+    "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.0.0.rc1 (ecb24df104c2453a00fa5097d2e879d7731b9596)",
+    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/stellar-relay-lib/src/tests/mod.rs
+++ b/clients/stellar-relay-lib/src/tests/mod.rs
@@ -56,25 +56,11 @@ async fn stellar_overlay_should_receive_scp_messages() {
 
 	timeout(Duration::from_secs(300), async move {
 		let mut ov_conn_locked = ov_conn.lock().await;
-		match ov_conn_locked.listen().await {
-			Ok(Some(msg)) => {
-				scps_vec_clone.lock().await.push(msg);
-				log::info!("stellar_overlay_should_receive_scp_messages(): msg:");
-				ov_conn_locked.disconnect();
-			},
-			Ok(None) => {
-				log::info!("stellar_overlay_should_receive_scp_messages(): no msg");
-			},
-			Err(e) => {
-				log::error!("stellar_overlay_should_receive_scp_messages(): error: {e:?}");
-				ov_conn_locked.disconnect();
-			},
+		if let Ok(Some(msg)) = ov_conn_locked.listen().await {
+			scps_vec_clone.lock().await.push(msg);
+
+			ov_conn_locked.disconnect();
 		}
-		// if let Ok(Some(msg)) = ov_conn_locked.listen().await {
-		// 	scps_vec_clone.lock().await.push(msg);
-		//
-		// 	ov_conn_locked.disconnect();
-		// }
 	})
 	.await
 	.expect("time has elapsed");
@@ -157,7 +143,7 @@ async fn stellar_overlay_disconnect_works() {
 	let mut overlay_connection =
 		StellarOverlayConnection::connect(node_info.clone(), conn_info).await.unwrap();
 
-	let _ = overlay_connection.listen().await.expect("should return a message");
+	let _ = overlay_connection.listen().await.unwrap();
 
 	overlay_connection.disconnect();
 }

--- a/clients/stellar-relay-lib/src/tests/mod.rs
+++ b/clients/stellar-relay-lib/src/tests/mod.rs
@@ -56,11 +56,25 @@ async fn stellar_overlay_should_receive_scp_messages() {
 
 	timeout(Duration::from_secs(300), async move {
 		let mut ov_conn_locked = ov_conn.lock().await;
-		if let Ok(Some(msg)) = ov_conn_locked.listen().await {
-			scps_vec_clone.lock().await.push(msg);
-
-			ov_conn_locked.disconnect();
+		match ov_conn_locked.listen().await {
+			Ok(Some(msg)) => {
+				scps_vec_clone.lock().await.push(msg);
+				log::info!("stellar_overlay_should_receive_scp_messages(): msg:");
+				ov_conn_locked.disconnect();
+			},
+			Ok(None) => {
+				log::info!("stellar_overlay_should_receive_scp_messages(): no msg");
+			},
+			Err(e) => {
+				log::error!("stellar_overlay_should_receive_scp_messages(): error: {e:?}");
+				ov_conn_locked.disconnect();
+			},
 		}
+		// if let Ok(Some(msg)) = ov_conn_locked.listen().await {
+		// 	scps_vec_clone.lock().await.push(msg);
+		//
+		// 	ov_conn_locked.disconnect();
+		// }
 	})
 	.await
 	.expect("time has elapsed");
@@ -143,7 +157,7 @@ async fn stellar_overlay_disconnect_works() {
 	let mut overlay_connection =
 		StellarOverlayConnection::connect(node_info.clone(), conn_info).await.unwrap();
 
-	let _ = overlay_connection.listen().await.unwrap();
+	let _ = overlay_connection.listen().await.expect("should return a message");
 
 	overlay_connection.disconnect();
 }

--- a/clients/vault/resources/config/mainnet/stellar_relay_config_frankfurt.json
+++ b/clients/vault/resources/config/mainnet/stellar_relay_config_frankfurt.json
@@ -4,10 +4,10 @@
     "port": 11625
   },
   "node_info": {
-    "ledger_version": 19,
-    "overlay_version": 29,
+    "ledger_version": 20,
+    "overlay_version": 30,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 19.14.0 (5664eff4e76ca6a277883d4085711dc3fa7c318a)",
+    "version_str": "stellar-core 20.0.2 (669916b56106a72a7f79ab8b4a7898e77b28b49e)",
     "is_pub_net": true
   },
   "stellar_history_archive_urls": [

--- a/clients/vault/resources/config/mainnet/stellar_relay_config_iowa.json
+++ b/clients/vault/resources/config/mainnet/stellar_relay_config_iowa.json
@@ -4,10 +4,10 @@
     "port": 11625
   },
   "node_info": {
-    "ledger_version": 19,
-    "overlay_version": 29,
+    "ledger_version": 20,
+    "overlay_version": 30,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 19.14.0 (5664eff4e76ca6a277883d4085711dc3fa7c318a)",
+    "version_str": "stellar-core 20.0.2 (669916b56106a72a7f79ab8b4a7898e77b28b49e)",
     "is_pub_net": true
   },
   "stellar_history_archive_urls": [

--- a/clients/vault/resources/config/mainnet/stellar_relay_config_singapore.json
+++ b/clients/vault/resources/config/mainnet/stellar_relay_config_singapore.json
@@ -4,10 +4,10 @@
     "port": 11625
   },
   "node_info": {
-    "ledger_version": 19,
-    "overlay_version": 29,
+    "ledger_version": 20,
+    "overlay_version": 30,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 19.14.0 (5664eff4e76ca6a277883d4085711dc3fa7c318a)",
+    "version_str": "stellar-core 20.0.2 (669916b56106a72a7f79ab8b4a7898e77b28b49e)",
     "is_pub_net": true
   },
   "stellar_history_archive_urls": [

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest1.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest1.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 30,
+    "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.0.0.rc1 (ecb24df104c2453a00fa5097d2e879d7731b9596)",
+    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest2.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest2.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 30,
+    "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.0.0.rc1 (ecb24df104c2453a00fa5097d2e879d7731b9596)",
+    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest3.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest3.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 30,
+    "overlay_version": 31,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.0.0.rc1 (ecb24df104c2453a00fa5097d2e879d7731b9596)",
+    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -20,7 +20,7 @@ use crate::types::FilterWith;
 
 use super::*;
 
-const SECRET: &str = "SBLI7RKEJAEFGLZUBSCOFJHQBPFYIIPLBCKN7WVCWT4NEG2UJEW33N73";
+const SECRET: &str = "SB6WHKIU2HGVBRNKNOEOQUY4GFC4ZLG5XPGWLEAHTIZXBXXYACC76VSQ";
 
 #[derive(Clone)]
 struct MockFilter;


### PR DESCRIPTION
This PR adds changes that fix failing unit tests. The overlay configuration files were updated and a different secret key is used for testnet. 

Closes #476.