### PR TITLE
431 Add environment variable options to Spacewalk

### DIFF
--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -23,7 +23,7 @@ testing-utils = [
 async-trait = "0.1.40"
 backoff = { version = "0.3.0", features = ["tokio"] }
 cfg-if = "1.0"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.1", features = ["derive", "env"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 futures = "0.3.5"
 log = "0.4.0"

--- a/clients/runtime/src/cli.rs
+++ b/clients/runtime/src/cli.rs
@@ -13,17 +13,17 @@ use crate::{
 #[derive(Parser, Debug, Clone)]
 pub struct ProviderUserOpts {
 	/// Keyring to use, mutually exclusive with keyfile.
-	#[clap(long, required_unless_present = "keyfile", parse(try_from_str = parse_account_keyring))]
+	#[clap(long, env = "KEYRING", required_unless_present = "keyfile", parse(try_from_str = parse_account_keyring))]
 	pub keyring: Option<AccountKeyring>,
 
 	/// Path to the json file containing key pairs in a map.
 	/// Valid content of this file is e.g.
 	/// `{ "MyUser1": "<Polkadot Account Mnemonic>", "MyUser2": "<Polkadot Account Mnemonic>" }`.
-	#[clap(long, conflicts_with = "keyring", requires = "keyname")]
+	#[clap(long, env = "KEYFILE", conflicts_with = "keyring", requires = "keyname")]
 	pub keyfile: Option<String>,
 
 	/// The name of the account from the keyfile to use.
-	#[clap(long, conflicts_with = "keyring", requires = "keyfile")]
+	#[clap(long, env = "KEYNAME", conflicts_with = "keyring", requires = "keyfile")]
 	pub keyname: Option<String>,
 }
 
@@ -89,7 +89,7 @@ pub fn parse_duration_minutes(src: &str) -> Result<Duration, ParseIntError> {
 #[derive(Parser, Debug, Clone)]
 pub struct ConnectionOpts {
 	/// Parachain websocket URL.
-	#[clap(long, default_value = "ws://127.0.0.1:9944")]
+	#[clap(long, env = "SPACEWALK_PARACHAIN_URL", default_value = "ws://127.0.0.1:9944")]
 	pub spacewalk_parachain_url: String,
 
 	/// Timeout in milliseconds to wait for connection to spacewalk-parachain.

--- a/clients/runtime/src/cli.rs
+++ b/clients/runtime/src/cli.rs
@@ -93,15 +93,15 @@ pub struct ConnectionOpts {
 	pub spacewalk_parachain_url: String,
 
 	/// Timeout in milliseconds to wait for connection to spacewalk-parachain.
-	#[clap(long, parse(try_from_str = parse_duration_ms), default_value = "60000")]
+	#[clap(long, env = "SPACEWALK_PARACHAIN_CONN_TIMEOUT_MS", parse(try_from_str = parse_duration_ms), default_value = "60000")]
 	pub spacewalk_parachain_connection_timeout_ms: Duration,
 
 	/// Maximum number of concurrent requests
-	#[clap(long)]
+	#[clap(long, env = "MAX_CONCURRENT_REQUESTS")]
 	pub max_concurrent_requests: Option<usize>,
 
 	/// Maximum notification capacity for each subscription
-	#[clap(long)]
+	#[clap(long, env = "S")]
 	pub max_notifs_per_subscription: Option<usize>,
 }
 

--- a/clients/runtime/src/cli.rs
+++ b/clients/runtime/src/cli.rs
@@ -93,7 +93,7 @@ pub struct ConnectionOpts {
 	pub spacewalk_parachain_url: String,
 
 	/// Timeout in milliseconds to wait for connection to spacewalk-parachain.
-	#[clap(long, env = "SPACEWALK_PARACHAIN_CONN_TIMEOUT_MS", parse(try_from_str = parse_duration_ms), default_value = "60000")]
+	#[clap(long, env = "SPACEWALK_PARACHAIN_CONNECTION_TIMEOUT_MS", parse(try_from_str = parse_duration_ms), default_value = "60000")]
 	pub spacewalk_parachain_connection_timeout_ms: Duration,
 
 	/// Maximum number of concurrent requests

--- a/clients/runtime/src/cli.rs
+++ b/clients/runtime/src/cli.rs
@@ -101,7 +101,7 @@ pub struct ConnectionOpts {
 	pub max_concurrent_requests: Option<usize>,
 
 	/// Maximum notification capacity for each subscription
-	#[clap(long, env = "S")]
+	#[clap(long, env = "MAX_NOTIFS_PER_SUBSCRIPTION")]
 	pub max_notifs_per_subscription: Option<usize>,
 }
 

--- a/clients/service/src/cli.rs
+++ b/clients/service/src/cli.rs
@@ -54,27 +54,27 @@ impl LoggingFormat {
 #[derive(Parser, Debug, Clone)]
 pub struct ServiceConfig {
 	/// Restart or stop on error.
-	#[clap(long, default_value = "always")]
+	#[clap(long, env = "RESTART_POLICY", default_value = "always")]
 	pub restart_policy: RestartPolicy,
 
 	/// Logging output format.
-	#[clap(long, default_value = "full")]
+	#[clap(long, env = "LOGGING_FORMAT", default_value = "full")]
 	pub logging_format: LoggingFormat,
 }
 
 #[derive(Parser, Debug, Clone)]
 pub struct MonitoringConfig {
 	/// Do not expose a Prometheus metric endpoint.
-	#[clap(long)]
+	#[clap(long, env = "NO_PROMETHEUS")]
 	pub no_prometheus: bool,
 
 	/// Expose Prometheus exporter on all interfaces.
 	///
 	/// Default is local.
-	#[clap(long)]
+	#[clap(long, env = "PROMETHEUS_EXTERNAL")]
 	pub prometheus_external: bool,
 
 	/// Specify Prometheus exporter TCP Port.
-	#[clap(long, default_value = "9616")]
+	#[clap(long, env = "PROMETHEUS_PORT", default_value = "9616")]
 	pub prometheus_port: u16,
 }

--- a/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest1.json
+++ b/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest1.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 31,
+    "overlay_version": 32,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
+    "version_str": "stellar-core 20.2.0.rc3 (34d82fc00426643e16b7ad59c9fde169b778eb4b)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest2.json
+++ b/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest2.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 31,
+    "overlay_version": 32,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
+    "version_str": "stellar-core 20.2.0.rc3 (34d82fc00426643e16b7ad59c9fde169b778eb4b)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest3.json
+++ b/clients/stellar-relay-lib/resources/config/testnet/stellar_relay_config_sdftest3.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 31,
+    "overlay_version": 32,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.1.0 (114b833e755400178a57142f45b7fb892ddb034f)",
+    "version_str": "stellar-core 20.2.0.rc3 (34d82fc00426643e16b7ad59c9fde169b778eb4b)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -24,7 +24,7 @@ async-std = "1.12.0"
 async-trait = "0.1.40"
 base64 = { version = '0.13.0', default-features = false, features = ['alloc'] }
 bincode = "1.3.3"
-clap = "3.1"
+clap = { version = "3.1", features = ["env"] }
 rand = "0.8.5"
 futures = "0.3.5"
 governor = "0.5.0"

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest1.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest1.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 31,
+    "overlay_version": 32,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.2.0.rc1 (3076c138d77735c6ce8230886a540f4d54d85c59)",
+    "version_str": "stellar-core 20.2.0.rc3 (34d82fc00426643e16b7ad59c9fde169b778eb4b)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest2.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest2.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 31,
+    "overlay_version": 32,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.2.0.rc1 (3076c138d77735c6ce8230886a540f4d54d85c59)",
+    "version_str": "stellar-core 20.2.0.rc3 (34d82fc00426643e16b7ad59c9fde169b778eb4b)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/resources/config/testnet/stellar_relay_config_sdftest3.json
+++ b/clients/vault/resources/config/testnet/stellar_relay_config_sdftest3.json
@@ -5,9 +5,9 @@
   },
   "node_info": {
     "ledger_version": 20,
-    "overlay_version": 31,
+    "overlay_version": 32,
     "overlay_min_version": 27,
-    "version_str": "stellar-core 20.2.0.rc1 (3076c138d77735c6ce8230886a540f4d54d85c59)",
+    "version_str": "stellar-core 20.2.0.rc3 (34d82fc00426643e16b7ad59c9fde169b778eb4b)",
     "is_pub_net": false
   },
   "stellar_history_archive_urls": []

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -243,9 +243,9 @@ mod tests {
 			sleep(Duration::from_secs(1)).await;
 			latest_slot = agent.last_slot_index().await;
 		}
-		// use a future slot (2 slots ahead) to ensure enough messages can be collected
+		// use 1 slot ahead, to ensure enough messages can be collected
 		// and to avoid "missed" messages.
-		latest_slot += 2;
+		latest_slot += 1;
 
 		let proof_result = agent.get_proof(latest_slot).await;
 		assert!(proof_result.is_ok(), "Failed to get proof for slot: {}", latest_slot);

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -221,6 +221,7 @@ pub struct VaultServiceConfig {
 	pub faucet_url: Option<String>,
 
 	/// Automatically register the vault with the given amount of collateral
+	/// note: when specifying the env, make sure to enclose it with double quotes.
 	#[clap(long, env = "AUTO_REGISTER", value_parser = parse_collateral_and_amount)]
 	pub auto_register: Vec<(String, String, Option<u128>)>,
 

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -217,7 +217,7 @@ pub struct VaultServiceConfig {
 	pub stellar_overlay_config_filepath: String,
 
 	/// Pass the faucet URL for auto-registration.
-	#[clap(long)]
+	#[clap(long, env = "FAUCET_URL")]
 	pub faucet_url: Option<String>,
 
 	/// Automatically register the vault with the given amount of collateral
@@ -226,15 +226,15 @@ pub struct VaultServiceConfig {
 	pub auto_register: Vec<(String, String, Option<u128>)>,
 
 	/// Minimum time to the redeem/replace execution deadline to make the stellar payment.
-	#[clap(long, value_parser = parse_duration_minutes, default_value = "1")]
+	#[clap(long, env = "PAYMENT_MARGIN_MINUTES", value_parser = parse_duration_minutes, default_value = "1")]
 	pub payment_margin_minutes: Duration,
 
 	/// Opt out of participation in replace requests.
-	#[clap(long)]
+	#[clap(long, env = "NO_AUTO_REPLACE")]
 	pub no_auto_replace: bool,
 
 	/// Don't try to execute issues.
-	#[clap(long)]
+	#[clap(long, env = "NO_ISSUE_EXECUTION")]
 	pub no_issue_execution: bool,
 }
 

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -210,10 +210,10 @@ fn parse_collateral_and_amount(
 
 #[derive(Parser, Clone, Debug)]
 pub struct VaultServiceConfig {
-	#[clap(long, help = "The Stellar secret key that is used to sign transactions.")]
+	#[clap(long, env = "STELLAR_VAULT_SECRET_KEY_FILEPATH", help = "The Stellar secret key that is used to sign transactions.")]
 	pub stellar_vault_secret_key_filepath: String,
 
-	#[clap(long, help = "The filepath where the json config for StellarOverlay is located")]
+	#[clap(long, env = "STELLAR_OVERLAY_CONFIG_FILEPATH", help = "The filepath where the json config for StellarOverlay is located")]
 	pub stellar_overlay_config_filepath: String,
 
 	/// Pass the faucet URL for auto-registration.
@@ -221,7 +221,7 @@ pub struct VaultServiceConfig {
 	pub faucet_url: Option<String>,
 
 	/// Automatically register the vault with the given amount of collateral
-	#[clap(long, value_parser = parse_collateral_and_amount)]
+	#[clap(long, env = "AUTO_REGISTER", value_parser = parse_collateral_and_amount)]
 	pub auto_register: Vec<(String, String, Option<u128>)>,
 
 	/// Minimum time to the redeem/replace execution deadline to make the stellar payment.

--- a/clients/vault/src/system.rs
+++ b/clients/vault/src/system.rs
@@ -210,10 +210,18 @@ fn parse_collateral_and_amount(
 
 #[derive(Parser, Clone, Debug)]
 pub struct VaultServiceConfig {
-	#[clap(long, env = "STELLAR_VAULT_SECRET_KEY_FILEPATH", help = "The Stellar secret key that is used to sign transactions.")]
+	#[clap(
+		long,
+		env = "STELLAR_VAULT_SECRET_KEY_FILEPATH",
+		help = "The Stellar secret key that is used to sign transactions."
+	)]
 	pub stellar_vault_secret_key_filepath: String,
 
-	#[clap(long, env = "STELLAR_OVERLAY_CONFIG_FILEPATH", help = "The filepath where the json config for StellarOverlay is located")]
+	#[clap(
+		long,
+		env = "STELLAR_OVERLAY_CONFIG_FILEPATH",
+		help = "The filepath where the json config for StellarOverlay is located"
+	)]
 	pub stellar_overlay_config_filepath: String,
 
 	/// Pass the faucet URL for auto-registration.


### PR DESCRIPTION
closes #431 

adding the ff. arguments an ENV option:
1. KEYRING
2. KEYFILE
3. KEYNAME
4. SPACEWALK_PARACHAIN_URL
5. STELLAR_VAULT_SECRET_KEY_FILEPATH
6. STELLAR_OVERLAY_CONFIG_FILEPATH
7. AUTO_REGISTER

note for **_AUTO_REGISTER_**:  since the value must be a tuple, make sure to **_enclose it with double quotes_**. 

:no_good: :x: `export AUTO_REGISTER=0,GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN:USDC,1000000` :x: :no_good:

:white_check_mark: :ok_hand: **`export AUTO_REGISTER="0,GAKNDFRRWA3RPWNLTI3G4EBSD3RGNZZOY5WKWYMQ6CQTG3KIEKPYWAYC:USDC,1000000"`** :ok_hand: :white_check_mark:


For arguments that accept _`option`_,  make sure to **_enclose it with double quotes_** with the _ACTUAL_ value.
:no_good: :x: `export MAX_NOTIFS_PER_SUBSCRIPTION="1"` :x: :no_good:
:no_good: :x: `export MAX_NOTIFS_PER_SUBSCRIPTION="Some(1)"` :x: :no_good:

:white_check_mark: :ok_hand: **`export MAX_NOTIFS_PER_SUBSCRIPTION=1`** :ok_hand: :white_check_mark: