### PR TITLE
Update Pendulum metadata

### DIFF
--- a/clients/runtime/src/lib.rs
+++ b/clients/runtime/src/lib.rs
@@ -74,7 +74,7 @@ compile_error!("You need to select at least one of the metadata features");
 #[cfg_attr(
 	feature = "parachain-metadata-pendulum",
 	subxt(
-		runtime_metadata_path = "metadata-parachain-foucoco.scale",
+		runtime_metadata_path = "metadata-parachain-pendulum.scale",
 		derive_for_all_types = "Clone, PartialEq, Eq",
 	)
 )]

--- a/clients/runtime/src/types.rs
+++ b/clients/runtime/src/types.rs
@@ -107,9 +107,7 @@ mod metadata_aliases {
 		if #[cfg(feature = "standalone-metadata")] {
 			pub type EncodedCall = metadata::runtime_types::spacewalk_runtime_standalone::RuntimeCall;
 		} else if #[cfg(feature = "parachain-metadata-pendulum")] {
-			pub type EncodedCall = metadata::runtime_types::foucoco_runtime::RuntimeCall;
-			// TODO Eventually change to
-			// pub type EncodedCall = metadata::runtime_types::pendulum_runtime::RuntimeCall;
+			pub type EncodedCall = metadata::runtime_types::pendulum_runtime::RuntimeCall;
 		} else if #[cfg(feature = "parachain-metadata-amplitude")] {
 			pub type EncodedCall = metadata::runtime_types::amplitude_runtime::RuntimeCall;
 		} else if #[cfg(feature = "parachain-metadata-foucoco")] {


### PR DESCRIPTION
- [x] Change the configuration to use pendulum's metadata instead of foucoco
- [ ] Download the latest metadata.scale and metadata.json file from pendulum using `subxt`. This is blocked until the latest runtime upgrade with the Spacewalk pallets goes live on Pendulum.

Closes #484.