### PR TITLE
Adding cargo fix to pre-commit hook

### DIFF
--- a/.maintain/add-precommit-hook.sh
+++ b/.maintain/add-precommit-hook.sh
@@ -29,6 +29,36 @@ if [ ${#rust_files[@]} -ne 0 ]; then
 else
     echo "No changes, formatting skipped"
 fi
+wait
+
+echo "Running cargo clippy --fix on project"
+before_clippy=$(git diff --name-only)
+$(command -v cargo) clippy --fix --allow-dirty --allow-staged --all-features
+after_clippy=$(git diff --name-only)
+wait
+
+# Files modified by clippy
+readarray -t before_files <<< "$before_clippy"
+readarray -t after_files <<< "$after_clippy"
+clippy_modified_files=()
+for i in "${after_files[@]}"; do
+    skip=
+    for j in "${before_files[@]}"; do
+        [[ $i == $j ]] && { skip=1; break; }
+    done
+    [[ -n $skip ]] || clippy_modified_files+=("$i")
+done
+
+# Add only the files modified by clippy
+if [ ${#clippy_modified_files[@]} -ne 0 ]; then
+    git add ${clippy_modified_files[@]}
+    echo "Clippy modifications added for: ${clippy_modified_files[@]}"
+else
+    echo "No modifications by clippy"
+fi
+
+echo "Pre-commit hook execution completed."
+
 EOF
 
 chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
Regarding #153 

I will leave this as a draft pull request since I am not totally convinced about the results.

### What is added
We add `cargo clippy --fix` command to run over the whole project after every commit. 

Since there may be files that were modified but not staged, we will not add them to the commit, although they will be fixed by `clippy`.

### What could improve
Ideally, we would just run `fix` only on the modified files like we do with `rustfmt` but this is not possible with `clippy`.

Another possibility that was tested was to identify the package to which the modified file belongs and run `clippy fix` on the package level. Although this works, there is a problem to identify which flags each crate requires. Passing `--all-features` to every package fails on some of them.

### Alternatively
Since it takes quite some time for the compilation to take place, it perhaps is better to perform `clippy fix` on a `pre-push` hook.