### PR TITLE
Improve robustness of Spacewalk integration tests

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -4,16 +4,9 @@ on:
       - 'main'
 
 name: continuous-integration-main
-
 jobs:
   ci:
-    strategy:
-      max-parallel: 1
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
       # Make sure CI fails on all warnings, including Clippy lints
@@ -30,18 +23,12 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v2
 
-      - name: Install package (ubuntu-latest)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install package
         run: |
           sudo docker image prune --all --force
           echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
           sudo apt-get update && sudo apt-get upgrade -y
           sudo apt-get install -y protobuf-compiler libprotobuf-dev
-
-      - name: Install package (macos-latest)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install protobuf
 
       - name: Setup Rust toolchain
         # Call `rustup show` as a hack so that the toolchain defined in rust-toolchain.toml is installed
@@ -51,7 +38,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: "${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}"
+          key: "ubuntu-latest-cargo-${{ hashFiles('**/Cargo.lock') }}"
           shared-key: "shared"
 
       - name: Install Protoc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7217,6 +7217,7 @@ dependencies = [
  "sp-std 5.0.0",
  "sp-version",
  "spacewalk-primitives",
+ "spacewalk-runtime-standalone-mainnet",
  "spacewalk-runtime-standalone-testnet",
  "spacewalk-standalone",
  "substrate-stellar-sdk",

--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -15,6 +15,7 @@ testing-utils = [
     "rand",
     "testchain",
     "testchain-runtime/testing-utils",
+    "mainnet-runtime/testing-utils",
     "subxt-client",
     "oracle/testing-utils"
 ]
@@ -58,6 +59,7 @@ rand = { version = "0.7", optional = true }
 tempdir = { version = "0.3.7", optional = true }
 testchain = { package = "spacewalk-standalone", path = "../../testchain/node", optional = true }
 testchain-runtime = { package = "spacewalk-runtime-standalone-testnet", path = "../../testchain/runtime/testnet", optional = true }
+mainnet-runtime = { package = "spacewalk-runtime-standalone-mainnet", path = "../../testchain/runtime/mainnet", optional = true }
 
 # Substrate Stellar Dependencies
 substrate-stellar-sdk = { git = "https://github.com/pendulum-chain/substrate-stellar-sdk", branch = "polkadot-v0.9.40" }

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -17,7 +17,7 @@ standalone-metadata = ["runtime/standalone-metadata"]
 parachain-metadata-pendulum = ["runtime/parachain-metadata-pendulum"]
 parachain-metadata-amplitude = ["runtime/parachain-metadata-amplitude"]
 parachain-metadata-foucoco = ["runtime/parachain-metadata-foucoco"]
-integration-test = ["runtime/standalone-metadata", "integration"]
+integration-test = ["integration", "standalone-metadata"]
 
 [dependencies]
 async-std = "1.12.0"
@@ -82,7 +82,7 @@ serial_test = "0.9.0"
 tempdir = "0.3.7"
 
 # Workspace dependencies
-runtime = { path = "../runtime", features = ["testing-utils"] }
+runtime = { path = "../runtime", features = ["testing-utils", "standalone-metadata"] }
 wallet = { path = "../wallet", features = ["testing-utils"] }
 subxt = { version = "0.25.0" }
 

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -218,7 +218,7 @@ mod tests {
 	async fn test_get_proof_for_current_slot() {
 		// let it run for a few seconds, making sure that the other tests have successfully shutdown
 		// their connection to Stellar Node
-		sleep(Duration::from_secs(5)).await;
+		sleep(Duration::from_secs(2)).await;
 
 		let shutdown_sender = ShutdownSender::new();
 
@@ -236,6 +236,7 @@ mod tests {
 			sleep(Duration::from_secs(1)).await;
 			latest_slot = agent.last_slot_index().await;
 		}
+		latest_slot +=1;
 		// let's wait for envelopes and txset to be available for creating a proof
 		sleep(Duration::from_secs(5)).await;
 

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -236,7 +236,7 @@ mod tests {
 			sleep(Duration::from_secs(1)).await;
 			latest_slot = agent.last_slot_index().await;
 		}
-		latest_slot +=1;
+		latest_slot += 1;
 		// let's wait for envelopes and txset to be available for creating a proof
 		sleep(Duration::from_secs(5)).await;
 

--- a/clients/vault/src/oracle/agent.rs
+++ b/clients/vault/src/oracle/agent.rs
@@ -218,7 +218,7 @@ mod tests {
 	async fn test_get_proof_for_current_slot() {
 		// let it run for a few seconds, making sure that the other tests have successfully shutdown
 		// their connection to Stellar Node
-		sleep(Duration::from_secs(20)).await;
+		sleep(Duration::from_secs(5)).await;
 
 		let shutdown_sender = ShutdownSender::new();
 
@@ -236,9 +236,8 @@ mod tests {
 			sleep(Duration::from_secs(1)).await;
 			latest_slot = agent.last_slot_index().await;
 		}
-		// use 1 slot ahead, to ensure enough messages can be collected
-		// and to avoid "missed" messages.
-		latest_slot += 1;
+		// let's wait for envelopes and txset to be available for creating a proof
+		sleep(Duration::from_secs(5)).await;
 
 		let proof_result = agent.get_proof(latest_slot).await;
 		assert!(proof_result.is_ok(), "Failed to get proof for slot: {}", latest_slot);

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -603,7 +603,7 @@ async fn test_issue_cancel_succeeds() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ntest::timeout(900_000)] // timeout at 15 minutes
+#[ntest::timeout(1_200_000)] // timeout at 20 minutes
 #[serial]
 async fn test_issue_execution_succeeds_from_archive() {
 	let is_public_network = true;

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -603,6 +603,7 @@ async fn test_issue_cancel_succeeds() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ntest::timeout(900_000)] // timeout at 15 minutes
 #[serial]
 async fn test_issue_execution_succeeds_from_archive() {
 	let is_public_network = true;

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -793,7 +793,7 @@ async fn test_issue_overpayment_succeeds() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn clear() {
+async fn test_automatic_issue_execution_succeeds_on_mainnet() {
 	let is_public_network = true;
 	test_automatic_issue_execution_succeeds_on_network(is_public_network).await;
 }

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -853,7 +853,7 @@ async fn test_automatic_issue_execution_succeeds_on_network(is_public_network: b
 				.await
 				.expect("should return a result");
 
-				tracing::warn!("Sent payment successfully: {:?}", result);
+				tracing::info!("Sent payment successfully: {:?}", result);
 
 				// Sleep 5 seconds to give other thread some time to receive the RequestIssue event
 				// and add it to the set
@@ -875,14 +875,6 @@ async fn test_automatic_issue_execution_succeeds_on_network(is_public_network: b
 			let memos_to_issue_ids = Arc::new(RwLock::new(IssueIdLookup::new()));
 			let (issue_event_tx, _issue_event_rx) = mpsc::channel::<CancellationEvent>(16);
 			let service = join3(
-				vault::service::listen_for_new_transactions(
-					wallet_read.public_key(),
-					wallet_read.is_public_network(),
-					slot_tx_env_map.clone(),
-					issue_set.clone(),
-					memos_to_issue_ids.clone(),
-					issue_filter,
-				),
 				vault::service::listen_for_issue_requests(
 					vault_provider.clone(),
 					wallet_read.public_key(),
@@ -896,6 +888,14 @@ async fn test_automatic_issue_execution_succeeds_on_network(is_public_network: b
 					slot_tx_env_map.clone(),
 					issue_set.clone(),
 					memos_to_issue_ids.clone(),
+				),
+				vault::service::listen_for_new_transactions(
+					wallet_read.public_key(),
+					wallet_read.is_public_network(),
+					slot_tx_env_map.clone(),
+					issue_set.clone(),
+					memos_to_issue_ids.clone(),
+					issue_filter,
 				),
 			);
 			drop(wallet_read);

--- a/clients/vault/tests/vault_integration_tests.rs
+++ b/clients/vault/tests/vault_integration_tests.rs
@@ -792,7 +792,7 @@ async fn test_issue_overpayment_succeeds() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn test_automatic_issue_execution_succeeds_on_mainnet() {
+async fn clear() {
 	let is_public_network = true;
 	test_automatic_issue_execution_succeeds_on_network(is_public_network).await;
 }

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -38,6 +38,9 @@ pub enum Error {
 
 	#[error("Failed to get fee: {0}")]
 	FailedToGetFee(String),
+
+	#[error("Permission Denied to {0}")]
+	PermissionDenied(String),
 }
 
 impl Error {

--- a/clients/wallet/src/error.rs
+++ b/clients/wallet/src/error.rs
@@ -38,9 +38,6 @@ pub enum Error {
 
 	#[error("Failed to get fee: {0}")]
 	FailedToGetFee(String),
-
-	#[error("Permission Denied to {0}")]
-	PermissionDenied(String),
 }
 
 impl Error {

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -162,7 +162,6 @@ pub struct EmbeddedTransactions {
 
 // This represents each record for a transaction in the Horizon API response
 #[derive(Clone, Deserialize, Encode, Decode, Default)]
-#[serde(bound(deserialize = "'de: 'static"))]
 pub struct TransactionResponse {
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub id: Vec<u8>,

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -163,36 +163,36 @@ pub struct EmbeddedTransactions {
 // This represents each record for a transaction in the Horizon API response
 #[derive(Clone, Deserialize, Encode, Decode, Default)]
 pub struct TransactionResponse {
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub id: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_u128")]
+	#[serde(deserialize_with = "de_str_to_u128")]
 	pub paging_token: PagingToken,
 	pub successful: bool,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub hash: Vec<u8>,
 	pub ledger: Slot,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub created_at: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub source_account: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub source_account_sequence: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub fee_account: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_u64")]
+	#[serde(deserialize_with = "de_str_to_u64")]
 	pub fee_charged: u64,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub max_fee: Vec<u8>,
 	operation_count: u32,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub envelope_xdr: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub result_xdr: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub result_meta_xdr: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub fee_meta_xdr: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub memo_type: Vec<u8>,
 	#[serde(default)]
 	#[serde(deserialize_with = "de_string_to_optional_bytes")]
@@ -279,11 +279,11 @@ impl TransactionResponse {
 
 #[derive(Deserialize)]
 pub struct HorizonAccountResponse {
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub id: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub account_id: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_i64")]
+	#[serde(deserialize_with = "de_str_to_i64")]
 	pub sequence: i64,
 	pub balances: Vec<HorizonBalance>,
 	// ...
@@ -316,7 +316,7 @@ impl HorizonAccountResponse {
 
 #[derive(Deserialize, Encode, Decode, Default, Debug)]
 pub struct HorizonBalance {
-	#[serde(deserialize_with = "de_string_to_f64")]
+	#[serde(deserialize_with = "de_str_to_f64")]
 	pub balance: f64,
 	#[serde(default)]
 	#[serde(deserialize_with = "de_str_to_optional_bytes")]
@@ -324,7 +324,7 @@ pub struct HorizonBalance {
 	#[serde(default)]
 	#[serde(deserialize_with = "de_str_to_optional_bytes")]
 	pub asset_issuer: Option<Vec<u8>>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub asset_type: Vec<u8>,
 }
 
@@ -360,43 +360,43 @@ pub struct HorizonClaimableBalanceResponse {
 
 #[derive(Deserialize, Debug)]
 pub struct FeeDistribution {
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub max: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub min: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub mode: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p10: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p20: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p30: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p40: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p50: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p60: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p70: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p80: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p90: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p95: u32,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub p99: u32,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct FeeStats {
-	#[serde(deserialize_with = "de_string_to_u64")]
+	#[serde(deserialize_with = "de_str_to_u64")]
 	pub last_ledger: Slot,
-	#[serde(deserialize_with = "de_string_to_u32")]
+	#[serde(deserialize_with = "de_str_to_u32")]
 	pub last_ledger_base_fee: u32,
-	#[serde(deserialize_with = "de_string_to_f64")]
+	#[serde(deserialize_with = "de_str_to_f64")]
 	pub ledger_capacity_usage: f64,
 	pub fee_charged: FeeDistribution,
 	pub max_fee: FeeDistribution,
@@ -426,27 +426,27 @@ impl FeeStats {
 // This represents each record for a claimable balance in the Horizon API response
 #[derive(Deserialize, Encode, Decode, Default, Debug)]
 pub struct ClaimableBalance {
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub id: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub paging_token: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub asset: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub amount: Vec<u8>,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub sponsor: Vec<u8>,
 
 	pub claimants: Vec<Claimant>,
 	pub last_modified_ledger: Slot,
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub last_modified_time: Vec<u8>,
 }
 
 // This represents a Claimant
 #[derive(Deserialize, Encode, Decode, Default, Debug)]
 pub struct Claimant {
-	#[serde(deserialize_with = "de_string_to_bytes")]
+	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub destination: Vec<u8>,
 	// For now we assume that the predicate is always unconditional
 	pub predicate: ClaimantPredicate,

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -195,7 +195,7 @@ pub struct TransactionResponse {
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub memo_type: Vec<u8>,
 	#[serde(default)]
-	#[serde(deserialize_with = "de_cow_string_to_optional_bytes")]
+	#[serde(deserialize_with = "de_string_to_optional_bytes")]
 	pub memo: Option<Vec<u8>>,
 }
 
@@ -319,10 +319,10 @@ pub struct HorizonBalance {
 	#[serde(deserialize_with = "de_string_to_f64")]
 	pub balance: f64,
 	#[serde(default)]
-	#[serde(deserialize_with = "de_string_to_optional_bytes")]
+	#[serde(deserialize_with = "de_str_to_optional_bytes")]
 	pub asset_code: Option<Vec<u8>>,
 	#[serde(default)]
-	#[serde(deserialize_with = "de_string_to_optional_bytes")]
+	#[serde(deserialize_with = "de_str_to_optional_bytes")]
 	pub asset_issuer: Option<Vec<u8>>,
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub asset_type: Vec<u8>,

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -162,6 +162,7 @@ pub struct EmbeddedTransactions {
 
 // This represents each record for a transaction in the Horizon API response
 #[derive(Clone, Deserialize, Encode, Decode, Default)]
+#[serde(bound(deserialize = "'de: 'static"))]
 pub struct TransactionResponse {
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub id: Vec<u8>,
@@ -195,7 +196,7 @@ pub struct TransactionResponse {
 	#[serde(deserialize_with = "de_string_to_bytes")]
 	pub memo_type: Vec<u8>,
 	#[serde(default)]
-	#[serde(deserialize_with = "de_string_to_optional_bytes")]
+	#[serde(deserialize_with = "de_cow_string_to_optional_bytes")]
 	pub memo: Option<Vec<u8>>,
 }
 

--- a/clients/wallet/src/horizon/serde.rs
+++ b/clients/wallet/src/horizon/serde.rs
@@ -53,6 +53,13 @@ pub fn de_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::
 where
 	D: Deserializer<'de>,
 {
+	Option::<&str>::deserialize(de).map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
+}
+
+pub fn de_cow_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
+where
+	D: Deserializer<'de>,
+{
 	Option::<Cow<str>>::deserialize(de)
 		.map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
 }

--- a/clients/wallet/src/horizon/serde.rs
+++ b/clients/wallet/src/horizon/serde.rs
@@ -1,6 +1,5 @@
-use std::borrow::Cow;
 use serde::{Deserialize, Deserializer};
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 pub fn de_string_to_bytes<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
 where
@@ -54,9 +53,6 @@ pub fn de_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::
 where
 	D: Deserializer<'de>,
 {
-
-	Option::<Cow<str>>::deserialize(de).map(
-		|opt_wrapped|
-			opt_wrapped.map(|x| x.as_bytes().to_vec())
-	)
+	Option::<Cow<str>>::deserialize(de)
+		.map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
 }

--- a/clients/wallet/src/horizon/serde.rs
+++ b/clients/wallet/src/horizon/serde.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
 
-pub fn de_string_to_bytes<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
+pub fn de_str_to_bytes<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
 where
 	D: Deserializer<'de>,
 {
@@ -9,7 +9,7 @@ where
 	Ok(s.as_bytes().to_vec())
 }
 
-pub fn de_string_to_u128<'de, D>(de: D) -> Result<u128, D::Error>
+pub fn de_str_to_u128<'de, D>(de: D) -> Result<u128, D::Error>
 where
 	D: Deserializer<'de>,
 {
@@ -17,7 +17,7 @@ where
 	u128::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub fn de_string_to_u64<'de, D>(de: D) -> Result<u64, D::Error>
+pub fn de_str_to_u64<'de, D>(de: D) -> Result<u64, D::Error>
 where
 	D: Deserializer<'de>,
 {
@@ -25,7 +25,7 @@ where
 	u64::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub fn de_string_to_i64<'de, D>(de: D) -> Result<i64, D::Error>
+pub fn de_str_to_i64<'de, D>(de: D) -> Result<i64, D::Error>
 where
 	D: Deserializer<'de>,
 {
@@ -33,7 +33,7 @@ where
 	i64::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub fn de_string_to_f64<'de, D>(de: D) -> Result<f64, D::Error>
+pub fn de_str_to_f64<'de, D>(de: D) -> Result<f64, D::Error>
 where
 	D: Deserializer<'de>,
 {
@@ -41,7 +41,7 @@ where
 	f64::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub fn de_string_to_u32<'de, D>(de: D) -> Result<u32, D::Error>
+pub fn de_str_to_u32<'de, D>(de: D) -> Result<u32, D::Error>
 where
 	D: Deserializer<'de>,
 {

--- a/clients/wallet/src/horizon/serde.rs
+++ b/clients/wallet/src/horizon/serde.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
 
@@ -53,5 +54,9 @@ pub fn de_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::
 where
 	D: Deserializer<'de>,
 {
-	Option::<&str>::deserialize(de).map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
+
+	Option::<Cow<str>>::deserialize(de).map(
+		|opt_wrapped|
+			opt_wrapped.map(|x| x.as_bytes().to_vec())
+	)
 }

--- a/clients/wallet/src/horizon/serde.rs
+++ b/clients/wallet/src/horizon/serde.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Deserializer};
-use std::{borrow::Cow, str::FromStr};
+use std::str::FromStr;
 
 pub fn de_string_to_bytes<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
 where
@@ -49,17 +49,16 @@ where
 	u32::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub fn de_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
+pub fn de_str_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
 where
 	D: Deserializer<'de>,
 {
 	Option::<&str>::deserialize(de).map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
 }
 
-pub fn de_cow_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
+pub fn de_string_to_optional_bytes<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
 where
 	D: Deserializer<'de>,
 {
-	Option::<Cow<str>>::deserialize(de)
-		.map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
+	Option::<String>::deserialize(de).map(|opt_wrapped| opt_wrapped.map(|x| x.as_bytes().to_vec()))
 }

--- a/clients/wallet/src/horizon/tests.rs
+++ b/clients/wallet/src/horizon/tests.rs
@@ -9,7 +9,11 @@ use crate::{
 	mock::secret_key_from_encoding,
 };
 use mockall::predicate::*;
-use primitives::stellar::{network::{Network, PUBLIC_NETWORK, TEST_NETWORK}, types::Preconditions, Asset, Operation, PublicKey, SecretKey, StroopAmount, Transaction, TransactionEnvelope};
+use primitives::stellar::{
+	network::{Network, PUBLIC_NETWORK, TEST_NETWORK},
+	types::Preconditions,
+	Asset, Operation, PublicKey, SecretKey, StroopAmount, Transaction, TransactionEnvelope,
+};
 use tokio::sync::RwLock;
 
 use crate::types::FilterWith;
@@ -207,7 +211,7 @@ async fn fetch_horizon_and_process_new_transactions_success() {
 
 	let slot = response.ledger();
 	let envelope = response.to_envelope().expect("should convert to envelope");
-	slot_env_map.write().await.insert(slot,envelope);
+	slot_env_map.write().await.insert(slot, envelope);
 
 	fetcher
 		.fetch_horizon_and_process_new_transactions(

--- a/clients/wallet/src/horizon/traits.rs
+++ b/clients/wallet/src/horizon/traits.rs
@@ -59,3 +59,15 @@ impl<K, V> IsEmptyExt for HashMap<K, V> {
 		self.is_empty()
 	}
 }
+
+impl<V> IsEmptyExt for Vec<V> {
+	fn is_empty(&self) -> bool {
+		self.is_empty()
+	}
+}
+
+impl<V> IsEmptyExt for [V] {
+	fn is_empty(&self) -> bool {
+		self.is_empty()
+	}
+}

--- a/clients/wallet/src/horizon/traits.rs
+++ b/clients/wallet/src/horizon/traits.rs
@@ -11,6 +11,7 @@ use primitives::stellar::{
 	ClaimableBalanceId, PublicKey, StellarTypeToString, TransactionEnvelope,
 };
 use serde::de::DeserializeOwned;
+use std::collections::HashMap;
 
 #[async_trait]
 pub trait HorizonClient {
@@ -46,4 +47,15 @@ pub trait HorizonClient {
 		max_retries: u8,
 		max_backoff_delay_in_secs: u16,
 	) -> Result<TransactionResponse, Error>;
+}
+
+/// An important trait to check if something is empty.
+pub trait IsEmptyExt {
+	fn is_empty(&self) -> bool;
+}
+
+impl<K, V> IsEmptyExt for HashMap<K, V> {
+	fn is_empty(&self) -> bool {
+		self.is_empty()
+	}
 }

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -471,13 +471,13 @@ mod test {
 	#[tokio::test]
 	#[serial]
 	async fn check_is_transaction_already_submitted() {
-		let wallet = wallet_with_storage("resources/checkcheck_middle_transaction_match")
+		let wallet = wallet_with_storage("resources/check_is_transaction_already_submitted")
 			.expect("")
 			.clone();
 		let mut wallet = wallet.write().await;
 
 		let asset = StellarAsset::native();
-		let amount = 1002;
+		let amount = 10;
 
 		// test is_transaction_already_submitted returns true
 		{
@@ -537,7 +537,7 @@ mod test {
 		let seq = wallet.get_sequence().await.expect("return sequence number");
 
 		let asset = StellarAsset::native();
-		let amount = 1002;
+		let amount = 20;
 
 		// test bump_sequence_number_and_submit success
 		{
@@ -604,7 +604,7 @@ mod test {
 		let wallet = wallet.write().await;
 
 		let dummy_envelope = wallet
-			.create_dummy_envelope_no_signature(1003)
+			.create_dummy_envelope_no_signature(15)
 			.await
 			.expect("should return an envelope");
 
@@ -646,7 +646,7 @@ mod test {
 			.create_payment_envelope_no_signature(
 				default_destination(),
 				StellarAsset::native(),
-				100,
+				13,
 				rand::random(),
 				DEFAULT_STROOP_FEE_PER_OPERATION,
 				sequence + 1,
@@ -691,7 +691,7 @@ mod test {
 		// tx_bad_seq test
 		{
 			let envelope = wallet
-				.create_dummy_envelope_no_signature(1010)
+				.create_dummy_envelope_no_signature(18)
 				.await
 				.expect("returns an envelope");
 			let envelope_xdr = envelope.to_base64_xdr();
@@ -733,7 +733,7 @@ mod test {
 		// tx_internal_error test
 		{
 			let envelope = wallet
-				.create_dummy_envelope_no_signature(1020)
+				.create_dummy_envelope_no_signature(10)
 				.await
 				.expect("returns an envelope");
 			let envelope_xdr = envelope.to_base64_xdr();
@@ -772,7 +772,7 @@ mod test {
 		// other error
 		{
 			let envelope = wallet
-				.create_dummy_envelope_no_signature(1010)
+				.create_dummy_envelope_no_signature(20)
 				.await
 				.expect("returns an envelope");
 			let envelope_xdr = envelope.to_base64_xdr();
@@ -817,7 +817,7 @@ mod test {
 					asset_code,
 					issuer: default_destination(),
 				}),
-				1001,
+				25,
 				rand::random(),
 				DEFAULT_STROOP_FEE_PER_OPERATION,
 				seq_number + 2,
@@ -834,7 +834,7 @@ mod test {
 			.create_payment_envelope(
 				default_destination(),
 				StellarAsset::native(),
-				1100,
+				22,
 				rand::random(),
 				DEFAULT_STROOP_FEE_PER_OPERATION,
 				seq_number + 10,
@@ -851,7 +851,7 @@ mod test {
 			.create_payment_envelope(
 				default_destination(),
 				StellarAsset::native(),
-				1002,
+				11,
 				rand::random(),
 				DEFAULT_STROOP_FEE_PER_OPERATION,
 				seq_number + 1,

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -48,13 +48,7 @@ impl StellarWallet {
 	#[doc(hidden)]
 	/// Submits transactions found in the wallet's cache to Stellar.
 	async fn _resubmit_transactions_from_cache(&self) {
-		let permit = match self.semaphore.acquire().await {
-			Ok(permit) => permit,
-			Err(e) => {
-				tracing::warn!("_resubmit_transactions_from_cache(): permission denied: {e:?}");
-				return
-			},
-		};
+		let _ = self.transaction_submission_lock.lock().await;
 
 		// Collect envelopes from cache
 		let envelopes = match self.get_tx_envelopes_from_cache() {
@@ -107,8 +101,6 @@ impl StellarWallet {
 				me.handle_errors(error_collector).await;
 			});
 		}
-
-		drop(permit);
 	}
 
 	#[doc(hidden)]

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -1,6 +1,6 @@
 use cached::proc_macro::cached;
 use reqwest::Client;
-use std::{fmt::Formatter, sync::Arc};
+use std::{fmt::Formatter, sync::Arc, time::Duration};
 
 use primitives::stellar::{
 	network::{Network, PUBLIC_NETWORK, TEST_NETWORK},
@@ -8,7 +8,7 @@ use primitives::stellar::{
 	Asset as StellarAsset, Operation, PublicKey, SecretKey, StellarTypeToString, Transaction,
 	TransactionEnvelope,
 };
-use tokio::sync::Mutex;
+use tokio::sync::Semaphore;
 
 use crate::{
 	cache::WalletStateStorage,
@@ -27,7 +27,9 @@ use crate::{
 	},
 	types::PagingToken,
 };
-use primitives::{StellarPublicKeyRaw, StellarStroops, TransactionEnvelopeExt};
+use primitives::{
+	derive_shortened_request_id, StellarPublicKeyRaw, StellarStroops, TransactionEnvelopeExt,
+};
 
 use crate::types::FeeAttribute;
 #[cfg(test)]
@@ -39,9 +41,9 @@ pub struct StellarWallet {
 	is_public_network: bool,
 	/// Used to make sure that only one transaction is submitted at a time,
 	/// so that the transaction is not rejected due to an outdated sequence number.
-	/// Releasing the lock ensures the sequence number of the account
+	/// Acquiring a permit ensures the sequence number of the account
 	/// has been increased on the network.
-	pub(crate) transaction_submission_lock: Arc<Mutex<()>>,
+	pub(crate) semaphore: Arc<Semaphore>,
 	/// Used for caching Stellar transactions before they get submitted.
 	/// Also used for caching the latest cursor to page through Stellar transactions in horizon
 	cache: WalletStateStorage,
@@ -100,14 +102,23 @@ impl StellarWallet {
 
 		let cache = WalletStateStorage::new(cache_path, &pub_key, is_public_network);
 
+		// using a builder to decrease idle connections
+		// https://users.rust-lang.org/t/reqwest-http-client-fails-when-too-much-concurrency/55644/2
+		let client = reqwest::Client::builder()
+			// default is 90 seconds.
+			.pool_idle_timeout(Some(Duration::from_secs(60)))
+			// default is usize max.
+			.pool_max_idle_per_host(usize::MAX / 2)
+			.build()?;
+
 		Ok(StellarWallet {
 			secret_key,
 			is_public_network,
-			transaction_submission_lock: Arc::new(Mutex::new(())),
+			semaphore: Arc::new(Semaphore::const_new(1)),
 			cache,
 			max_retry_attempts_before_fallback: Self::DEFAULT_MAX_RETRY_ATTEMPTS_BEFORE_FALLBACK,
 			max_backoff_delay: Self::DEFAULT_MAX_BACKOFF_DELAY_IN_SECS,
-			client: reqwest::Client::new(),
+			client,
 		})
 	}
 
@@ -357,7 +368,12 @@ impl StellarWallet {
 		request_id: [u8; 32],
 		operations: Vec<Operation>,
 	) -> Result<TransactionResponse, Error> {
-		let _ = self.transaction_submission_lock.lock().await;
+		let permit = self.semaphore.acquire().await.map_err(|e| {
+			tracing::warn!("send_to_address(): Permission denied: {e:?}");
+
+			let req_id = String::from_utf8(derive_shortened_request_id(&request_id));
+			Error::PermissionDenied(format!("send to address with request id: {req_id:?}"))
+		})?;
 
 		let stroop_fee_per_operation =
 			get_fee_stat_for(self.is_public_network, FeeAttribute::default())
@@ -380,7 +396,10 @@ impl StellarWallet {
 			operations,
 		)?;
 
-		self.submit_transaction(envelope).await
+		let result = self.submit_transaction(envelope).await;
+		drop(permit);
+
+		result
 	}
 }
 

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -1,7 +1,6 @@
 use cached::proc_macro::cached;
 use reqwest::Client;
-use std::{fmt::Formatter, sync::Arc};
-use std::time::Duration;
+use std::{fmt::Formatter, sync::Arc, time::Duration};
 
 use primitives::stellar::{
 	network::{Network, PUBLIC_NETWORK, TEST_NETWORK},

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -99,6 +99,14 @@ impl StellarWallet {
 		})?;
 
 		let cache = WalletStateStorage::new(cache_path, &pub_key, is_public_network);
+		// using a builder to decrease idle connections
+		// https://users.rust-lang.org/t/reqwest-http-client-fails-when-too-much-concurrency/55644/2
+		let client = reqwest::Client::builder()
+			// default is 90 seconds.
+			.pool_idle_timeout(Some(Duration::from_secs(60)))
+			// default is usize max.
+			.pool_max_idle_per_host(usize::MAX / 2)
+			.build()?;
 
 		Ok(StellarWallet {
 			secret_key,
@@ -107,7 +115,7 @@ impl StellarWallet {
 			cache,
 			max_retry_attempts_before_fallback: Self::DEFAULT_MAX_RETRY_ATTEMPTS_BEFORE_FALLBACK,
 			max_backoff_delay: Self::DEFAULT_MAX_BACKOFF_DELAY_IN_SECS,
-			client: reqwest::Client::new(),
+			client,
 		})
 	}
 

--- a/clients/wallet/src/stellar_wallet.rs
+++ b/clients/wallet/src/stellar_wallet.rs
@@ -1,6 +1,7 @@
 use cached::proc_macro::cached;
 use reqwest::Client;
 use std::{fmt::Formatter, sync::Arc};
+use std::time::Duration;
 
 use primitives::stellar::{
 	network::{Network, PUBLIC_NETWORK, TEST_NETWORK},


### PR DESCRIPTION
Closes #494.

The multiple mainnet integration issues (and its fixes) are as follows:
* cannot determine which `DecimalsLookUp` to use. 
   * fix: make sure for the feature `integration-test`, the clients/vault uses the `standalone-metadata` feature:
    https://github.com/pendulum-chain/spacewalk/blob/ea913fab5ae2a47368d48206fba5e7897e3c118d/clients/vault/src/lib.rs#L52-L53
    * fix: make sure the clients/runtime has access to the [mainnet-runtime](https://github.com/pendulum-chain/spacewalk/tree/main/testchain/runtime/mainnet)
* failed with
   ```
      HorizonResponseError(reqwest::Error { kind: Decode, source: Error("invalid type: string \"ySHX => SHX/XLM DAILY\", expected a borrowed string", line: 9484, column: 44) })
   ```
    * fix: Some memo texts have non-literal characters, messing up deserialization.  A solution is to ~[use `Cow<str>` instead](https://users.rust-lang.org/t/solved-serde-deserialize-str-containig-special-chars/27218/2)~ `String`.
* `'could not find event: Issue::ExecuteIssue' ` potentially because all transactions have been traversed (reached EOF) before the  _memo to check_ hashmap was filled. A.K.A. probably race condition.
  * fix: DO NOT ITERATE OVER the list of transactions UNLESS the hashmap has values inside.
     * introducing `IsEmptyExt` since the parameters being passed are using generic datatypes.
       ```rust
            pub trait IsEmptyExt {
	        fn is_empty(&self) -> bool;
            }
       ```
       https://github.com/pendulum-chain/spacewalk/blob/ea913fab5ae2a47368d48206fba5e7897e3c118d/clients/wallet/src/horizon/horizon.rs#L255-L257
   