### PR TITLE
499 make vault retry stellar transaction submission for tx insufficient fee error

### DIFF
--- a/clients/wallet/src/horizon/horizon.rs
+++ b/clients/wallet/src/horizon/horizon.rs
@@ -267,7 +267,7 @@ impl<C: HorizonClient + Clone> HorizonFetcher<C> {
 			future::join(issue_map.read(), memos_to_issue_ids.read()).await;
 
 		if issue_map.is_empty() || memos_to_issue_ids.is_empty() {
-			tracing::info!("fetch_horizon_and_process_new_transactions(): nothing to traverse");
+			tracing::debug!("fetch_horizon_and_process_new_transactions(): nothing to traverse");
 			return Ok(last_cursor)
 		}
 		let mut txs_iter = self.fetch_transactions_iter(last_cursor).await?;

--- a/clients/wallet/src/horizon/responses.rs
+++ b/clients/wallet/src/horizon/responses.rs
@@ -181,8 +181,8 @@ pub struct TransactionResponse {
 	pub fee_account: Vec<u8>,
 	#[serde(deserialize_with = "de_str_to_u64")]
 	pub fee_charged: u64,
-	#[serde(deserialize_with = "de_str_to_bytes")]
-	pub max_fee: Vec<u8>,
+	#[serde(deserialize_with = "de_str_to_u64")]
+	pub max_fee: u64,
 	operation_count: u32,
 	#[serde(deserialize_with = "de_str_to_bytes")]
 	pub envelope_xdr: Vec<u8>,
@@ -219,7 +219,7 @@ impl Debug for TransactionResponse {
 			.field("source_account_sequence", &debug_str_or_vec_u8!(&self.source_account_sequence))
 			.field("fee_account", &debug_str_or_vec_u8!(&self.fee_account))
 			.field("fee_charged", &self.fee_charged)
-			.field("max_fee", &debug_str_or_vec_u8!(&self.max_fee))
+			.field("max_fee", &self.max_fee)
 			.field("operation_count", &self.operation_count)
 			.field("envelope_xdr", &debug_str_or_vec_u8!(&self.envelope_xdr))
 			.field("result_xdr", &debug_str_or_vec_u8!(&self.result_xdr))

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -221,7 +221,7 @@ impl StellarWallet {
 			return self.bump_sequence_number_and_submit(tx).await
 		}
 
-		tracing::error!("handle_tx_bad_seq_error_with_envelope(): Similar transaction already submitted. Skipping {:?}", tx);
+		tracing::error!("handle_tx_insufficient_fee_error(): Similar transaction already submitted. Skipping {:?}", tx);
 
 		Err(ResubmissionError("Transaction already submitted".to_string()))
 	}

--- a/clients/wallet/src/resubmissions.rs
+++ b/clients/wallet/src/resubmissions.rs
@@ -21,6 +21,8 @@ use primitives::stellar::{types::SequenceNumber, PublicKey};
 use reqwest::Client;
 
 pub const RESUBMISSION_INTERVAL_IN_SECS: u64 = 1800;
+// The maximum fee we want to charge for a transaction
+const MAXIMUM_TX_FEE: u32 = 10_000_000; // 1 XLM
 
 #[cfg_attr(test, mockable)]
 impl StellarWallet {
@@ -212,6 +214,9 @@ impl StellarWallet {
 
 			// Bump the fee by 10x
 			tx.fee = tx.fee * 10;
+			if tx.fee > MAXIMUM_TX_FEE {
+				tx.fee = MAXIMUM_TX_FEE;
+			}
 
 			return self.bump_sequence_number_and_submit(tx).await
 		}

--- a/pallets/oracle/rpc/runtime-api/src/lib.rs
+++ b/pallets/oracle/rpc/runtime-api/src/lib.rs
@@ -2,11 +2,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 use codec::{Codec, Decode, Encode};
-use frame_support::{dispatch::DispatchError};
+use frame_support::dispatch::DispatchError;
 use primitives::UnsignedFixedPoint;
+use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use scale_info::TypeInfo;
 #[derive(Eq, PartialEq, Encode, Decode, Default, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]

--- a/testchain/node/src/service.rs
+++ b/testchain/node/src/service.rs
@@ -4,7 +4,9 @@ use futures::StreamExt;
 use sc_client_api::BlockBackend;
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_consensus_grandpa::SharedVoterState;
-use sc_executor::{NativeElseWasmExecutor, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY, HeapAllocStrategy};
+use sc_executor::{
+	HeapAllocStrategy, NativeElseWasmExecutor, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY,
+};
 use sc_service::{
 	error::Error as ServiceError, Configuration, RpcHandlers, TFullBackend, TFullClient,
 	TaskManager,
@@ -115,7 +117,7 @@ pub fn new_partial_mainnet(
 		.with_max_runtime_instances(config.max_runtime_instances)
 		.with_runtime_cache_size(config.runtime_cache_size)
 		.build();
-	
+
 	let executor = NativeElseWasmExecutor::<MainnetExecutor>::new_with_wasm_executor(wasm);
 
 	let (client, backend, keystore_container, task_manager) =
@@ -219,7 +221,6 @@ pub fn new_partial_testnet(
 	>,
 	ServiceError,
 > {
-
 	let telemetry = config
 		.telemetry_endpoints
 		.clone()
@@ -242,7 +243,7 @@ pub fn new_partial_testnet(
 		.with_max_runtime_instances(config.max_runtime_instances)
 		.with_runtime_cache_size(config.runtime_cache_size)
 		.build();
-	
+
 	let executor = NativeElseWasmExecutor::<TestnetExecutor>::new_with_wasm_executor(wasm);
 
 	let (client, backend, keystore_container, task_manager) =
@@ -461,8 +462,7 @@ pub fn new_full(mut config: Configuration) -> Result<(TaskManager, RpcHandlers),
 
 	// if the node isn't actively participating in consensus then it doesn't
 	// need a keystore, regardless of which protocol we use below.
-	let keystore =
-		if role.is_authority() { Some(keystore_container.keystore()) } else { None };
+	let keystore = if role.is_authority() { Some(keystore_container.keystore()) } else { None };
 
 	let grandpa_config = sc_consensus_grandpa::Config {
 		// FIXME #1578 make this available through chainspec


### PR DESCRIPTION
This PR adds handling for 'tx_insufficient_fee' errors. 

We create a new transaction with a fee that is 10 times higher than the previous one. This 10x factor is adopted from the requirement of FeeBump transactions, see [here](https://developers.stellar.org/docs/learn/encyclopedia/fees-surge-pricing-fee-strategies#fee-bumps-on-past-transactions). We **cannot** use fee bump transactions however, as we did not add proper handling for them in the stellar-relay pallet [here](https://github.com/pendulum-chain/spacewalk/blob/bda384bcc6db3da88198c714851a261dcdea1063/pallets/currency/src/lib.rs#L135). Using fee bump transactions here is not necessary though as they were introduced with a different purpose in mind. For more information see [this](https://stellar.org/blog/developers/how-we-simplified-fees-on-the-stellar-network) blog post. 

The increased fee will not go beyond the maximum of 1 XLM. This amount was chosen arbitrarily and we could think about making this configurable so that each vault operator can choose this value but it should be fine not to make this configurable for the time being. 

Closes #499. 