### PR TITLE
Retry on rpc timeout response

### DIFF
--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -200,6 +200,23 @@ impl Error {
 			&format!("{:?}", SecurityPalletError::ParachainNotRunning),
 		)
 	}
+
+	pub fn is_timeout_error(&self) -> bool {
+		match self {
+			Error::SubxtRuntimeError(SubxtError::Rpc(RpcError::ClientError(e))) =>
+				match e.downcast_ref::<JsonRpseeError>() {
+					Some(e) => matches!(e, JsonRpseeError::RequestTimeout),
+					None => {
+						log::error!(
+							"Failed to downcast RPC error; this is a bug please file an issue"
+						);
+						false
+					},
+				},
+			_ => false,
+		}
+	}
+	
 }
 
 impl RecoverableError {

--- a/clients/runtime/src/error.rs
+++ b/clients/runtime/src/error.rs
@@ -216,7 +216,6 @@ impl Error {
 			_ => false,
 		}
 	}
-	
 }
 
 impl RecoverableError {

--- a/clients/runtime/src/rpc.rs
+++ b/clients/runtime/src/rpc.rs
@@ -247,6 +247,8 @@ impl SpacewalkParachain {
 							} else if err.is_block_hash_not_found_error() {
 								log::info!("Re-sending transaction after apparent fork");
 								Err(RetryPolicy::Skip(Error::BlockHashNotFound))
+							} else if err.is_timeout_error() {
+								Err(RetryPolicy::Skip(Error::Timeout))
 							} else {
 								Err(RetryPolicy::Throw(err))
 							}

--- a/clients/vault/src/oracle/storage/traits.rs
+++ b/clients/vault/src/oracle/storage/traits.rs
@@ -141,7 +141,9 @@ pub trait ArchiveStorage {
 	fn remove_file(&self, target_slot: Slot) {
 		let (_, file) = self.get_url_and_file_name(target_slot);
 		if let Err(e) = fs::remove_file(&file) {
-			tracing::warn!("remove_file(): failed to remove file {file} for slot {target_slot}: {e:?}");
+			tracing::warn!(
+				"remove_file(): failed to remove file {file} for slot {target_slot}: {e:?}"
+			);
 		}
 	}
 

--- a/clients/vault/src/requests/structs.rs
+++ b/clients/vault/src/requests/structs.rs
@@ -210,6 +210,8 @@ impl Request {
 								Err(RetryPolicy::Throw(err))
 							} else if err.is_block_hash_not_found_error() {
 								Err(RetryPolicy::Skip(EnrichedError::BlockHashNotFound))
+							} else if err.is_timeout_error() {
+								Err(RetryPolicy::Skip(EnrichedError::Timeout))
 							} else {
 								Err(RetryPolicy::Throw(err))
 							}


### PR DESCRIPTION
Closes #516.

### General Description
Upon receiving a `RequestTimeout` error, the client should retry sending the transaction. This will be done with the [same](https://github.com/pendulum-chain/spacewalk/blob/9aafee4a22877ad2cb7c6c515b3b505002bd41e5/clients/runtime/src/retry.rs#L43) `backoff` used for other errors defined as "Skippable". 

### Implementation
We add a [method](https://github.com/pendulum-chain/spacewalk/pull/518/files#diff-6469b7c5aed83b33ec6bbd2a61154190361c333995a98a3c172436491a901b9bR204) to identify the `RequestTimeout` error, and add it to the respective closures with the corresponding `Skip` retry policy.

The client's [existing](https://github.com/pendulum-chain/spacewalk/blob/9aafee4a22877ad2cb7c6c515b3b505002bd41e5/clients/runtime/src/rpc.rs#L220) timeout (for some transactions) should also be larger (currently 5 minutes) than the one returned by the unresponsive chain. For [requests](https://github.com/pendulum-chain/spacewalk/blob/9aafee4a22877ad2cb7c6c515b3b505002bd41e5/clients/vault/src/requests/structs.rs#L189) we will just retry until the backoff is exausted.