### PR TITLE
increase amount redeemed in benchmark test.

### DIFF
--- a/pallets/redeem/src/benchmarking.rs
+++ b/pallets/redeem/src/benchmarking.rs
@@ -132,7 +132,7 @@ benchmarks! {
 	liquidation_redeem {
 		let origin: T::AccountId = account("Origin", 0, 0);
 		let vault_id = get_vault_id::<T>();
-		let amount = 1000;
+		let amount = 100000;
 
 		mint_wrapped::<T>(&origin, amount.into());
 


### PR DESCRIPTION
Required to [fix](https://github.com/pendulum-chain/pendulum/pull/489#issuecomment-2346739621) benchmark when run for pendulum runtime.