### PR TITLE
Update to latest rev of substrate-stellar-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11698,7 +11698,7 @@ dependencies = [
 [[package]]
 name = "substrate-stellar-sdk"
 version = "0.3.0"
-source = "git+https://github.com/pendulum-chain/substrate-stellar-sdk?branch=polkadot-v1.1.0#6ff899abd7127d59261d7a5d06283a2e5913c6d2"
+source = "git+https://github.com/pendulum-chain/substrate-stellar-sdk?branch=polkadot-v1.1.0#5760e4d52a2136117918177cef58c078ffa4807b"
 dependencies = [
  "base64 0.13.1",
  "hex",

--- a/clients/stellar-relay-lib/examples/connect.rs
+++ b/clients/stellar-relay-lib/examples/connect.rs
@@ -30,7 +30,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 				StellarMessage::Hello(_) => {
 					tracing::info!("received Hello message");
 				},
-
 				StellarMessage::ScpMessage(msg) => {
 					let node_id = msg.statement.node_id.to_encoding();
 					let node_id = base64::encode(&node_id);
@@ -49,9 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 						slot
 					);
 				},
-				_ => {
-					let _ = overlay_connection.send_to_node(StellarMessage::GetPeers).await;
-				},
+				_ => {},
 			},
 			Ok(None) => {},
 			Err(Error::Timeout) => {


### PR DESCRIPTION
This is required because the SCP types changed again and the vault is otherwise not able to decode archived entries for transaction sets. This was fixed in https://github.com/pendulum-chain/substrate-stellar-sdk/pull/38 and is available on the latest version of the `polkadot-v1.1.0` branch.