### PR TITLE
release: Bump version to v1.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clients-info"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2052,7 +2052,7 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "currency"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fee"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -4452,7 +4452,7 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "issue"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "fee",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "jsonrpsee 0.16.3",
  "module-issue-rpc-runtime-api",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "module-issue-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "jsonrpsee 0.16.3",
  "module-oracle-rpc-runtime-api",
@@ -5959,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "module-oracle-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "jsonrpsee 0.16.3",
  "module-redeem-rpc-runtime-api",
@@ -5984,7 +5984,7 @@ dependencies = [
 
 [[package]]
 name = "module-redeem-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "jsonrpsee 0.16.3",
  "module-replace-rpc-runtime-api",
@@ -6006,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "module-replace-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "jsonrpsee 0.16.3",
  "module-oracle-rpc-runtime-api",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "module-oracle-rpc-runtime-api",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "nomination"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "fee",
@@ -6572,7 +6572,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oracle"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "dia-oracle",
@@ -7225,7 +7225,7 @@ dependencies = [
 
 [[package]]
 name = "pooled-rewards"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "redeem"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "fee",
@@ -7995,7 +7995,7 @@ dependencies = [
 
 [[package]]
 name = "replace"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "fee",
@@ -8082,7 +8082,7 @@ dependencies = [
 
 [[package]]
 name = "reward"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -8102,7 +8102,7 @@ dependencies = [
 
 [[package]]
 name = "reward-distribution"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "async-trait",
  "backoff",
@@ -9868,7 +9868,7 @@ dependencies = [
 
 [[package]]
 name = "security"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10052,7 +10052,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "async-trait",
  "clap 3.2.25",
@@ -11471,7 +11471,7 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-primitives"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "base58",
  "frame-support",
@@ -11488,7 +11488,7 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-runtime-standalone-mainnet"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "cfg-if 1.0.0",
  "clients-info",
@@ -11553,7 +11553,7 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-runtime-standalone-testnet"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "cfg-if 1.0.0",
  "clients-info",
@@ -11618,7 +11618,7 @@ dependencies = [
 
 [[package]]
 name = "spacewalk-standalone"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "clap 4.5.4",
  "frame-benchmarking",
@@ -11750,7 +11750,7 @@ dependencies = [
 
 [[package]]
 name = "staking"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "frame-benchmarking",
@@ -11806,7 +11806,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-relay"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "base64 0.13.1",
  "frame-benchmarking",
@@ -11827,7 +11827,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-relay-lib"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "async-std",
  "base64 0.13.1",
@@ -12037,7 +12037,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-client"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "futures 0.1.31",
  "futures 0.3.30",
@@ -13006,7 +13006,7 @@ checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "vault"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -13054,7 +13054,7 @@ dependencies = [
 
 [[package]]
 name = "vault-registry"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "currency",
  "fee",
@@ -13156,7 +13156,7 @@ dependencies = [
 
 [[package]]
 name = "wallet"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "async-trait",
  "cached",

--- a/clients/runner/Cargo.toml
+++ b/clients/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 
 [dependencies]

--- a/clients/runtime/Cargo.toml
+++ b/clients/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2018"
 name = "runtime"
-version = "1.0.15"
+version = "1.0.16"
 
 [features]
 default = []

--- a/clients/runtime/client/Cargo.toml
+++ b/clients/runtime/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-client"
-version = "1.0.15"
+version = "1.0.16"
 authors = []
 edition = "2018"
 

--- a/clients/service/Cargo.toml
+++ b/clients/service/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2018"
 name = "service"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 async-trait = { workspace = true }

--- a/clients/stellar-relay-lib/Cargo.toml
+++ b/clients/stellar-relay-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-relay-lib"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/clients/vault/Cargo.toml
+++ b/clients/vault/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "The Vault client intermediates between Stellar and the Spacewalk Parachain."
 edition = "2018"
 name = "vault"
-version = "1.0.15"
+version = "1.0.16"
 
 [features]
 std = [ "base64/std", "primitives/std", "stellar-relay-lib/std" ]

--- a/clients/wallet/Cargo.toml
+++ b/clients/wallet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 edition = "2021"
 name = "wallet"
-version = "1.0.15"
+version = "1.0.16"
 
 [features]
 default = []

--- a/pallets/clients-info/Cargo.toml
+++ b/pallets/clients-info/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clients-info"
 authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 
 [dependencies]

--- a/pallets/currency/Cargo.toml
+++ b/pallets/currency/Cargo.toml
@@ -4,7 +4,7 @@ description = "Currency module"
 edition = "2021"
 homepage = "https://pendulumchain.org"
 name = "currency"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/fee/Cargo.toml
+++ b/pallets/fee/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Fee module"
 edition = "2021"
 name = "fee"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/issue/Cargo.toml
+++ b/pallets/issue/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Issue module"
 edition = "2021"
 name = "issue"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 hex = { workspace = true, features = ['alloc'] }

--- a/pallets/issue/rpc/Cargo.toml
+++ b/pallets/issue/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-issue-rpc"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 

--- a/pallets/issue/rpc/runtime-api/Cargo.toml
+++ b/pallets/issue/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-issue-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 

--- a/pallets/nomination/Cargo.toml
+++ b/pallets/nomination/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomination"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Pendulum"]
 edition = "2021"
 

--- a/pallets/oracle/Cargo.toml
+++ b/pallets/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracle"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Pendulum"]
 edition = "2021"
 

--- a/pallets/oracle/rpc/Cargo.toml
+++ b/pallets/oracle/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 name = "module-oracle-rpc"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"]}

--- a/pallets/oracle/rpc/runtime-api/Cargo.toml
+++ b/pallets/oracle/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 name = "module-oracle-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"]}

--- a/pallets/pooled-rewards/Cargo.toml
+++ b/pallets/pooled-rewards/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Pooled Reward module"
 edition = "2021"
 name = "pooled-rewards"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/redeem/Cargo.toml
+++ b/pallets/redeem/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Redeem module"
 edition = "2021"
 name = "redeem"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/redeem/rpc/Cargo.toml
+++ b/pallets/redeem/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-redeem-rpc"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 

--- a/pallets/redeem/rpc/runtime-api/Cargo.toml
+++ b/pallets/redeem/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-redeem-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 

--- a/pallets/replace/Cargo.toml
+++ b/pallets/replace/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Replace module"
 edition = "2021"
 name = "replace"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/replace/rpc/Cargo.toml
+++ b/pallets/replace/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-replace-rpc"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 

--- a/pallets/replace/rpc/runtime-api/Cargo.toml
+++ b/pallets/replace/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-replace-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 

--- a/pallets/reward-distribution/Cargo.toml
+++ b/pallets/reward-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reward-distribution"
 authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 
 [dependencies]

--- a/pallets/reward/Cargo.toml
+++ b/pallets/reward/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Reward module"
 edition = "2021"
 name = "reward"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/security/Cargo.toml
+++ b/pallets/security/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum Chain"]
 edition = "2021"
 name = "security"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"]}

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 description = "Staking module"
 edition = "2021"
 name = "staking"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }

--- a/pallets/stellar-relay/Cargo.toml
+++ b/pallets/stellar-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-relay"
-version = "1.0.15"
+version = "1.0.16"
 description = "Spacewalk pallet for handling relayer functions"
 authors = ["Pendulum Chain <https://github.com/pendulum-chain>"]
 homepage = "https://pendulumchain.org/"

--- a/pallets/vault-registry/Cargo.toml
+++ b/pallets/vault-registry/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2021"
 name = "vault-registry"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"]}

--- a/pallets/vault-registry/rpc/Cargo.toml
+++ b/pallets/vault-registry/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 name = "module-vault-registry-rpc"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, default-features = true }

--- a/pallets/vault-registry/rpc/runtime-api/Cargo.toml
+++ b/pallets/vault-registry/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2021"
 name = "module-vault-registry-rpc-runtime-api"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true, features = ["derive", "max-encoded-len"]}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2018"
 name = "spacewalk-primitives"
-version = "1.0.15"
+version = "1.0.16"
 
 [dependencies]
 codec = { workspace = true }

--- a/testchain/node/Cargo.toml
+++ b/testchain/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Pendulum"]
 build = "build.rs"
 edition = "2018"
 name = "spacewalk-standalone"
-version = "1.0.15"
+version = "1.0.16"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/testchain/runtime/mainnet/Cargo.toml
+++ b/testchain/runtime/mainnet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2021"
 name = 'spacewalk-runtime-standalone-mainnet'
-version = "1.0.15"
+version = "1.0.16"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/testchain/runtime/testnet/Cargo.toml
+++ b/testchain/runtime/testnet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Pendulum"]
 edition = "2021"
 name = 'spacewalk-runtime-standalone-testnet'
-version = "1.0.15"
+version = "1.0.16"
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']


### PR DESCRIPTION
Bumps the version in all crates to `1.0.16` to prepare for the next release. 